### PR TITLE
[BACK-1184] Update CuratedItemListCard component

### DIFF
--- a/src/_shared/components/MainContentWrapper/MainContentWrapper.tsx
+++ b/src/_shared/components/MainContentWrapper/MainContentWrapper.tsx
@@ -4,7 +4,7 @@ import { makeStyles, Theme } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme: Theme) => ({
   mainContent: {
-    maxWidth: 1000,
+    maxWidth: 1260,
     marginTop: '7.5rem',
     [theme.breakpoints.down('sm')]: {
       marginTop: '5.5rem',

--- a/src/prospects/components/CuratedItemListCard/CuratedItemListCard.styles.tsx
+++ b/src/prospects/components/CuratedItemListCard/CuratedItemListCard.styles.tsx
@@ -6,33 +6,41 @@ import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 export const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
-      margin: 'auto',
-      padding: '1.25rem 0.25rem',
-      border: 0,
-      borderBottom: `1px solid ${theme.palette.grey[300]}`,
-      cursor: 'pointer',
-      '&:active': {
-        backgroundColor: theme.palette.grey[300],
-      },
+      height: '100%',
+      display: 'flex',
+      flexDirection: 'column',
     },
-    image: {
-      borderRadius: 4,
+    actions: {
+      margin: 'auto',
+    },
+    content: {
+      padding: '0.5rem',
+    },
+    flexGrow: {
+      flexGrow: 1,
     },
     link: {
       textDecoration: 'none',
-      padding: '1.25 rem 0',
+      color: theme.palette.grey[900],
+    },
+    list: {
+      borderBottom: `1px solid ${theme.palette.grey[300]}`,
+    },
+    listItemIcon: {
+      minWidth: '2rem',
+    },
+    publisher: {
+      marginTop: '0.25rem',
+      fontWeight: 400,
+      fontSize: '0.875rem',
+      color: theme.palette.grey[600],
     },
     title: {
-      fontSize: '1.25rem',
+      fontSize: '1rem',
       fontWeight: 500,
     },
-    subtitle: {
-      fontWeight: 400,
-    },
-    [theme.breakpoints.down('sm')]: {
-      title: {
-        fontSize: '1rem',
-      },
+    status: {
+      textTransform: 'capitalize',
     },
   })
 );

--- a/src/prospects/components/CuratedItemListCard/CuratedItemListCard.test.tsx
+++ b/src/prospects/components/CuratedItemListCard/CuratedItemListCard.test.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Router } from 'react-router-dom';
-import { createMemoryHistory } from 'history';
-import { MockedProvider } from '@apollo/client/testing';
-import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
 import {
   CuratedItem,
   CuratedStatus,
@@ -43,10 +40,7 @@ describe('The CuratedItemListCard component', () => {
     // The link to the curated item page is present and is well-formed
     const link = screen.getByRole('link');
     expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute(
-      'href',
-      expect.stringContaining(item.externalId)
-    );
+    expect(link).toHaveAttribute('href', expect.stringContaining(item.url));
 
     // The excerpt is also present
     const excerpt = screen.getByText(/wanted to know about react/i);
@@ -79,36 +73,5 @@ describe('The CuratedItemListCard component', () => {
     );
 
     expect(screen.getByText(/^de$/i)).toBeInTheDocument();
-  });
-
-  it("links to an individual item's page", () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/prospects/corpus/'],
-    });
-
-    render(
-      <MockedProvider>
-        <Router history={history}>
-          <CuratedItemListCard item={item} />
-        </Router>
-      </MockedProvider>
-    );
-
-    // While the entire card is a giant link, we can click on
-    // anything we like within that link - i.e., the title of the item
-    userEvent.click(screen.getByText(item.title));
-    expect(history.location.pathname).toEqual(
-      `/prospects/corpus/${item.externalId}/`
-    );
-
-    // Let's go back to the Corpus page
-    history.goBack();
-    expect(history.location.pathname).toEqual('/prospects/corpus/');
-
-    // And click on the image this time
-    userEvent.click(screen.getByRole('img'));
-    expect(history.location.pathname).toEqual(
-      `/prospects/corpus/${item.externalId}/`
-    );
   });
 });

--- a/src/prospects/components/CuratedItemListCard/CuratedItemListCard.tsx
+++ b/src/prospects/components/CuratedItemListCard/CuratedItemListCard.tsx
@@ -1,17 +1,22 @@
 import React from 'react';
-import { useStyles } from './CuratedItemListCard.styles';
-import { Link } from 'react-router-dom';
 import {
-  Box,
   Card,
+  CardActions,
+  CardContent,
   CardMedia,
-  Chip,
-  Grid,
+  Link,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
   Typography,
 } from '@material-ui/core';
 import LanguageIcon from '@material-ui/icons/Language';
-import ReactMarkdown from 'react-markdown';
+import LabelOutlinedIcon from '@material-ui/icons/LabelOutlined';
+import ThumbUpIcon from '@material-ui/icons/ThumbUp';
+import { useStyles } from './CuratedItemListCard.styles';
 import { CuratedItem } from '../../api/curated-corpus-api/generatedTypes';
+import { Button } from '../../../_shared/components';
 
 interface CuratedItemListCardProps {
   /**
@@ -27,61 +32,73 @@ export const CuratedItemListCard: React.FC<CuratedItemListCardProps> = (
   const { item } = props;
 
   return (
-    <Link
-      to={{
-        pathname: `/prospects/corpus/${item.externalId}/`,
-        state: { item },
-      }}
-      className={classes.link}
-    >
-      <Card variant="outlined" square className={classes.root}>
-        <Grid container spacing={2}>
-          <Grid item xs={4} sm={2}>
-            <CardMedia
-              component="img"
-              src={
-                item.imageUrl && item.imageUrl.length > 0
-                  ? item.imageUrl
-                  : '/placeholders/collectionSmall.svg'
-              }
-              alt={item.title}
-              className={classes.image}
-            />
-          </Grid>
-          <Grid item xs={8} sm={10}>
-            <Typography
-              className={classes.title}
-              variant="h3"
-              align="left"
-              gutterBottom
-            >
-              {item.title}
-            </Typography>
-            <Typography
-              className={classes.subtitle}
-              variant="subtitle2"
-              color="textSecondary"
-              component="span"
-              align="left"
-            >
-              <span>{item.status}</span>
-            </Typography>{' '}
-            <Box py={1}>
-              <Chip
-                variant="outlined"
-                color="primary"
-                label={item.language.toUpperCase()}
-                icon={<LanguageIcon />}
-              />
-            </Box>
-            <Typography noWrap component="div">
-              <ReactMarkdown>
-                {item.excerpt ? item.excerpt.substring(0, 100) : ''}
-              </ReactMarkdown>
-            </Typography>
-          </Grid>
-        </Grid>
-      </Card>
-    </Link>
+    <Card className={classes.root}>
+      <CardMedia
+        component="img"
+        src={
+          item.imageUrl && item.imageUrl.length > 0
+            ? item.imageUrl
+            : '/placeholders/collectionSmall.svg'
+        }
+        alt={item.title}
+      />
+      <CardContent className={classes.content}>
+        <Typography className={classes.publisher} gutterBottom>
+          Publisher Name
+        </Typography>
+        <Typography
+          className={classes.title}
+          variant="h3"
+          align="left"
+          gutterBottom
+        >
+          <Link href={item.url} className={classes.link}>
+            {item.title}
+          </Link>
+        </Typography>
+        <Typography variant="body2" component="p" gutterBottom>
+          {item.excerpt}
+        </Typography>
+      </CardContent>
+
+      {/* Push the rest of the elements to the bottom of the card. */}
+      <div className={classes.flexGrow} />
+
+      <List dense className={classes.list}>
+        <ListItem>
+          <ListItemIcon className={classes.listItemIcon}>
+            <ThumbUpIcon />
+          </ListItemIcon>
+          <ListItemText
+            className={classes.status}
+            primary={item.status.toLowerCase()}
+          />
+        </ListItem>
+        <ListItem>
+          <ListItemIcon className={classes.listItemIcon}>
+            <LabelOutlinedIcon />
+          </ListItemIcon>
+          <ListItemText primary={item.topic} />
+        </ListItem>
+        <ListItem>
+          <ListItemIcon className={classes.listItemIcon}>
+            <LanguageIcon />
+          </ListItemIcon>
+          <ListItemText primary={item.language.toUpperCase()} />
+        </ListItem>
+      </List>
+
+      <CardActions className={classes.actions}>
+        <Button buttonType="positive" variant="text">
+          Schedule
+        </Button>
+        <Button buttonType="negative" variant="text">
+          Reject
+        </Button>
+        <Button buttonType="positive" variant="text">
+          Edit
+        </Button>
+      </CardActions>
+    </Card>
   );
 };

--- a/src/prospects/pages/CuratedItemsPage/CuratedItemsPage.tsx
+++ b/src/prospects/pages/CuratedItemsPage/CuratedItemsPage.tsx
@@ -7,6 +7,7 @@ import {
 import { HandleApiResponse, LoadMore } from '../../../_shared/components';
 import { CuratedItemListCard, CuratedItemSearchForm } from '../../components';
 import { config } from '../../../config';
+import { Grid } from '@material-ui/core';
 
 export const CuratedItemsPage: React.FC = (): JSX.Element => {
   const [loading, reloading, error, data, updateData] = useFetchMoreResults(
@@ -30,17 +31,33 @@ export const CuratedItemsPage: React.FC = (): JSX.Element => {
       />
       {!data && <HandleApiResponse loading={loading} error={error} />}
 
-      {data &&
-        data.getCuratedItems.edges.map((edge: CuratedItemEdge) => {
-          if (edge.node) {
-            return (
-              <CuratedItemListCard
-                key={edge.node?.externalId}
-                item={edge.node}
-              />
-            );
-          }
-        })}
+      <Grid
+        container
+        direction="row"
+        alignItems="stretch"
+        justifyContent="flex-start"
+        spacing={3}
+      >
+        {data &&
+          data.getCuratedItems.edges.map((edge: CuratedItemEdge) => {
+            if (edge.node) {
+              return (
+                <Grid
+                  item
+                  xs={12}
+                  sm={6}
+                  md={3}
+                  key={`grid-${edge.node?.externalId}`}
+                >
+                  <CuratedItemListCard
+                    key={edge.node?.externalId}
+                    item={edge.node}
+                  />
+                </Grid>
+              );
+            }
+          })}
+      </Grid>
 
       {data && (
         <LoadMore

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -3,8 +3,8 @@ import {
    * backport from v.5 to fix deprecation warnings in Material UI
    * see here for details: https://github.com/mui-org/material-ui/issues/13394
    */
-  unstable_createMuiStrictModeTheme as createMuiTheme,
   Theme,
+  unstable_createMuiStrictModeTheme as createMuiTheme,
 } from '@material-ui/core/styles';
 
 /* Curation frontend colors */


### PR DESCRIPTION
## Goal

Updated `CuratedItemListCard` component to match the new wireframes. In an attempt to make sure information from the right pane on the curated item card in the wireframe fits width-wise ended up rearranging elements quite a bit.

- Publisher field yet to come through from the API - used placeholder instead.

- Updated max page width to 1260px (up from ~1000px) to fit four cards in desktop view.


Tickets:

- https://getpocket.atlassian.net/browse/BACK-1184


