### PR TITLE
(refactor) Move reorderable story list out of Collection Page component 

### DIFF
--- a/collections/src/components/ReorderableCollectionStoryList/ReorderableCollectionStoryList.tsx
+++ b/collections/src/components/ReorderableCollectionStoryList/ReorderableCollectionStoryList.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { Typography } from '@material-ui/core';
+import {
+  DragDropContext,
+  Draggable,
+  Droppable,
+  DropResult,
+} from 'react-beautiful-dnd';
+import { StoryListCard } from '../';
+import { CollectionStory } from '../../api/collection-api/generatedTypes';
+
+interface CollectionStoryListProps {
+  /**
+   * All the stories that belong to a collection
+   */
+  stories: CollectionStory[];
+
+  /**
+   * A callback function that will run a mutation every time a story's order
+   * in the list is updated
+   * @param result
+   */
+  reorder: (result: DropResult) => void;
+
+  /**
+   * A special Apollo Client helper that fetches updated query results
+   * from the API on demand - here we pass it on to StoryListCard
+   * that runs it if a story is deleted.
+   */
+  refetch: () => void;
+}
+
+/**
+ * This component displays a list of stories for a collection and allows users
+ * to drag and drop stories to change the order they appear in the collection.
+ *
+ * @param props
+ * @constructor
+ */
+export const ReorderableCollectionStoryList: React.FC<CollectionStoryListProps> =
+  (props): JSX.Element => {
+    const { stories, reorder, refetch } = props;
+
+    return (
+      <DragDropContext onDragEnd={reorder}>
+        <Droppable droppableId="characters">
+          {(provided) => (
+            <Typography
+              component="div"
+              className="characters"
+              {...provided.droppableProps}
+              ref={provided.innerRef}
+            >
+              {stories.map((story: CollectionStory, index: number) => {
+                return (
+                  <Draggable
+                    key={story.externalId}
+                    draggableId={story.externalId}
+                    index={index}
+                  >
+                    {(provided) => {
+                      return (
+                        <Typography
+                          component="div"
+                          ref={provided.innerRef}
+                          {...provided.draggableProps}
+                          {...provided.dragHandleProps}
+                        >
+                          <StoryListCard
+                            key={story.externalId}
+                            story={story}
+                            refetch={refetch}
+                          />
+                        </Typography>
+                      );
+                    }}
+                  </Draggable>
+                );
+              })}
+              {provided.placeholder}
+            </Typography>
+          )}
+        </Droppable>
+      </DragDropContext>
+    );
+  };

--- a/collections/src/components/index.ts
+++ b/collections/src/components/index.ts
@@ -23,6 +23,7 @@ export { Modal } from './Modal/Modal';
 export { PartnerForm } from './PartnerForm/PartnerForm';
 export { PartnerInfo } from './PartnerInfo/PartnerInfo';
 export { PartnerListCard } from './PartnerListCard/PartnerListCard';
+export { ReorderableCollectionStoryList } from './ReorderableCollectionStoryList/ReorderableCollectionStoryList';
 export { SharedFormButtons } from './_form-elements/SharedFormButtons/SharedFormButtons';
 export type { SharedFormButtonsProps } from './_form-elements/SharedFormButtons/SharedFormButtons';
 export { StoryCard } from './StoryCard/StoryCard';


### PR DESCRIPTION
Follow-up to https://github.com/Pocket/curation-admin-tools/pull/201: Part 2/2.

- Moved the code that uses 'react-beautiful-dnd' to display a list of reorderable
collection stories to its own component.

- Updated the method that runs each time the stories are reordered to use the 'runMutation'
hook.

- Although this component looks testable, it's not quite there - it refers to 'StoryCardList'
that contains multiple mutations and needs untangling first before unit tests for
'ReorderableCollectionStoryList' can be added.

**Note that this PR's target is the `sponsored-collections` feature branch.**

Also note that this PR will conflict with https://github.com/Pocket/curation-admin-tools/pull/211 - depending on which one is merged first, the other one will have to be manually updated later.
