### PR TITLE
[BACK-875] Disable cache for Client API requests and add UI fixes

### DIFF
--- a/collections/src/theme.ts
+++ b/collections/src/theme.ts
@@ -101,6 +101,10 @@ theme.overrides = {
       '&:hover': {
         border: `2px solid ${theme.palette.primary.dark}`,
       },
+      '&.Mui-disabled': {
+        backgroundColor: theme.palette.grey[100],
+        border: `2px solid ${theme.palette.grey[400]}`,
+      },
     },
 
     /**


### PR DESCRIPTION
## Goal

Fix a number of small issues around requesting data from Client API - unfortunately no fix for the originally reported issue so far.

Tickets:

- https://getpocket.atlassian.net/browse/BACK-875

## Implementation Decisions

- Disabled cache on the query that requests data from the Parser
for a URL. This doesn't fix the issue of no data for a collections
URL detailed in BACK-875. It does, however, fix an annoying issue
with the UI where if you edited some fields but then decided to
go back to what the Parser fetched clicking on the "Populate" button
had no apparent effect as the request was cached so I thought it was
worthwhile to keep this change.

- Now disabling the "Populate" button while the request is in progress.

- Found an edge case where, on initial page load, you can bypass form
validation and send an empty URL to the Parser. Documented it in the code
and marked with a TODO for when we run out of other things to fix.