### PR TITLE
[BACK-988] Refresh stories on deleting a partnership

### DIFF
--- a/collections/src/components/CollectionPartnerAssociationInfo/CollectionPartnerAssociationInfo.tsx
+++ b/collections/src/components/CollectionPartnerAssociationInfo/CollectionPartnerAssociationInfo.tsx
@@ -11,14 +11,11 @@ import {
 import ReactMarkdown from 'react-markdown';
 import EditIcon from '@material-ui/icons/Edit';
 import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
-import { ApolloQueryResult } from '@apollo/client';
 import { FormikValues } from 'formik';
 import { FormikHelpers } from 'formik/dist/types';
 import {
   CollectionPartnerAssociation,
   CollectionPartnershipType,
-  Exact,
-  GetCollectionPartnerAssociationQuery,
   useDeleteCollectionPartnerAssociationMutation,
   useGetCollectionPartnersQuery,
   useUpdateCollectionPartnerAssociationImageUrlMutation,
@@ -43,15 +40,8 @@ interface AssociationPreviewProps {
    * A helper method that requests the partnership from the API
    * whenever the cache needs updating, i.e. on deleting or updating
    * the partnership.
-   *
-   * The type is a little verbose and can be undefined
-   * as it comes from a useLazyQuery() hook instead of useQuery()
    */
-  refetch:
-    | ((
-        variables?: Partial<Exact<{ externalId: string }>> | undefined
-      ) => Promise<ApolloQueryResult<GetCollectionPartnerAssociationQuery>>)
-    | undefined;
+  refetch: () => void;
 }
 
 /**

--- a/collections/src/pages/CollectionPage/CollectionPage.tsx
+++ b/collections/src/pages/CollectionPage/CollectionPage.tsx
@@ -635,12 +635,17 @@ export const CollectionPage = (): JSX.Element => {
             )}
 
             {associationData &&
-              associationData.getCollectionPartnerAssociationForCollection && (
+              associationData.getCollectionPartnerAssociationForCollection &&
+              refetchAssociation &&
+              refetchStories && (
                 <CollectionPartnerAssociationInfo
                   association={
                     associationData.getCollectionPartnerAssociationForCollection
                   }
-                  refetch={refetchAssociation}
+                  refetch={() => {
+                    refetchAssociation();
+                    refetchStories();
+                  }}
                 />
               )}
 


### PR DESCRIPTION
## Goal

Frontend follow-up to https://github.com/Pocket/collection-api/pull/334. 

Tickets:

- https://getpocket.atlassian.net/browse/BACK-988

## Implementation Decisions

The solution is a bit crude - we were already sending a `refetch()` helper function to the `CollectionPartnerAssociationInfo` component that was using it to fetch the fresh data from the API on completing either the `update` or the `delete` mutation. We're now sending this component two refetch helpers at once but that means stories are refreshed not only on deleting a partnership, but also on updating it. 

Once the pagination PR is in, which contains the beginnings of proper cache management on the client side, we will be able to phase out the reliance on passing around `refetch()` helpers everywhere.
