### PR TITLE
fix(CI) Skip running 'terraform plan' on production when deploying to dev

### DIFF
--- a/.aws/package.json
+++ b/.aws/package.json
@@ -5,8 +5,7 @@
   "types": "src/main.ts",
   "private": true,
   "scripts": {
-    "build:dev": "npm run build && NODE_ENV=development npm run synth",
-    "build": "rm -rf dist && tsc",
+    "build:dev": "rm -rf dist && NODE_ENV=development npm run synth",
     "synth": "cdktf synth",
     "compile": "tsc --pretty",
     "watch": "tsc -w"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -54,8 +54,7 @@ phases:
       - tfenv install
       - tfenv use $(cat .terraform-version)
 
-      - npm install
-      - npm run build
+      - npm ci
       # synthesize the js into terraform json with the proper node environment
       - 'if [ "$GIT_BRANCH" == "$DEV_BRANCH" ]; then NODE_ENV=development npm run synth; else npm run synth; fi'
       - cd cdktf.out/stacks/curation-admin-tools
@@ -64,7 +63,7 @@ phases:
     commands:
       - echo Build started on `date`
       ### If the branch is not main and its not dev, lets do a plan on prod.
-      - 'if [ "$CODEBUILD_WEBHOOK_HEAD_REF" != "$MAIN_BRANCH_REF" ] && [ "$CODEBUILD_WEBHOOK_HEAD_REF" != "$DEV_BRANCH_REF" ]; then terraform plan -lock=false -refresh=false -no-color; fi'
+      - 'if [ "$CODEBUILD_WEBHOOK_HEAD_REF" != "$MAIN_BRANCH_REF" ] && [ "$CODEBUILD_WEBHOOK_HEAD_REF" != "$DEV_BRANCH_REF" ] && [ -z "$GIT_BRANCH" ]; then terraform plan -lock=false -refresh=false -no-color; fi'
       #### If the branch is dev, lets do an apply on dev.
       - 'if [ "$GIT_BRANCH" == "$DEV_BRANCH" ]; then TF_WORKSPACE=$TF_DEV_WORKSPACE TF_LOG=INFO terraform apply -auto-approve -no-color; fi'
       #### If the branch is main lets apply.


### PR DESCRIPTION
## Goal

- Update the workflow to skip terraform plan when GIT_BRANCH is not empty
 since that is used for main and dev branch builds. Without this condition,
 deploying to the dev branch runs terraform plan against the production
 workspace.

- Update the npm script build:dev to avoid double compilation of the code
 and remove build to remove redundancy.

Note: propagating the fix from https://github.com/Pocket/backend-typescript-template/pull/206
by @kkyeboah to this repository.
