### PR TITLE
fix(terraform) switch terraform-modules from github package to npm package

### DIFF
--- a/.aws/package.json
+++ b/.aws/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@cdktf/provider-aws": "2.0.10",
     "@cdktf/provider-null": "0.2.7",
-    "@pocket/terraform-modules": "1.27.1",
+    "@pocket-tools/terraform-modules": "1.27.1",
     "cdktf": "0.5.0",
     "constructs": "3.3.147"
   },


### PR DESCRIPTION
## Goal

Fix infrastructure installation - noticed that I couldn't run `npm ci` because `@pocket/terraform-modules` at 1.27.1 is erroring out on GitHub with a 401 error for some reason. `backend-typescript-template` refers to `@pocket-tools/terraform-modules`, so switching to that instead. 
## Todos
