### PR TITLE
[BACK-844] In lieu of working pagination, increase limit of items on page to 50

### DIFF
--- a/collections/src/api/generatedTypes.ts
+++ b/collections/src/api/generatedTypes.ts
@@ -526,7 +526,10 @@ export type GetAuthorByIdQuery = { __typename?: 'Query' } & {
   >;
 };
 
-export type GetAuthorsQueryVariables = Exact<{ [key: string]: never }>;
+export type GetAuthorsQueryVariables = Exact<{
+  page?: Maybe<Scalars['Int']>;
+  perPage?: Maybe<Scalars['Int']>;
+}>;
 
 export type GetAuthorsQuery = { __typename?: 'Query' } & {
   getCollectionAuthors: { __typename?: 'CollectionAuthorsResult' } & {
@@ -1456,8 +1459,8 @@ export type GetAuthorByIdQueryResult = Apollo.QueryResult<
   GetAuthorByIdQueryVariables
 >;
 export const GetAuthorsDocument = gql`
-  query getAuthors {
-    getCollectionAuthors {
+  query getAuthors($page: Int, $perPage: Int) {
+    getCollectionAuthors(page: $page, perPage: $perPage) {
       authors {
         ...AuthorData
       }
@@ -1478,6 +1481,8 @@ export const GetAuthorsDocument = gql`
  * @example
  * const { data, loading, error } = useGetAuthorsQuery({
  *   variables: {
+ *      page: // value for 'page'
+ *      perPage: // value for 'perPage'
  *   },
  * });
  */

--- a/collections/src/api/queries/getAuthors.ts
+++ b/collections/src/api/queries/getAuthors.ts
@@ -5,8 +5,8 @@ import { AuthorData } from '../fragments/AuthorData';
  * Get a list of authors
  */
 export const getAuthors = gql`
-  query getAuthors {
-    getCollectionAuthors {
+  query getAuthors($page: Int, $perPage: Int) {
+    getCollectionAuthors(page: $page, perPage: $perPage) {
       authors {
         ...AuthorData
       }

--- a/collections/src/pages/AuthorListPage/AuthorListPage.tsx
+++ b/collections/src/pages/AuthorListPage/AuthorListPage.tsx
@@ -9,7 +9,9 @@ import { AuthorModel, useGetAuthorsQuery } from '../../api';
  */
 export const AuthorListPage = (): JSX.Element => {
   // Load authors
-  const { loading, error, data } = useGetAuthorsQuery();
+  const { loading, error, data } = useGetAuthorsQuery({
+    variables: { perPage: 50 },
+  });
 
   return (
     <>

--- a/collections/src/pages/CollectionListPage/CollectionListPage.tsx
+++ b/collections/src/pages/CollectionListPage/CollectionListPage.tsx
@@ -38,21 +38,27 @@ export const CollectionListPage = (): JSX.Element => {
   };
 
   // Load draft collections
-  const { loading, error, data } = useGetDraftCollectionsQuery();
+  const { loading, error, data } = useGetDraftCollectionsQuery({
+    variables: { perPage: 50 },
+  });
 
   // Load published collections
   const {
     loading: loadingPublished,
     error: errorPublished,
     data: dataPublished,
-  } = useGetPublishedCollectionsQuery();
+  } = useGetPublishedCollectionsQuery({
+    variables: { perPage: 50 },
+  });
 
   // Load archived collections
   const {
     loading: loadingArchived,
     error: errorArchived,
     data: dataArchived,
-  } = useGetArchivedCollectionsQuery();
+  } = useGetArchivedCollectionsQuery({
+    variables: { perPage: 50 },
+  });
 
   // Define the set of tabs that we're going to show on this page
   const tabs: CustomTabType[] = [

--- a/collections/src/pages/CollectionPage/CollectionPage.tsx
+++ b/collections/src/pages/CollectionPage/CollectionPage.tsx
@@ -32,7 +32,6 @@ import {
   useUpdateCollectionMutation,
   useCreateCollectionStoryMutation,
   useImageUploadMutation,
-  useUpdateCollectionStoryMutation,
   useUpdateCollectionStorySortOrderMutation,
 } from '../../api';
 import { useNotifications } from '../../hooks/useNotifications';
@@ -58,9 +57,6 @@ export const CollectionPage = (): JSX.Element => {
 
   // prepare the "create story" mutation
   const [createStory] = useCreateCollectionStoryMutation();
-
-  // prepare the "update story" mutation
-  const [updateStory] = useUpdateCollectionStoryMutation();
 
   // prepare the "update story sort order" mutation
   const [updateStorySortOrder] = useUpdateCollectionStorySortOrderMutation();
@@ -338,12 +334,6 @@ export const CollectionPage = (): JSX.Element => {
 
     // save the new order of stories to the database
     reorderedStories.forEach((story: StoryModel, index: number) => {
-      // get rid of the __typename property as the mutation variable
-      // doesn't expect to receive it
-      const authors = story.authors.map((author) => {
-        return { name: author.name, sortOrder: author.sortOrder };
-      });
-
       const newSortOrder = index + 1;
 
       // update each affected story with the new sort order


### PR DESCRIPTION
## Goal

Let users more easily access the collections/authors that are there without using search while we're working on pagination and other features post-launch.

Tickets:

- https://getpocket.atlassian.net/browse/BACK-844

## Implementation Decisions

- Now requesting 50 items in queries
- Removed some obsolete code
