### PR TITLE
[BACK-1000] Fix 'Cancel' button on 'Add Partnership' form

### DIFF
--- a/collections/src/pages/CollectionPage/CollectionPage.tsx
+++ b/collections/src/pages/CollectionPage/CollectionPage.tsx
@@ -669,6 +669,7 @@ export const CollectionPage = (): JSX.Element => {
                               partnersData.getCollectionPartners.partners
                             }
                             onSubmit={handleCreateAssociationSubmit}
+                            onCancel={togglePartnershipForm}
                           />
                         )}
                       </Grid>


### PR DESCRIPTION
## Goal

If a user opens up the "Add Partnership" form and decides not to create a partnership, the "Cancel" button that rolls up the form and hides it from view should work.

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1000

