### PR TITLE
[BACK-828] Fix UI bug when reordering stories

### DIFF
--- a/collections/src/components/StoryListCard/StoryListCard.tsx
+++ b/collections/src/components/StoryListCard/StoryListCard.tsx
@@ -28,6 +28,8 @@ interface StoryListCardProps {
   story: StoryModel;
 
   collectionExternalId: string;
+
+  refetch: () => void;
 }
 
 /**
@@ -38,7 +40,7 @@ interface StoryListCardProps {
 export const StoryListCard: React.FC<StoryListCardProps> = (props) => {
   const classes = useStyles();
   const { showNotification } = useNotifications();
-  const { story, collectionExternalId } = props;
+  const { story, collectionExternalId, refetch } = props;
 
   const [showEditForm, setShowEditForm] = useState<boolean>(false);
 
@@ -57,16 +59,11 @@ export const StoryListCard: React.FC<StoryListCardProps> = (props) => {
       variables: {
         externalId: story.externalId,
       },
-      refetchQueries: [
-        {
-          query: GetCollectionStoriesDocument,
-          variables: {
-            id: collectionExternalId,
-          },
-        },
-      ],
     })
       .then(() => {
+        // manually refresh the cache
+        refetch();
+
         showNotification(
           `Deleted "${story.title.substring(0, 50)}..."`,
           'success'
@@ -94,6 +91,9 @@ export const StoryListCard: React.FC<StoryListCardProps> = (props) => {
       },
     })
       .then(() => {
+        // manually refresh the cache
+        refetch();
+
         showNotification(
           `Updated "${story.title.substring(0, 50)}..."`,
           'success'


### PR DESCRIPTION
## Goal

Fix a strange side effect of running mutations after reordering stories with drag'n'drop - without the mutations wired up, the stories stay where they've been moved to. With the mutations, they snap back to (nearly? one should have its sort order updated) their old positions.

Tickets:

- https://getpocket.atlassian.net/browse/BACK-828

## Implementation Decisions

- Set cache policy on collection stories query to `standby` (like the default 'cache-first' policy except it never polls the server for updates: https://www.apollographql.com/docs/react/data/queries/).

- Updated code to fetch the initial data and refetch the stories manually after every mutation (update, create, delete). 

The plan is to keep this `standby` policy but replace refetching queries with more precise updates documented here: https://www.apollographql.com/docs/react/caching/cache-interaction/#example-updating-the-cache-after-a-mutation in a follow-up PR. That would make the UI snappier and not bombard the server with extra queries.
