### PR TITLE
[SHIPIT-055] Remove text-transform styles on collection data

### DIFF
--- a/collections/src/components/CollectionInfo/CollectionInfo.styles.tsx
+++ b/collections/src/components/CollectionInfo/CollectionInfo.styles.tsx
@@ -1,4 +1,4 @@
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 
 /**
  * Styles for the CollectionInfo component.
@@ -10,7 +10,6 @@ export const useStyles = makeStyles((theme: Theme) =>
     },
     subtitle: {
       fontWeight: 400,
-      textTransform: 'capitalize',
     },
     iabAvatar: {
       height: theme.spacing(3),

--- a/collections/src/components/CollectionListCard/CollectionListCard.styles.tsx
+++ b/collections/src/components/CollectionListCard/CollectionListCard.styles.tsx
@@ -1,4 +1,4 @@
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 
 /**
  * Styles for the CollectionListCard component.
@@ -35,7 +35,6 @@ export const useStyles = makeStyles((theme: Theme) =>
     },
     subtitle: {
       fontWeight: 400,
-      textTransform: 'capitalize',
     },
     [theme.breakpoints.down('sm')]: {
       title: {

--- a/collections/src/components/StoryCard/StoryCard.styles.tsx
+++ b/collections/src/components/StoryCard/StoryCard.styles.tsx
@@ -1,4 +1,4 @@
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 
 /**
  * Styles for the StoryCard component.
@@ -15,7 +15,6 @@ export const useStyles = makeStyles((theme: Theme) =>
     },
     subtitle: {
       fontWeight: 400,
-      textTransform: 'capitalize',
     },
     [theme.breakpoints.down('sm')]: {
       title: {


### PR DESCRIPTION
## Goal

We need to preview the data in the Admin UI exactly as it was entered by the curation team so that there's no confusion about whether, for example, a publisher's name or a collection title is not, in fact, capitalised.

A review of all the frontend code has revealed that we used `textTransform` styles to capitalise collection authors, as well as story publishers and authors. This PR removes these styles.
