### PR TITLE
fix(empty authors) - empty author value sends empty array to API

### DIFF
--- a/collections/src/utils/transformAuthors.test.ts
+++ b/collections/src/utils/transformAuthors.test.ts
@@ -1,0 +1,46 @@
+import { transformAuthors } from './transformAuthors';
+
+describe('transformAuthors', () => {
+  it('processes a string with commas then spaces', () => {
+    const result = transformAuthors('the dude, walter');
+
+    expect(result.length).toEqual(2);
+  });
+
+  it('processes a string with commas and no spaces', () => {
+    const result = transformAuthors('the dude,walter');
+
+    expect(result.length).toEqual(2);
+  });
+
+  it('trims extra spaces off author names and keeps spaces within names', () => {
+    const result = transformAuthors('  the dude,   walter ,maude lebowski');
+
+    expect(result[0].name).toEqual('the dude');
+    expect(result[1].name).toEqual('walter');
+    expect(result[2].name).toEqual('maude lebowski');
+  });
+
+  it('generates the correct sort order', () => {
+    const result = transformAuthors('the dude, walter, maude lebowski');
+
+    expect(result[0].name).toEqual('the dude');
+    expect(result[0].sortOrder).toEqual(0);
+    expect(result[1].name).toEqual('walter');
+    expect(result[1].sortOrder).toEqual(1);
+    expect(result[2].name).toEqual('maude lebowski');
+    expect(result[2].sortOrder).toEqual(2);
+  });
+
+  it('return an empty array if the author string is empty', () => {
+    const result = transformAuthors('');
+
+    expect(result.length).toEqual(0);
+  });
+
+  it('return an empty array if the author string is just spaces', () => {
+    const result = transformAuthors('    ');
+
+    expect(result.length).toEqual(0);
+  });
+});

--- a/collections/src/utils/transformAuthors.ts
+++ b/collections/src/utils/transformAuthors.ts
@@ -4,7 +4,16 @@ interface StoryAuthor {
 }
 
 export const transformAuthors = (authors: string): StoryAuthor[] => {
-  return authors.split(', ').map((name: string, sortOrder: number) => {
-    return { name, sortOrder };
-  });
+  // get rid of any whitespace on the sides
+  authors = authors.trim();
+
+  // ensure authors isn't an empty string
+  if (authors) {
+    return authors.split(',').map((name: string, sortOrder: number) => {
+      return { name: name.trim(), sortOrder };
+    });
+  } else {
+    // if authors *is* an empty string, just return an empty array
+    return [];
+  }
 };


### PR DESCRIPTION
## Goal

empty author value sends empty array to API. currently, an empty author value sends an array of 1 (with a blank `name`) to the API. 

- added tests for transformAuthor helper