### PR TITLE
[BACK-1194] Increase authors shown per page for Collections

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -23,7 +23,7 @@ export const config = {
   }`,
   environment: process.env.NODE_ENV,
   pagination: {
-    authorsPerPage: 30,
+    authorsPerPage: 200,
     collectionsPerPage: 30,
     partnersPerPage: 30,
     // To display four items in a row, 32 is a better choice than 30 which gives us 7 1/2 rows.


### PR DESCRIPTION
## Goal
Show more authors per page in the Collections tool. Currently, we show 30 authors per page - there are three pages 

## Todos

- [x] Bumped perPage config value from 30 to 200

Tickets:
- https://getpocket.atlassian.net/browse/BACK-1194

### Screenshot / Screen capture
> I didn't see a test for this so I'm testing it by literally scrolling all the way to the bottom and making sure the `Load more results ->` button is inactive, meaning we have all the authors on one page


> https://user-images.githubusercontent.com/16694733/140383656-dd75027b-407d-4372-8911-d8e049d22a53.mov

