### PR TITLE
Revert "[DEPBOT-0102]: Bump node from 15 to 16"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # development build - build app
-FROM node:16 as builder
+FROM node:15 as builder
 WORKDIR /usr/src/app
 ARG GIT_SHA
 ARG APP_ENV


### PR DESCRIPTION
Reverts Pocket/curation-admin-tools#28

`build_docker` task now dies with

```
The command '/bin/sh -c cd collections     && npm install --silent     && REACT_APP_ENV=${APP_ENV} npm run build' returned a non-zero code: 1

Exited with code exit status 1

CircleCI received exit code 1
```

Reverting to see if it makes a difference.