### PR TITLE
[BACK-822] Implement a Preview page for collections

### DIFF
--- a/collections/src/components/CollectionPreview/CollectionPreview.styles.tsx
+++ b/collections/src/components/CollectionPreview/CollectionPreview.styles.tsx
@@ -1,0 +1,35 @@
+import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+
+/**
+ * Styles for the CollectionPreview component.
+ */
+export const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    title: {
+      fontWeight: 500,
+    },
+    excerpt: {
+      fontSize: '1.25rem',
+      color: theme.palette.grey[500],
+    },
+    intro: {
+      fontSize: '1.25rem',
+    },
+    storyTitle: {
+      fontSize: '1.25rem',
+      fontWeight: 500,
+      '& a': {
+        textDecoration: 'none',
+        color: '#222222',
+      },
+    },
+    storyCard: {
+      margin: 'auto',
+      padding: '2rem 0.5rem',
+      border: 0,
+    },
+    image: {
+      borderRadius: 4,
+    },
+  })
+);

--- a/collections/src/components/CollectionPreview/CollectionPreview.test.tsx
+++ b/collections/src/components/CollectionPreview/CollectionPreview.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { CollectionPreview } from './CollectionPreview';
+import {
+  CollectionModel,
+  CollectionStatus,
+  StoryModel,
+} from '../../api/collection-api';
+
+describe('The CollectionPreview component', () => {
+  let collection: CollectionModel;
+  let stories: StoryModel[];
+
+  beforeEach(() => {
+    collection = {
+      externalId: '124abc',
+      title: 'Hidden Histories of Presidential Medical Dramas',
+      slug: 'collection-slug',
+      imageUrl: 'https://placeimg.com/640/480/people?random=494',
+      excerpt:
+        'There’s a long history of presidential ailments, including George Washington’s near-death encounter with the flu, Grover Cleveland’s secret tumor, and the clandestine suffering of John F. Kennedy. ',
+      intro: 'Intro text is generally longer than the excerpt.',
+      status: CollectionStatus.Published,
+      authors: [
+        {
+          externalId: '456-abc',
+          name: 'Collection Author',
+          slug: 'collection-author',
+          active: true,
+        },
+      ],
+    };
+
+    stories = [
+      {
+        externalId: '123-abc',
+        title: 'The first story in this collection',
+        url: 'https://www.test.com/',
+        excerpt: 'This story should always be the first.',
+        authors: [{ name: 'First Author', sortOrder: 1 }],
+        publisher: 'Pocket Collections',
+      },
+    ];
+  });
+
+  it('shows basic collection information', () => {
+    render(
+      <MemoryRouter>
+        <CollectionPreview collection={collection} stories={stories} />
+      </MemoryRouter>
+    );
+
+    // The title is present
+    const title = screen.getByText(collection.title);
+    expect(title).toBeInTheDocument();
+
+    // So is the excerpt
+    const excerpt = screen.getByText(/presidential ailments/i);
+    expect(excerpt).toBeInTheDocument();
+
+    // And the intro
+    const intro = screen.getByText(/intro text is/i);
+    expect(intro).toBeInTheDocument();
+
+    // Shows a single collection author correctly
+    const authors = screen.getByText(collection.authors[0].name);
+    expect(authors).toBeInTheDocument();
+
+    // collection image alt text is the title of the collection
+    const image = screen.getByAltText(collection.title);
+    expect(image).toBeInTheDocument();
+  });
+
+  it('shows multiple collection authors correctly', () => {
+    // Add a second author
+    collection.authors.push({
+      externalId: '789-zzz',
+      name: 'Another Author',
+      slug: 'another-author',
+      active: true,
+    });
+
+    render(
+      <MemoryRouter>
+        <CollectionPreview collection={collection} stories={stories} />
+      </MemoryRouter>
+    );
+
+    // Displays authors as a comma-separated list
+    const authors = screen.getByText('Collection Author, Another Author');
+    expect(authors).toBeInTheDocument();
+  });
+
+  it('shows collection stories', () => {
+    render(
+      <MemoryRouter>
+        <CollectionPreview collection={collection} stories={stories} />
+      </MemoryRouter>
+    );
+
+    // Displays story title
+    const storyTitle = screen.getByText(stories[0].title);
+    expect(storyTitle).toBeInTheDocument();
+
+    // Displays story excerpt
+    const storyExcerpt = screen.getByText(stories[0].excerpt);
+    expect(storyExcerpt).toBeInTheDocument();
+
+    // Displays story publisher
+    const storyPublisher = screen.getByText(stories[0].publisher!);
+    expect(storyPublisher).toBeInTheDocument();
+
+    // Displays story authors
+    const storyAuthors = screen.getByText(stories[0].authors[0].name);
+    expect(storyAuthors).toBeInTheDocument();
+
+    // story image alt text is the title of the story
+    const image = screen.getByAltText(stories[0].title);
+    expect(image).toBeInTheDocument();
+  });
+});

--- a/collections/src/components/CollectionPreview/CollectionPreview.tsx
+++ b/collections/src/components/CollectionPreview/CollectionPreview.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { Card, Grid, Hidden, Typography } from '@material-ui/core';
+import ReactMarkdown from 'react-markdown';
+import {
+  StoryModel,
+  CollectionModel,
+  AuthorModel,
+} from '../../api/collection-api';
+import { useStyles } from './CollectionPreview.styles';
+import { CollectionStoryAuthor } from '../../api/collection-api/generatedTypes';
+
+interface CollectionPreviewProps {
+  /**
+   * An object with everything collection-related in it.
+   */
+  collection: CollectionModel;
+
+  /**
+   * Collection stories, separately
+   */
+  stories: StoryModel[] | undefined;
+}
+
+export const CollectionPreview: React.FC<CollectionPreviewProps> = (
+  props
+): JSX.Element => {
+  const { collection, stories } = props;
+  const classes = useStyles();
+
+  // The &middot; character is only needed if the story has authors as it separates
+  // the list of authors and the name of the publisher.
+  // There appears to be no way to display an HTML special character conditionally
+  // (well, except for setting innerHTML directly) other than assigning it to a variable
+  const middot = '\u00b7';
+
+  return (
+    <>
+      <Grid container spacing={2}>
+        <Grid item xs={12}>
+          <Typography variant="h4" color="primary">
+            Collection Preview
+          </Typography>
+        </Grid>
+        <Grid item xs={12}>
+          <Typography variant="h4" className={classes.title}>
+            {collection.title}
+          </Typography>
+        </Grid>
+        <Grid item xs={12}>
+          <ReactMarkdown className={classes.excerpt}>
+            {collection.excerpt}
+          </ReactMarkdown>
+        </Grid>
+        <Grid item xs={12}>
+          <Typography
+            variant="subtitle1"
+            color="textSecondary"
+            component="span"
+            align="left"
+          >
+            {collection.authors
+              .map((author: AuthorModel) => {
+                return author.name;
+              })
+              .join(', ')}
+          </Typography>
+        </Grid>
+        <Grid item xs={12}>
+          <img width="100%" src={collection.imageUrl} alt={collection.title} />
+        </Grid>
+        <Grid item xs={12}>
+          <ReactMarkdown className={classes.intro}>
+            {collection.intro}
+          </ReactMarkdown>
+        </Grid>
+        {stories &&
+          stories.map((story: StoryModel) => {
+            // TODO: decouple StoryListCard from the form so that
+            // it can be used here, too
+
+            // Work out a comma-separated list of authors if there are any for this story
+            const displayAuthors = story.authors
+              ?.map((author: CollectionStoryAuthor) => {
+                return author.name;
+              })
+              .join(', ');
+
+            return (
+              <Card
+                variant="outlined"
+                square
+                className={classes.storyCard}
+                key={story.externalId}
+              >
+                <Grid container spacing={2}>
+                  <Grid item xs={3}>
+                    <img
+                      src={story.imageUrl}
+                      width="100%"
+                      alt={story.title}
+                      className={classes.image}
+                    />
+                  </Grid>
+                  <Grid item xs={7} sm={8}>
+                    <Typography
+                      variant="h3"
+                      align="left"
+                      className={classes.storyTitle}
+                      gutterBottom
+                    >
+                      <a href={story.url}>{story.title}</a>
+                    </Typography>
+                    <Typography
+                      variant="subtitle1"
+                      color="textSecondary"
+                      component="span"
+                      align="left"
+                    >
+                      <span>{displayAuthors}</span>
+                      {displayAuthors.length > 0 && ` ${middot} `}
+                      <span>{story.publisher}</span>
+                    </Typography>
+                    <Hidden smDown implementation="css">
+                      <Typography component="div">
+                        <ReactMarkdown className="compact-markdown">
+                          {story.excerpt ? story.excerpt : ''}
+                        </ReactMarkdown>
+                      </Typography>
+                    </Hidden>
+                  </Grid>
+                </Grid>
+              </Card>
+            );
+          })}
+      </Grid>
+    </>
+  );
+};

--- a/collections/src/components/Modal/Modal.tsx
+++ b/collections/src/components/Modal/Modal.tsx
@@ -24,7 +24,12 @@ export const Modal: React.FC<ModalProps & DialogProps> = (
   const { open, children, handleClose } = props;
 
   return (
-    <Dialog open={open} onClose={handleClose} fullScreen={fullScreen}>
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      fullScreen={fullScreen}
+      maxWidth="md"
+    >
       <Box
         flex="1"
         display="flex"

--- a/collections/src/components/index.ts
+++ b/collections/src/components/index.ts
@@ -6,6 +6,7 @@ export { Chip } from './Chip/Chip';
 export { CollectionForm } from './CollectionForm/CollectionForm';
 export { CollectionInfo } from './CollectionInfo/CollectionInfo';
 export { CollectionListCard } from './CollectionListCard/CollectionListCard';
+export { CollectionPreview } from './CollectionPreview/CollectionPreview';
 export { CollectionSearchForm } from './CollectionSearchForm/CollectionSearchForm';
 export { HandleApiResponse } from './HandleApiResponse/HandleApiResponse';
 export { Header } from './Header/Header';

--- a/collections/src/pages/CollectionPage/CollectionPage.tsx
+++ b/collections/src/pages/CollectionPage/CollectionPage.tsx
@@ -3,6 +3,7 @@ import { useLocation, useParams } from 'react-router-dom';
 import {
   Box,
   Button,
+  ButtonGroup,
   Collapse,
   Grid,
   Paper,
@@ -17,8 +18,10 @@ import {
 import {
   CollectionForm,
   CollectionInfo,
+  CollectionPreview,
   HandleApiResponse,
   ImageUpload,
+  Modal,
   ScrollToTop,
   StoryForm,
   StoryListCard,
@@ -39,6 +42,7 @@ import {
 import { useNotifications } from '../../hooks/useNotifications';
 import { FormikValues } from 'formik';
 import EditIcon from '@material-ui/icons/Edit';
+import VisibilityIcon from '@material-ui/icons/Visibility';
 import {
   GetArchivedCollectionsDocument,
   GetCollectionByExternalIdDocument,
@@ -434,6 +438,17 @@ export const CollectionPage = (): JSX.Element => {
     });
   };
 
+  const [previewCollectionOpen, setPreviewCollectionOpen] = useState<boolean>(
+    false
+  );
+  /**
+   * Preview the entire collection in a modal
+   */
+  const previewCollection = () => {
+    //
+    setPreviewCollectionOpen(true);
+  };
+
   return (
     <>
       <ScrollToTop />
@@ -450,12 +465,20 @@ export const CollectionPage = (): JSX.Element => {
               </h1>
             </Box>
             <Box alignSelf="center">
-              <Button color="primary" onClick={toggleEditForm}>
-                <EditIcon />
-              </Button>
+              <ButtonGroup
+                orientation="vertical"
+                color="primary"
+                variant="text"
+              >
+                <Button color="primary" onClick={toggleEditForm}>
+                  <EditIcon />
+                </Button>
+                <Button color="primary" onClick={previewCollection}>
+                  <VisibilityIcon />
+                </Button>
+              </ButtonGroup>
             </Box>
           </Box>
-
           <Grid container spacing={2}>
             <Grid item xs={12} sm={4}>
               <ImageUpload
@@ -468,7 +491,6 @@ export const CollectionPage = (): JSX.Element => {
               <CollectionInfo collection={collection} />
             </Grid>
           </Grid>
-
           <Collapse in={showEditForm}>
             <Paper elevation={4}>
               <Box p={2} mt={3}>
@@ -558,7 +580,6 @@ export const CollectionPage = (): JSX.Element => {
               </Droppable>
             </DragDropContext>
           </Box>
-
           <Paper elevation={4}>
             <Box p={2} mt={3}>
               <Box mb={2}>
@@ -574,6 +595,14 @@ export const CollectionPage = (): JSX.Element => {
               />
             </Box>
           </Paper>
+          <Modal
+            open={previewCollectionOpen}
+            handleClose={() => {
+              setPreviewCollectionOpen(false);
+            }}
+          >
+            <CollectionPreview collection={collection} stories={stories} />
+          </Modal>
         </>
       )}
     </>


### PR DESCRIPTION
## Goal

Allow the curators to preview the collection in a separate window (modal overlay) without the distractions of various buttons in the main UI.

Tickets:

- https://getpocket.atlassian.net/browse/BACK-822

## Implementation Decisions

- Added a new "Preview Collection" button - the eye icon right under
the edit icon in the top right corner of the collection page.

- Added a new CollectionPreview component with tests. It is used
on the Collection page to display a preview for the entire collection
in a modal. The styles are rudimentary and fonts don't match the web
version - something to iterate on later.
