### PR TITLE
[BACK-987] Change copy next to story to 'from partner/sponsor'

### DIFF
--- a/collections/src/components/CollectionPreview/CollectionPreview.test.tsx
+++ b/collections/src/components/CollectionPreview/CollectionPreview.test.tsx
@@ -160,7 +160,7 @@ describe('The CollectionPreview component', () => {
     );
 
     // Out of the two stories in the mock data, only one is sponsored
-    const sponsoredStories = screen.getAllByText(/from partner/i);
+    const sponsoredStories = screen.getAllByText(/from partner\/sponsor/i);
     expect(sponsoredStories.length).toEqual(1);
   });
 

--- a/collections/src/components/StoryCard/StoryCard.test.tsx
+++ b/collections/src/components/StoryCard/StoryCard.test.tsx
@@ -116,7 +116,7 @@ describe('The StoryCard component', () => {
     expect(middot).not.toBeInTheDocument();
   });
 
-  it('displays "From Partner" if a story is sponsored', () => {
+  it('displays "From partner/sponsor" if a story is sponsored', () => {
     story.fromPartner = true;
 
     render(
@@ -125,7 +125,7 @@ describe('The StoryCard component', () => {
       </MemoryRouter>
     );
 
-    const fromPartner = screen.getByText(/from partner/i);
+    const fromPartner = screen.getByText(/from partner\/sponsor/i);
     expect(fromPartner).toBeInTheDocument();
   });
 });

--- a/collections/src/components/StoryCard/StoryCard.tsx
+++ b/collections/src/components/StoryCard/StoryCard.tsx
@@ -62,7 +62,7 @@ export const StoryCard: React.FC<StoryCardProps> = (props): JSX.Element => {
               color="primary"
               variant="subtitle2"
             >
-              From partner
+              From partner/sponsor
             </Typography>
           </Grid>
         </Grid>


### PR DESCRIPTION
## Goal

What the title says! This is a very small PR. Updates copy & two tests. 

Note that the PR was open against the `feature/sponsored-collections` branch rather than `main`.

Tickets:

- https://getpocket.atlassian.net/browse/BACK-987

