### PR TITLE
FIXIT: Show up to 1000 entries in collection author dropdown

### DIFF
--- a/collections/src/pages/AddCollectionPage/AddCollectionPage.tsx
+++ b/collections/src/pages/AddCollectionPage/AddCollectionPage.tsx
@@ -34,7 +34,9 @@ export const AddCollectionPage: React.FC = (): JSX.Element => {
   };
 
   // Load authors
-  const { loading, error, data: authorsData } = useGetAuthorsQuery();
+  const { loading, error, data: authorsData } = useGetAuthorsQuery({
+    variables: { page: 1, perPage: 1000 },
+  });
 
   // prepare the "add new collection" mutation
   // has to be done at the top level of the component because it's a hook

--- a/collections/src/pages/CollectionPage/CollectionPage.tsx
+++ b/collections/src/pages/CollectionPage/CollectionPage.tsx
@@ -114,7 +114,7 @@ export const CollectionPage = (): JSX.Element => {
     loading: authorsLoading,
     error: authorsError,
     data: authorsData,
-  } = useGetAuthorsQuery();
+  } = useGetAuthorsQuery({ variables: { page: 1, perPage: 1000 } });
 
   // Load collection stories - deliberately in a separate query
   const {


### PR DESCRIPTION
## Goal

Fix bug whereby users can only see the first 20 authors in add/edit collection dropdowns as that is the default the authors query returns.
