### PR TITLE
fix(add collection) - fix author select

### DIFF
--- a/collections/src/components/CollectionForm/CollectionForm.tsx
+++ b/collections/src/components/CollectionForm/CollectionForm.tsx
@@ -190,7 +190,14 @@ export const CollectionForm: React.FC<CollectionFormProps> = (
                 id: 'authorExternalId',
               }}
               {...formik.getFieldProps('authorExternalId')}
+              error={
+                !!(
+                  formik.touched.authorExternalId &&
+                  formik.errors.authorExternalId
+                )
+              }
             >
+              <option value=""></option>
               {authors.map((author: AuthorModel) => {
                 return (
                   <option value={author.externalId} key={author.externalId}>


### PR DESCRIPTION
## Goal

fixes author select bug when creating a collection. previously, the select box did not have an empty option, meaning the first option was the alphabetically first author. formik would not allow the form to submit if this value was not changed - meaning, if you wanted to select the first author in the list, you had to select a different author, then re-select the first author.

additionally, no error message was given, so this was not easy to debug, and would be a blocker for launch.

- adds a blank option as the first/default
- adds error handling UI around author drop down

verified this does not break the edit state of this form.

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-850