### PR TITLE
fix(deps): Allow auto-merge job to approve patch updates only.

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -7,4 +7,4 @@
 
 - match:
     dependency_type: all
-    update_type: "semver:minor" # includes patch updates
+    update_type: "semver:patch" # approve only patch updates


### PR DESCRIPTION
## Goal

We have had the frontend break on a minor update - Apollo Client, post-upgrade from v.3.4 to v.3.5, stopped sending any and all requests to the Collection API.

The offending commit is here: https://github.com/Pocket/curation-admin-tools/pull/522
and to revert it, there was a PR by @Herraj here: https://github.com/Pocket/curation-admin-tools/pull/523