### PR TITLE
[BACK-827] Show story fields when parser cannot parse the URL

### DIFF
--- a/collections/src/components/StoryForm/StoryForm.tsx
+++ b/collections/src/components/StoryForm/StoryForm.tsx
@@ -126,14 +126,14 @@ export const StoryForm: React.FC<StoryFormProps> = (props): JSX.Element => {
         formik.setFieldValue('excerpt', data.getItemByUrl.excerpt);
         formik.setFieldValue('imageUrl', data.getItemByUrl.topImageUrl);
         setImageSrc(data.getItemByUrl.topImageUrl);
-
-        // if this is used to add a story and only the URL is visible,
-        // show the other fields now that they contain something
-        setShowOtherFields(true);
       } else {
         // This is the error path
         showNotification(`The parser couldn't process this URL`, 'error');
       }
+      // if this is used to add a story and only the URL is visible,
+      // show the other fields now that they contain something
+      // even if the parser can't process the URL at all.
+      setShowOtherFields(true);
     },
     onError: (error: ApolloError) => {
       // Show any other errors, i.e. cannot reach the API, etc.


### PR DESCRIPTION
## Goal

If the parser cannot parse the URL supplied when adding a new story to a collection, show the rest of the story add/edit form so that users can manually add all the data. 

Tickets:

- https://getpocket.atlassian.net/browse/BACK-827
