### PR TITLE
[BACK-1166] Wire Schedule Save Button on Live Corpus

### DIFF
--- a/src/collections/components/StoryListCard/StoryListCard.tsx
+++ b/src/collections/components/StoryListCard/StoryListCard.tsx
@@ -78,7 +78,7 @@ export const StoryListCard: React.FC<StoryListCardProps> = (props) => {
 
   // 1. Prepare the "update story" mutation
   const [updateStory] = useUpdateCollectionStoryMutation();
-  // 3. Update the story when the user submits the form
+  // 2. Update the story when the user submits the form
   const onUpdate = (
     values: FormikValues,
     formikHelpers: FormikHelpers<any>

--- a/src/curated-corpus/api/curated-corpus-api/generatedTypes.ts
+++ b/src/curated-corpus/api/curated-corpus-api/generatedTypes.ts
@@ -43,8 +43,8 @@ export type CreateCuratedItemInput = {
   isSyndicated: Scalars['Boolean'];
   /** What language this item is in. This is a two-letter code, for example, 'en' for English. */
   language: Scalars['String'];
-  /** Optionally, specify the external ID of the New Tab this item should be scheduled for. */
-  newTabFeedExternalId?: Maybe<Scalars['ID']>;
+  /** Optionally, specify the GUID of the New Tab this item should be scheduled for. */
+  newTabGuid?: Maybe<Scalars['ID']>;
   /** The name of the online publication that published this story. */
   publisher: Scalars['String'];
   /** Optionally, specify the date this item should be appearing on New Tab. Format: YYYY-MM-DD */
@@ -66,8 +66,8 @@ export type CreateCuratedItemInput = {
 export type CreateNewTabFeedScheduledItemInput = {
   /** The ID of the Curated Item that needs to be scheduled. */
   curatedItemExternalId: Scalars['ID'];
-  /** The ID of the New Tab Feed the Curated Item above is going to appear on. */
-  newTabFeedExternalId: Scalars['ID'];
+  /** The GUID of the New Tab Feed the Curated Item is going to appear on. Example: 'EN_US'. */
+  newTabGuid: Scalars['ID'];
   /** The date the associated Curated Item is scheduled to appear on New Tab. Format: YYYY-MM-DD. */
   scheduledDate: Scalars['Date'];
 };
@@ -222,12 +222,12 @@ export type NewTabFeedScheduledItem = {
   updatedBy?: Maybe<Scalars['String']>;
 };
 
-/** Available fields for filtering scheduled items for a given New Tab Feed. */
+/** Available fields for filtering scheduled items for a given New Tab. */
 export type NewTabFeedScheduledItemsFilterInput = {
   /** To what day to show scheduled items to, inclusive. Expects a date in YYYY-MM-DD format. */
   endDate: Scalars['Date'];
-  /** The ID of the New Tab Feed. A string in UUID format. */
-  newTabExternalId: Scalars['ID'];
+  /** The GUID of the New Tab. Example: 'EN_US'. */
+  newTabGuid: Scalars['ID'];
   /** Which day to show scheduled items from. Expects a date in YYYY-MM-DD format. */
   startDate: Scalars['Date'];
 };
@@ -442,6 +442,44 @@ export type RejectedCuratedCorpusItemDataFragment = {
   createdAt: number;
 };
 
+export type CreateNewTabFeedScheduledItemMutationVariables = Exact<{
+  curatedItemExternalId: Scalars['ID'];
+  newTabGuid: Scalars['ID'];
+  scheduledDate: Scalars['Date'];
+}>;
+
+export type CreateNewTabFeedScheduledItemMutation = {
+  __typename?: 'Mutation';
+  createNewTabFeedScheduledItem: {
+    __typename?: 'NewTabFeedScheduledItem';
+    externalId: string;
+    createdAt: number;
+    createdBy: string;
+    updatedAt: number;
+    updatedBy?: string | null | undefined;
+    scheduledDate: any;
+    curatedItem: {
+      __typename?: 'CuratedItem';
+      externalId: string;
+      title: string;
+      language: string;
+      publisher: string;
+      url: any;
+      imageUrl: any;
+      excerpt: string;
+      status: CuratedStatus;
+      topic: string;
+      isCollection: boolean;
+      isShortLived: boolean;
+      isSyndicated: boolean;
+      createdBy: string;
+      createdAt: number;
+      updatedBy?: string | null | undefined;
+      updatedAt: number;
+    };
+  };
+};
+
 export type GetCuratedItemsQueryVariables = Exact<{
   filters?: Maybe<CuratedItemFilter>;
   pagination?: Maybe<PaginationInput>;
@@ -554,6 +592,78 @@ export const RejectedCuratedCorpusItemDataFragmentDoc = gql`
     createdAt
   }
 `;
+export const CreateNewTabFeedScheduledItemDocument = gql`
+  mutation createNewTabFeedScheduledItem(
+    $curatedItemExternalId: ID!
+    $newTabGuid: ID!
+    $scheduledDate: Date!
+  ) {
+    createNewTabFeedScheduledItem(
+      data: {
+        curatedItemExternalId: $curatedItemExternalId
+        newTabGuid: $newTabGuid
+        scheduledDate: $scheduledDate
+      }
+    ) {
+      externalId
+      createdAt
+      createdBy
+      updatedAt
+      updatedBy
+      scheduledDate
+      curatedItem {
+        ...CuratedItemData
+      }
+    }
+  }
+  ${CuratedItemDataFragmentDoc}
+`;
+export type CreateNewTabFeedScheduledItemMutationFn = Apollo.MutationFunction<
+  CreateNewTabFeedScheduledItemMutation,
+  CreateNewTabFeedScheduledItemMutationVariables
+>;
+
+/**
+ * __useCreateNewTabFeedScheduledItemMutation__
+ *
+ * To run a mutation, you first call `useCreateNewTabFeedScheduledItemMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateNewTabFeedScheduledItemMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createNewTabFeedScheduledItemMutation, { data, loading, error }] = useCreateNewTabFeedScheduledItemMutation({
+ *   variables: {
+ *      curatedItemExternalId: // value for 'curatedItemExternalId'
+ *      newTabGuid: // value for 'newTabGuid'
+ *      scheduledDate: // value for 'scheduledDate'
+ *   },
+ * });
+ */
+export function useCreateNewTabFeedScheduledItemMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    CreateNewTabFeedScheduledItemMutation,
+    CreateNewTabFeedScheduledItemMutationVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    CreateNewTabFeedScheduledItemMutation,
+    CreateNewTabFeedScheduledItemMutationVariables
+  >(CreateNewTabFeedScheduledItemDocument, options);
+}
+export type CreateNewTabFeedScheduledItemMutationHookResult = ReturnType<
+  typeof useCreateNewTabFeedScheduledItemMutation
+>;
+export type CreateNewTabFeedScheduledItemMutationResult =
+  Apollo.MutationResult<CreateNewTabFeedScheduledItemMutation>;
+export type CreateNewTabFeedScheduledItemMutationOptions =
+  Apollo.BaseMutationOptions<
+    CreateNewTabFeedScheduledItemMutation,
+    CreateNewTabFeedScheduledItemMutationVariables
+  >;
 export const GetCuratedItemsDocument = gql`
   query getCuratedItems(
     $filters: CuratedItemFilter

--- a/src/curated-corpus/api/curated-corpus-api/mutations/createNewTabFeedScheduledItem.ts
+++ b/src/curated-corpus/api/curated-corpus-api/mutations/createNewTabFeedScheduledItem.ts
@@ -1,0 +1,29 @@
+import { gql } from '@apollo/client';
+import { CuratedItemData } from '../fragments/curatedItemData';
+
+export const createNewTabFeedScheduledItem = gql`
+  mutation createNewTabFeedScheduledItem(
+    $curatedItemExternalId: ID!
+    $newTabGuid: ID!
+    $scheduledDate: Date!
+  ) {
+    createNewTabFeedScheduledItem(
+      data: {
+        curatedItemExternalId: $curatedItemExternalId
+        newTabGuid: $newTabGuid
+        scheduledDate: $scheduledDate
+      }
+    ) {
+      externalId
+      createdAt
+      createdBy
+      updatedAt
+      updatedBy
+      scheduledDate
+      curatedItem {
+        ...CuratedItemData
+      }
+    }
+  }
+  ${CuratedItemData}
+`;

--- a/src/curated-corpus/components/ScheduleCuratedItemModal/ScheduleCuratedItemModal.tsx
+++ b/src/curated-corpus/components/ScheduleCuratedItemModal/ScheduleCuratedItemModal.tsx
@@ -4,16 +4,22 @@ import { Box, Grid, Typography } from '@material-ui/core';
 import { ScheduleCuratedItemForm } from '../';
 import { newTabs } from '../../helpers/definitions';
 import { CuratedItem } from '../../api/curated-corpus-api/generatedTypes';
+import { FormikValues } from 'formik';
+import { FormikHelpers } from 'formik/dist/types';
 
 interface ScheduleCuratedItemModalProps {
   curatedItem: CuratedItem;
   isOpen: boolean;
+  onSave: (
+    values: FormikValues,
+    formikHelpers: FormikHelpers<any>
+  ) => void | Promise<any>;
   toggleModal: () => void;
 }
 
 export const ScheduleCuratedItemModal: React.FC<ScheduleCuratedItemModalProps> =
   (props): JSX.Element => {
-    const { curatedItem, isOpen, toggleModal } = props;
+    const { curatedItem, isOpen, onSave, toggleModal } = props;
 
     return (
       <Modal
@@ -35,9 +41,7 @@ export const ScheduleCuratedItemModal: React.FC<ScheduleCuratedItemModalProps> =
             <ScheduleCuratedItemForm
               curatedItemExternalId={curatedItem.externalId}
               newTabList={newTabs}
-              onSubmit={() => {
-                // nothing to see here
-              }}
+              onSubmit={onSave}
               onCancel={() => {
                 toggleModal();
               }}


### PR DESCRIPTION
## Goal

Wire up the "Save" mutation on "Schedule this item for New Tab" form so that the new entry is saved in the database. 

By the way, there is no way to check on the frontend that these scheduled entries are created. Options are to get right into the database if you run the Curated Corpus API locally with

```bash
docker compose exec mysql bash
```

or to use the `getNewTabFeedScheduledItems` query in the API playground.

- Added a mutation and updated generated types to get custom useMutation hook.

- Wired up the mutation to the "Schedule" button.

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1166

https://user-images.githubusercontent.com/22447785/140494464-e86fb9f0-5bd6-4958-8704-7a5c011dbd6b.mov



