### PR TITLE
[BACK-783] Add language support for collections

### DIFF
--- a/collections/src/api/collection-api/fragments/CollectionData.ts
+++ b/collections/src/api/collection-api/fragments/CollectionData.ts
@@ -14,6 +14,7 @@ export const CollectionData = gql`
     excerpt
     intro
     imageUrl
+    language
     status
     authors {
       ...CollectionAuthorData

--- a/collections/src/api/collection-api/mutations/createCollection.ts
+++ b/collections/src/api/collection-api/mutations/createCollection.ts
@@ -15,6 +15,7 @@ export const createCollection = gql`
     $curationCategoryExternalId: String
     $IABParentCategoryExternalId: String
     $IABChildCategoryExternalId: String
+    $language: String!
   ) {
     createCollection(
       data: {
@@ -27,6 +28,7 @@ export const createCollection = gql`
         curationCategoryExternalId: $curationCategoryExternalId
         IABParentCategoryExternalId: $IABParentCategoryExternalId
         IABChildCategoryExternalId: $IABChildCategoryExternalId
+        language: $language
       }
     ) {
       ...CollectionData

--- a/collections/src/api/collection-api/mutations/updateCollection.ts
+++ b/collections/src/api/collection-api/mutations/updateCollection.ts
@@ -16,6 +16,7 @@ export const updateCollection = gql`
     $curationCategoryExternalId: String
     $IABParentCategoryExternalId: String
     $IABChildCategoryExternalId: String
+    $language: String!
     $imageUrl: Url
   ) {
     updateCollection(
@@ -30,6 +31,7 @@ export const updateCollection = gql`
         curationCategoryExternalId: $curationCategoryExternalId
         IABParentCategoryExternalId: $IABParentCategoryExternalId
         IABChildCategoryExternalId: $IABChildCategoryExternalId
+        language: $language
         imageUrl: $imageUrl
       }
     ) {

--- a/collections/src/api/collection-api/queries/getInitialCollectionFormData.ts
+++ b/collections/src/api/collection-api/queries/getInitialCollectionFormData.ts
@@ -12,6 +12,10 @@ export const getInitialCollectionFormData = gql`
       }
     }
 
+    getLanguages {
+      code
+    }
+
     getCurationCategories {
       externalId
       name

--- a/collections/src/components/CollectionForm/CollectionForm.styles.tsx
+++ b/collections/src/components/CollectionForm/CollectionForm.styles.tsx
@@ -1,0 +1,12 @@
+import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+
+/**
+ * Styles for the CollectionForm component.
+ */
+export const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    marginBottom: {
+      marginBottom: '1.25rem',
+    },
+  })
+);

--- a/collections/src/components/CollectionForm/CollectionForm.test.tsx
+++ b/collections/src/components/CollectionForm/CollectionForm.test.tsx
@@ -8,6 +8,7 @@ import {
   CollectionStatus,
   CurationCategory,
   IabParentCategory,
+  Language,
 } from '../../api/collection-api/generatedTypes';
 
 describe('The CollectionForm component', () => {
@@ -15,6 +16,7 @@ describe('The CollectionForm component', () => {
   let authors: CollectionAuthor[];
   let curationCategories: CurationCategory[];
   let iabCategories: IabParentCategory[];
+  let languages: Language[];
   let handleSubmit = jest.fn();
 
   beforeEach(() => {
@@ -42,6 +44,7 @@ describe('The CollectionForm component', () => {
         ' Praesent hendrerit eros luctus ligula facilisis, non sodales est ' +
         'suscipit. Nunc a lorem a metus venenatis euismod. Praesent id lectus' +
         ' lobortis, ullamcorper ipsum in, eleifend sapien.',
+      language: 'de',
       status: CollectionStatus.Draft,
       authors: [],
       curationCategory: { externalId: 'cde-234', name: 'Food', slug: 'food' },
@@ -86,6 +89,15 @@ describe('The CollectionForm component', () => {
         ],
       },
     ];
+
+    languages = [
+      {
+        code: 'en',
+      },
+      {
+        code: 'de',
+      },
+    ];
   });
 
   it('renders successfully', () => {
@@ -95,6 +107,7 @@ describe('The CollectionForm component', () => {
         collection={collection}
         curationCategories={curationCategories}
         iabCategories={iabCategories}
+        languages={languages}
         onSubmit={handleSubmit}
       />
     );
@@ -111,6 +124,7 @@ describe('The CollectionForm component', () => {
         collection={collection}
         curationCategories={curationCategories}
         iabCategories={iabCategories}
+        languages={languages}
         onSubmit={handleSubmit}
       />
     );
@@ -126,6 +140,7 @@ describe('The CollectionForm component', () => {
         collection={collection}
         curationCategories={curationCategories}
         iabCategories={iabCategories}
+        languages={languages}
         editMode={false}
         onSubmit={handleSubmit}
       />
@@ -142,6 +157,7 @@ describe('The CollectionForm component', () => {
         collection={collection}
         curationCategories={curationCategories}
         iabCategories={iabCategories}
+        languages={languages}
         onSubmit={handleSubmit}
       />
     );
@@ -155,6 +171,9 @@ describe('The CollectionForm component', () => {
     const statusField = screen.getByLabelText('Status');
     expect(statusField).toBeInTheDocument();
 
+    const languageField = screen.getByLabelText('Language Code');
+    expect(languageField).toBeInTheDocument();
+
     const authorField = screen.getByLabelText('Author');
     expect(authorField).toBeInTheDocument();
 
@@ -163,6 +182,15 @@ describe('The CollectionForm component', () => {
 
     const introField = screen.getByLabelText('Intro');
     expect(introField).toBeInTheDocument();
+
+    const curationCategoryField = screen.getByLabelText('Curation Category');
+    expect(curationCategoryField).toBeInTheDocument();
+
+    const iabParentCategoryField = screen.getByLabelText('IAB Parent Category');
+    expect(iabParentCategoryField).toBeInTheDocument();
+
+    const iabChildCategoryField = screen.getByLabelText('IAB Child Category');
+    expect(iabChildCategoryField).toBeInTheDocument();
   });
 
   it('validates the "title" field', async () => {
@@ -172,6 +200,7 @@ describe('The CollectionForm component', () => {
         collection={collection}
         curationCategories={curationCategories}
         iabCategories={iabCategories}
+        languages={languages}
         onSubmit={handleSubmit}
       />
     );
@@ -223,6 +252,7 @@ describe('The CollectionForm component', () => {
         collection={collection}
         curationCategories={curationCategories}
         iabCategories={iabCategories}
+        languages={languages}
         onSubmit={handleSubmit}
       />
     );
@@ -268,6 +298,7 @@ describe('The CollectionForm component', () => {
         collection={collection}
         curationCategories={curationCategories}
         iabCategories={iabCategories}
+        languages={languages}
         onSubmit={handleSubmit}
       />
     );
@@ -308,6 +339,7 @@ describe('The CollectionForm component', () => {
         collection={collection}
         curationCategories={curationCategories}
         iabCategories={iabCategories}
+        languages={languages}
         onSubmit={handleSubmit}
       />
     );
@@ -343,6 +375,7 @@ describe('The CollectionForm component', () => {
         collection={collection}
         curationCategories={curationCategories}
         iabCategories={iabCategories}
+        languages={languages}
         onSubmit={handleSubmit}
       />
     );

--- a/collections/src/components/CollectionForm/CollectionForm.validation.tsx
+++ b/collections/src/components/CollectionForm/CollectionForm.validation.tsx
@@ -1,7 +1,10 @@
 import * as yup from 'yup';
 import { CollectionStatus } from '../../api/collection-api/generatedTypes';
 
-export const getValidationSchema = (authorIds: string[]) => {
+export const getValidationSchema = (
+  authorIds: string[],
+  languages: string[]
+) => {
   return yup.object({
     title: yup
       .string()
@@ -20,6 +23,10 @@ export const getValidationSchema = (authorIds: string[]) => {
       .min(6),
     excerpt: yup.string(),
     intro: yup.string(),
+    language: yup
+      .string()
+      .oneOf(languages)
+      .required('Please choose a language code'),
     status: yup
       .mixed<CollectionStatus>()
       .oneOf(Object.values(CollectionStatus))

--- a/collections/src/components/CollectionInfo/CollectionInfo.test.tsx
+++ b/collections/src/components/CollectionInfo/CollectionInfo.test.tsx
@@ -6,6 +6,7 @@ import {
   Collection,
   CollectionStatus,
 } from '../../api/collection-api/generatedTypes';
+import { CollectionListCard } from '../CollectionListCard/CollectionListCard';
 
 describe('The CollectionInfo component', () => {
   let collection: Omit<Collection, 'stories'>;
@@ -19,6 +20,7 @@ describe('The CollectionInfo component', () => {
       excerpt:
         'There’s a long history of presidential ailments, including George Washington’s near-death encounter with the flu, Grover Cleveland’s secret tumor, and the clandestine suffering of John F. Kennedy. ',
       intro: 'Intro text is generally longer than the excerpt.',
+      language: 'de',
       status: CollectionStatus.Published,
       authors: [],
     };
@@ -56,6 +58,16 @@ describe('The CollectionInfo component', () => {
     expect(draft).not.toBeInTheDocument();
     const archived = screen.queryByText(/^archived/i);
     expect(archived).not.toBeInTheDocument();
+  });
+
+  it('shows language correctly', () => {
+    render(
+      <MemoryRouter>
+        <CollectionInfo collection={collection} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/^de$/i)).toBeInTheDocument();
   });
 
   it('shows label if curation category is set', () => {

--- a/collections/src/components/CollectionInfo/CollectionInfo.tsx
+++ b/collections/src/components/CollectionInfo/CollectionInfo.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Avatar, Box, Chip, Typography } from '@material-ui/core';
 import LabelOutlinedIcon from '@material-ui/icons/LabelOutlined';
+import LanguageIcon from '@material-ui/icons/Language';
 import ReactMarkdown from 'react-markdown';
 import { useStyles } from './CollectionInfo.styles';
 import { Collection } from '../../api/collection-api/generatedTypes';
@@ -33,6 +34,12 @@ export const CollectionInfo: React.FC<CollectionInfoProps> = (
         <span>{flattenAuthors(collection.authors)}</span>
       </Typography>
       <Box py={1}>
+        <Chip
+          variant="outlined"
+          color="primary"
+          label={collection.language.toUpperCase()}
+          icon={<LanguageIcon />}
+        />{' '}
         {collection.curationCategory && (
           <Chip
             variant="outlined"

--- a/collections/src/components/CollectionListCard/CollectionListCard.test.tsx
+++ b/collections/src/components/CollectionListCard/CollectionListCard.test.tsx
@@ -23,6 +23,7 @@ describe('The CollectionListCard component', () => {
         'There’s a long history of presidential ailments, including George Washington’s near-death encounter with the flu, Grover Cleveland’s secret tumor, and the clandestine suffering of John F. Kennedy. ',
       intro:
         'There’s a long history of presidential ailments, including George Washington’s near-death encounter with the flu, Grover Cleveland’s secret tumor, and the clandestine suffering of John F. Kennedy. ',
+      language: 'de',
       status: CollectionStatus.Published,
       authors: [],
     };
@@ -68,6 +69,16 @@ describe('The CollectionListCard component', () => {
     expect(draft).not.toBeInTheDocument();
     const archived = screen.queryByText(/^archived/i);
     expect(archived).not.toBeInTheDocument();
+  });
+
+  it('shows language correctly', () => {
+    render(
+      <MemoryRouter>
+        <CollectionListCard collection={collection} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/^de$/i)).toBeInTheDocument();
   });
 
   it('shows label if curation category is set', () => {

--- a/collections/src/components/CollectionListCard/CollectionListCard.tsx
+++ b/collections/src/components/CollectionListCard/CollectionListCard.tsx
@@ -14,6 +14,7 @@ import { useStyles } from './CollectionListCard.styles';
 import { Collection } from '../../api/collection-api/generatedTypes';
 import LabelOutlinedIcon from '@material-ui/icons/LabelOutlined';
 import { flattenAuthors } from '../../utils/flattenAuthors';
+import LanguageIcon from '@material-ui/icons/Language';
 
 interface CollectionListCardProps {
   /**
@@ -76,6 +77,12 @@ export const CollectionListCard: React.FC<CollectionListCardProps> = (
               <span>{flattenAuthors(collection.authors)}</span>
             </Typography>{' '}
             <Box py={1}>
+              <Chip
+                variant="outlined"
+                color="primary"
+                label={collection.language.toUpperCase()}
+                icon={<LanguageIcon />}
+              />{' '}
               {collection.curationCategory && (
                 <Chip
                   variant="outlined"

--- a/collections/src/components/CollectionPreview/CollectionPreview.test.tsx
+++ b/collections/src/components/CollectionPreview/CollectionPreview.test.tsx
@@ -21,6 +21,7 @@ describe('The CollectionPreview component', () => {
       excerpt:
         'There’s a long history of presidential ailments, including George Washington’s near-death encounter with the flu, Grover Cleveland’s secret tumor, and the clandestine suffering of John F. Kennedy. ',
       intro: 'Intro text is generally longer than the excerpt.',
+      language: 'en',
       status: CollectionStatus.Published,
       authors: [
         {

--- a/collections/src/components/Header/Header.tsx
+++ b/collections/src/components/Header/Header.tsx
@@ -58,7 +58,7 @@ export const Header: React.FC<HeaderProps> = (props): JSX.Element => {
           <Grid
             container
             direction="row"
-            justify="flex-start"
+            justifyContent="flex-start"
             alignItems="center"
           >
             <Hidden smDown implementation="css">

--- a/collections/src/pages/AddCollectionPage/AddCollectionPage.tsx
+++ b/collections/src/pages/AddCollectionPage/AddCollectionPage.tsx
@@ -29,6 +29,7 @@ export const AddCollectionPage: React.FC = (): JSX.Element => {
     excerpt: '',
     intro: '',
     imageUrl: '',
+    language: 'en',
     status: CollectionStatus.Draft,
     authors: [],
     stories: [],
@@ -61,6 +62,7 @@ export const AddCollectionPage: React.FC = (): JSX.Element => {
         curationCategoryExternalId: values.curationCategoryExternalId,
         IABParentCategoryExternalId: values.IABParentCategoryExternalId,
         IABChildCategoryExternalId: values.IABChildCategoryExternalId,
+        language: values.language,
       },
       // make sure the relevant Collections tab is updated
       // when we add a new collection
@@ -98,11 +100,13 @@ export const AddCollectionPage: React.FC = (): JSX.Element => {
           {data &&
             data.getCollectionAuthors &&
             data.getCurationCategories &&
-            data.getIABCategories && (
+            data.getIABCategories &&
+            data.getLanguages && (
               <CollectionForm
                 authors={data.getCollectionAuthors.authors}
                 curationCategories={data.getCurationCategories}
                 iabCategories={data.getIABCategories}
+                languages={data.getLanguages}
                 collection={collection}
                 onSubmit={handleSubmit}
                 editMode={false}

--- a/collections/src/pages/CollectionPage/CollectionPage.tsx
+++ b/collections/src/pages/CollectionPage/CollectionPage.tsx
@@ -188,6 +188,7 @@ export const CollectionPage = (): JSX.Element => {
         curationCategoryExternalId: values.curationCategoryExternalId,
         IABParentCategoryExternalId: values.IABParentCategoryExternalId,
         IABChildCategoryExternalId: values.IABChildCategoryExternalId,
+        language: values.language,
       },
       refetchQueries: [
         {
@@ -226,6 +227,7 @@ export const CollectionPage = (): JSX.Element => {
             data?.updateCollection?.IABParentCategory;
           collection.IABChildCategory =
             data?.updateCollection?.IABChildCategory;
+          collection.language = data?.updateCollection?.language!;
           toggleEditForm();
           formikHelpers.setSubmitting(false);
         }
@@ -510,7 +512,8 @@ export const CollectionPage = (): JSX.Element => {
                 {initialCollectionFormData &&
                   initialCollectionFormData.getCollectionAuthors &&
                   initialCollectionFormData.getCurationCategories &&
-                  initialCollectionFormData.getIABCategories && (
+                  initialCollectionFormData.getIABCategories &&
+                  initialCollectionFormData.getLanguages && (
                     <CollectionForm
                       authors={
                         initialCollectionFormData.getCollectionAuthors.authors
@@ -520,6 +523,7 @@ export const CollectionPage = (): JSX.Element => {
                         initialCollectionFormData.getCurationCategories
                       }
                       iabCategories={initialCollectionFormData.getIABCategories}
+                      languages={initialCollectionFormData.getLanguages}
                       editMode={true}
                       onCancel={toggleEditForm}
                       onSubmit={handleSubmit}


### PR DESCRIPTION
## Goal

Enable the curators to choose which locale/language this collection should be shown in. 

Tickets:

- https://getpocket.atlassian.net/browse/BACK-783

## Implementation Decisions

- Updated collection fragment, mutations and types

- Added language dropdown and validation against the list of supported languages
to add/edit collection form.

- Added language tag with a "globe" icon to collection info and collection list card
components.

- Updated tests.

Note that the types in this PR were regenerated against `main` in `collection-api` + the small fix in https://github.com/Pocket/collection-api/pull/293. The frontend will likely break if changes in this PR are merged ahead of the ones in https://github.com/Pocket/collection-api/pull/293.  
