### PR TITLE
refactor(search) - use lazy query

### DIFF
--- a/collections/src/api/index.ts
+++ b/collections/src/api/index.ts
@@ -30,7 +30,7 @@ export {
   useUpdateCollectionAuthorMutation,
   useCreateCollectionMutation,
   useUpdateCollectionMutation,
-  useGetSearchCollectionsQuery,
+  useGetSearchCollectionsLazyQuery,
 } from './generatedTypes';
 
 export { useGetStoryFromParserQuery } from './client-api/generatedTypes';


### PR DESCRIPTION
## Goal

use lazy query instead of going through the `skip` hoops.