### PR TITLE
[BACK-846] Fix UI bug with progress indicators in forms

### DIFF
--- a/collections/src/components/AuthorForm/AuthorForm.tsx
+++ b/collections/src/components/AuthorForm/AuthorForm.tsx
@@ -12,6 +12,7 @@ import {
 } from '@material-ui/core';
 import { AuthorModel } from '../../api';
 import { Button, MarkdownPreview } from '../';
+import { FormikHelpers } from 'formik/dist/types';
 
 interface AuthorFormProps {
   /**
@@ -22,7 +23,7 @@ interface AuthorFormProps {
   /**
    * What do we do with the submitted data?
    */
-  onSubmit: (values: FormikValues) => void;
+  onSubmit: (values: FormikValues, formikHelpers: FormikHelpers<any>) => void;
 
   /**
    * Do we need to show the cancel button? Not on the 'Add Author' page
@@ -70,8 +71,8 @@ export const AuthorForm: React.FC<AuthorFormProps> = (props): JSX.Element => {
       bio: yup.string(),
       active: yup.boolean().required(),
     }),
-    onSubmit: (values) => {
-      onSubmit(values);
+    onSubmit: (values, formikHelpers) => {
+      onSubmit(values, formikHelpers);
     },
   });
 

--- a/collections/src/components/CollectionForm/CollectionForm.tsx
+++ b/collections/src/components/CollectionForm/CollectionForm.tsx
@@ -15,6 +15,7 @@ import {
 import { AuthorModel, CollectionModel, CollectionStatus } from '../../api';
 import { Button, MarkdownPreview } from '../';
 import { useStyles } from './CollectionForm.styles';
+import { FormikHelpers } from 'formik/dist/types';
 
 interface CollectionFormProps {
   /**
@@ -30,7 +31,10 @@ interface CollectionFormProps {
   /**
    * What do we do with the submitted data?
    */
-  onSubmit: (values: FormikValues) => void;
+  onSubmit: (
+    values: FormikValues,
+    formikHelpers: FormikHelpers<any>
+  ) => void | Promise<any>;
 
   /**
    * Show "Cancel" button if the form is used to edit a new collection
@@ -99,8 +103,8 @@ export const CollectionForm: React.FC<CollectionFormProps> = (
         .required(),
       authorExternalId: yup.string().oneOf(authorIds).required(),
     }),
-    onSubmit: (values) => {
-      onSubmit(values);
+    onSubmit: (values, formikHelpers) => {
+      onSubmit(values, formikHelpers);
     },
   });
 

--- a/collections/src/components/StoryForm/StoryForm.tsx
+++ b/collections/src/components/StoryForm/StoryForm.tsx
@@ -18,6 +18,7 @@ import { useStyles } from './StoryForm.styles';
 import { CollectionStoryAuthor } from '../../api/generatedTypes';
 import { useNotifications } from '../../hooks/useNotifications';
 import { ApolloError } from '@apollo/client';
+import { FormikHelpers } from 'formik/dist/types';
 
 interface StoryFormProps {
   /**
@@ -28,7 +29,10 @@ interface StoryFormProps {
   /**
    * What do we do with the submitted data?
    */
-  onSubmit: (values: FormikValues) => void;
+  onSubmit: (
+    values: FormikValues,
+    formikHelpers: FormikHelpers<any>
+  ) => void | Promise<any>;
 
   /**
    * Whether to show the full form or just the URL+Populate button
@@ -95,8 +99,8 @@ export const StoryForm: React.FC<StoryFormProps> = (props): JSX.Element => {
         .min(6),
       publisher: yup.string(),
     }),
-    onSubmit: (values) => {
-      onSubmit(values);
+    onSubmit: (values: FormikValues, formikHelpers: FormikHelpers<any>) => {
+      onSubmit(values, formikHelpers);
     },
   });
 
@@ -130,11 +134,16 @@ export const StoryForm: React.FC<StoryFormProps> = (props): JSX.Element => {
         formik.setFieldValue('excerpt', data.getItemByUrl.excerpt);
         formik.setFieldValue('imageUrl', data.getItemByUrl.topImageUrl);
         setImageSrc(data.getItemByUrl.topImageUrl);
+
+        showNotification(
+          `The parser finished processing this story`,
+          'success'
+        );
       } else {
         // This is the error path
         showNotification(`The parser couldn't process this URL`, 'error');
       }
-      // if this is used to add a story and only the URL is visible,
+      // If this is used to add a story and only the URL is visible,
       // show the other fields now that they contain something
       // even if the parser can't process the URL at all.
       setShowOtherFields(true);

--- a/collections/src/components/StoryListCard/StoryListCard.tsx
+++ b/collections/src/components/StoryListCard/StoryListCard.tsx
@@ -22,11 +22,10 @@ import { transformAuthors } from '../../utils/transformAuthors';
 import { ImageUpload, StoryForm } from '../';
 import { useStyles } from './StoryListCard.styles';
 import { useNotifications } from '../../hooks/useNotifications';
+import { FormikHelpers } from 'formik/dist/types';
 
 interface StoryListCardProps {
   story: StoryModel;
-
-  collectionExternalId: string;
 
   refetch: () => void;
 }
@@ -39,7 +38,7 @@ interface StoryListCardProps {
 export const StoryListCard: React.FC<StoryListCardProps> = (props) => {
   const classes = useStyles();
   const { showNotification } = useNotifications();
-  const { story, collectionExternalId, refetch } = props;
+  const { story, refetch } = props;
 
   const [showEditForm, setShowEditForm] = useState<boolean>(false);
 
@@ -73,7 +72,10 @@ export const StoryListCard: React.FC<StoryListCardProps> = (props) => {
       });
   };
 
-  const onUpdate = (values: FormikValues): void => {
+  const onUpdate = (
+    values: FormikValues,
+    formikHelpers: FormikHelpers<any>
+  ): void => {
     // prepare authors! They need to be an array of objects again
     const authors = transformAuthors(values.authors);
 
@@ -98,9 +100,11 @@ export const StoryListCard: React.FC<StoryListCardProps> = (props) => {
           'success'
         );
         setShowEditForm(false);
+        formikHelpers.setSubmitting(false);
       })
       .catch((error: Error) => {
         showNotification(error.message, 'error');
+        formikHelpers.setSubmitting(false);
       });
   };
 

--- a/collections/src/pages/AddAuthorPage/AddAuthorPage.tsx
+++ b/collections/src/pages/AddAuthorPage/AddAuthorPage.tsx
@@ -6,6 +6,7 @@ import { AuthorModel, useCreateCollectionAuthorMutation } from '../../api';
 import { AuthorForm } from '../../components';
 import { useNotifications } from '../../hooks/useNotifications';
 import { GetAuthorsDocument } from '../../api/generatedTypes';
+import { FormikHelpers } from 'formik/dist/types';
 
 export const AddAuthorPage: React.FC = (): JSX.Element => {
   // Prepare state vars and helper methods for API notifications
@@ -32,7 +33,10 @@ export const AddAuthorPage: React.FC = (): JSX.Element => {
   /**
    * Collect form data and send it to the API
    */
-  const handleSubmit = (values: FormikValues): void => {
+  const handleSubmit = (
+    values: FormikValues,
+    formikHelpers: FormikHelpers<any>
+  ): void => {
     addAuthor({
       variables: {
         name: values.name,
@@ -56,6 +60,7 @@ export const AddAuthorPage: React.FC = (): JSX.Element => {
       })
       .catch((error: Error) => {
         showNotification(error.message, 'error');
+        formikHelpers.setSubmitting(false);
       });
   };
 

--- a/collections/src/pages/AddCollectionPage/AddCollectionPage.tsx
+++ b/collections/src/pages/AddCollectionPage/AddCollectionPage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { Box, Paper } from '@material-ui/core';
 import { FormikValues } from 'formik';
+import { FormikHelpers } from 'formik/dist/types';
 import {
   CollectionModel,
   CollectionStatus,
@@ -42,7 +43,10 @@ export const AddCollectionPage: React.FC = (): JSX.Element => {
   /**
    * Collect form data and send it to the API
    */
-  const handleSubmit = (values: FormikValues): void => {
+  const handleSubmit = (
+    values: FormikValues,
+    formikHelpers: FormikHelpers<any>
+  ): void => {
     addCollection({
       variables: {
         title: values.title,
@@ -68,6 +72,7 @@ export const AddCollectionPage: React.FC = (): JSX.Element => {
       })
       .catch((error: Error) => {
         showNotification(error.message, 'error');
+        formikHelpers.setSubmitting(false);
       });
   };
 

--- a/collections/src/pages/AuthorPage/AuthorPage.tsx
+++ b/collections/src/pages/AuthorPage/AuthorPage.tsx
@@ -23,6 +23,7 @@ import {
   useUpdateCollectionAuthorMutation,
 } from '../../api';
 import { useNotifications } from '../../hooks/useNotifications';
+import { FormikHelpers } from 'formik/dist/types';
 
 interface AuthorPageProps {
   author?: AuthorModel;
@@ -80,7 +81,10 @@ export const AuthorPage = (): JSX.Element => {
    * Collect form data and send it to the API.
    * Update components on page if updates have been saved successfully
    */
-  const handleSubmit = (values: FormikValues): void => {
+  const handleSubmit = (
+    values: FormikValues,
+    formikHelpers: FormikHelpers<any>
+  ): void => {
     updateAuthor({
       variables: {
         externalId: author!.externalId,
@@ -99,9 +103,11 @@ export const AuthorPage = (): JSX.Element => {
           author.active = data?.updateCollectionAuthor.active!;
         }
         toggleEditForm();
+        formikHelpers.setSubmitting(false);
       })
       .catch((error: Error) => {
         showNotification(error.message, 'error');
+        formikHelpers.setSubmitting(false);
       });
   };
 

--- a/collections/src/pages/CollectionPage/CollectionPage.tsx
+++ b/collections/src/pages/CollectionPage/CollectionPage.tsx
@@ -39,6 +39,7 @@ import { FormikValues } from 'formik';
 import EditIcon from '@material-ui/icons/Edit';
 import { GetCollectionByExternalIdDocument } from '../../api/generatedTypes';
 import { transformAuthors } from '../../utils/transformAuthors';
+import { FormikHelpers } from 'formik/dist/types';
 
 interface CollectionPageProps {
   collection?: CollectionModel;
@@ -150,7 +151,10 @@ export const CollectionPage = (): JSX.Element => {
    * Collect "edit collection" form data and send it to the API.
    * Update components on page if updates have been saved successfully
    */
-  const handleSubmit = (values: FormikValues): void => {
+  const handleSubmit = (
+    values: FormikValues,
+    formikHelpers: FormikHelpers<any>
+  ): void => {
     updateCollection({
       variables: {
         externalId: collection!.externalId,
@@ -181,10 +185,12 @@ export const CollectionPage = (): JSX.Element => {
           collection.status = data?.updateCollection?.status!;
           collection.authors = data?.updateCollection?.authors!;
           toggleEditForm();
+          formikHelpers.setSubmitting(false);
         }
       })
       .catch((error: Error) => {
         showNotification(error.message, 'error');
+        formikHelpers.setSubmitting(false);
       });
   };
 
@@ -237,8 +243,12 @@ export const CollectionPage = (): JSX.Element => {
   /**
    * Save a new story - a multi-step process
    * @param values
+   * @param formikHelpers
    */
-  const handleCreateStorySubmit = (values: FormikValues): void => {
+  const handleCreateStorySubmit = (
+    values: FormikValues,
+    formikHelpers: FormikHelpers<any>
+  ): void => {
     // If the parser returned an image, let's upload it to S3
     // First, side-step CORS issues that prevent us from downloading
     // the image directly from the publisher
@@ -291,9 +301,11 @@ export const CollectionPage = (): JSX.Element => {
                     'success'
                   );
                   setAddStoryFormKey(addStoryFormKey + 1);
+                  formikHelpers.setSubmitting(false);
                 })
                 .catch((error: Error) => {
                   showNotification(error.message, 'error');
+                  formikHelpers.setSubmitting(false);
                 });
             }
           })
@@ -414,6 +426,7 @@ export const CollectionPage = (): JSX.Element => {
                     collection={collection}
                     onSubmit={handleSubmit}
                     editMode={true}
+                    onCancel={toggleEditForm}
                   />
                 )}
               </Box>
@@ -456,9 +469,6 @@ export const CollectionPage = (): JSX.Element => {
                                   <StoryListCard
                                     key={story.externalId}
                                     story={story}
-                                    collectionExternalId={
-                                      collection!.externalId
-                                    }
                                     refetch={refetchStories}
                                   />
                                 </Typography>


### PR DESCRIPTION
## Goal

Stop displaying the LinearProgress component when the form has been submitted and we've received a response from the API.

Tickets:

- https://getpocket.atlassian.net/browse/BACK-846

## Implementation Decisions

Now using helper methods from Formik to set isSubmitting value back to false
once we get a response from the API.

In total, half a dozen places in the app needed this fix - 3x “add a …” forms
and 3x edit forms.

Also added a success message from the parser when it returns something.

Also fixed a minor issue with the Collection form - Cancel button stopped working.
