### PR TITLE
fix(reordering stories) - keep dragged order

### DIFF
--- a/collections/src/pages/CollectionPage/CollectionPage.tsx
+++ b/collections/src/pages/CollectionPage/CollectionPage.tsx
@@ -32,7 +32,6 @@ import {
   useUpdateCollectionMutation,
   useCreateCollectionStoryMutation,
   useImageUploadMutation,
-  useUpdateCollectionStoryMutation,
   useUpdateCollectionStorySortOrderMutation,
 } from '../../api';
 import { useNotifications } from '../../hooks/useNotifications';
@@ -58,9 +57,6 @@ export const CollectionPage = (): JSX.Element => {
 
   // prepare the "create story" mutation
   const [createStory] = useCreateCollectionStoryMutation();
-
-  // prepare the "update story" mutation
-  const [updateStory] = useUpdateCollectionStoryMutation();
 
   // prepare the "update story sort order" mutation
   const [updateStorySortOrder] = useUpdateCollectionStorySortOrderMutation();
@@ -118,6 +114,7 @@ export const CollectionPage = (): JSX.Element => {
     variables: {
       id: params.id,
     },
+    fetchPolicy: 'no-cache',
   });
 
   // Let's keep stories in state to be able to reorder them with drag'n'drop
@@ -338,12 +335,6 @@ export const CollectionPage = (): JSX.Element => {
 
     // save the new order of stories to the database
     reorderedStories.forEach((story: StoryModel, index: number) => {
-      // get rid of the __typename property as the mutation variable
-      // doesn't expect to receive it
-      const authors = story.authors.map((author) => {
-        return { name: author.name, sortOrder: author.sortOrder };
-      });
-
       const newSortOrder = index + 1;
 
       // update each affected story with the new sort order


### PR DESCRIPTION
## Goal

keep dragged order on collection stories.

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-828

## Implementation Decisions

- this is implemented in a very brute force way by disabling all caching
  on the stories query. as this is an admin tool, we're probably fine
  here in terms of performance, but if we can find a better solution,
  let's do it