### PR TITLE
Fix: add characters to strip from author/collection slugs

### DIFF
--- a/collections/src/components/AuthorForm/AuthorForm.tsx
+++ b/collections/src/components/AuthorForm/AuthorForm.tsx
@@ -80,7 +80,10 @@ export const AuthorForm: React.FC<AuthorFormProps> = (props): JSX.Element => {
    * Suggest a slug for the author - works off the "name" field
    */
   const suggestSlug = () => {
-    const newSlug = slugify(formik.values.name, { lower: true });
+    const newSlug = slugify(formik.values.name, {
+      lower: true,
+      remove: /[*+~.()'"!:@]/g,
+    });
     formik.setFieldValue('slug', newSlug);
   };
 

--- a/collections/src/components/CollectionForm/CollectionForm.tsx
+++ b/collections/src/components/CollectionForm/CollectionForm.tsx
@@ -112,7 +112,10 @@ export const CollectionForm: React.FC<CollectionFormProps> = (
    * Suggest a slug for the collection - works off the "title" field
    */
   const suggestSlug = () => {
-    const newSlug = slugify(formik.values.title, { lower: true });
+    const newSlug = slugify(formik.values.title, {
+      lower: true,
+      remove: /[*+~.()'"!:@]/g,
+    });
     formik.setFieldValue('slug', newSlug);
   };
 


### PR DESCRIPTION
## Goal

As above ^^^. Syncing `slugify` settings with the API: https://github.com/Pocket/collection-api/blob/2727a1654e8859ddbf28d9ec8d057e4b95a16624/src/config/index.ts#L25 so that slugs do not have dots, commas, etc.
