### PR TITLE
(fix) Enable Dependabot for Collections Frontend

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,0 +1,10 @@
+# To limit automatically merging to certain packages or prod/dev, see:
+# https://github.com/marketplace/actions/dependabot-auto-merge#configuration-file-syntax
+#
+# dependency_name   full name of dependency, or a regex string
+# dependency_type   all, production, development
+# update_type       all, security:*, semver:*
+
+- match:
+    dependency_type: all
+    update_type: "semver:minor" # includes patch updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,14 @@
 
 version: 2
 updates:
-  # Enable version updates for npm
+  # Enable version updates for Collections Admin UI
   - package-ecosystem: 'npm'
     # Look for `package.json` and `lock` files in the `root` directory
-    directory: '/'
-    # Check the npm registry for updates every day (weekdays)
+    directory: 'collections'
     schedule:
-      interval: 'monthly'
+      interval: 'daily'
+      time: '09:00'
+      timezone: 'America/Los_Angeles'
     commit-message:
       prefix: '[DEPBOT-0101]'
 
@@ -17,9 +18,10 @@ updates:
   - package-ecosystem: 'docker'
     # Look for a `Dockerfile` in the `root` directory
     directory: '/'
-    # Check for updates once a week
     schedule:
-      interval: 'monthly'
+      interval: 'daily'
+      time: '09:00'
+      timezone: 'America/Los_Angeles'
     commit-message:
       prefix: '[DEPBOT-0102]'
 
@@ -27,14 +29,18 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'monthly'
+      interval: 'daily'
+      time: '09:00'
+      timezone: 'America/Los_Angeles'
     commit-message:
       prefix: '[DEPBOT-0103]'
 
   # Maintain dependencies for Terraform
-  - package-ecosystem: 'terraform'
+  - package-ecosystem: 'npm'
     directory: '.aws'
     schedule:
-      interval: 'monthly'
+      interval: 'daily'
+      time: '09:00'
+      timezone: 'America/Los_Angeles'
     commit-message:
       prefix: '[DEPBOT-0104]'

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,17 @@
+# https://github.com/marketplace/actions/dependabot-auto-merge#inputs
+
+name: auto-merge
+
+on:
+  pull_request_target:
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2.4
+        with:
+          config: .github/auto-merge.yml # Path to configuration file (relative to root)
+          github-token: ${{ secrets.GITHUB }}
+          approve: true # Automatically approve pull-requests


### PR DESCRIPTION
## Goal

- I noticed that Dependabot PRs were being generated for .aws and .docker directories,
but not for the bulk of the code in this repository - that's because it's the first
of several frontends that will be in its own directory.

- Also enabling automatic merging for minor version updates with pocket-ci user.
