### PR TITLE
[BACK-1148] Wire up the reject button to display the rejection screen

### DIFF
--- a/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
+++ b/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
@@ -20,13 +20,18 @@ interface ProspectListCardProps {
    * An object with everything prospect-related in it.
    */
   prospect: Prospect;
+
+  /**
+   * What to do when the user presses the "Reject" button on the card.
+   */
+  onReject: () => void;
 }
 
 export const ProspectListCard: React.FC<ProspectListCardProps> = (
   props
 ): JSX.Element => {
   const classes = useStyles();
-  const { prospect } = props;
+  const { prospect, onReject } = props;
 
   return (
     <Card className={classes.root}>
@@ -93,7 +98,7 @@ export const ProspectListCard: React.FC<ProspectListCardProps> = (
         <Button buttonType="positive" variant="text">
           Add to Corpus
         </Button>
-        <Button buttonType="negative" variant="text">
+        <Button buttonType="negative" variant="text" onClick={onReject}>
           Reject
         </Button>
       </CardActions>

--- a/src/curated-corpus/components/RejectProspectForm/RejectProspectForm.test.tsx
+++ b/src/curated-corpus/components/RejectProspectForm/RejectProspectForm.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { RejectProspectForm } from './RejectProspectForm';
+import userEvent from '@testing-library/user-event';
+
+describe('The RejectProspectForm component', () => {
+  const handleSubmit = jest.fn();
+
+  it('renders successfully', () => {
+    render(<RejectProspectForm onSubmit={handleSubmit} />);
+
+    // there is at least a form and nothing falls over
+    const form = screen.getByRole('form');
+    expect(form).toBeInTheDocument();
+  });
+
+  it('has the requisite fields and buttons', () => {
+    render(<RejectProspectForm onSubmit={handleSubmit} />);
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    // We have six rejection reasons. They come from an enum in the Curated Corpus
+    // API schema - RejectionReason and are available through the codegen types.
+    expect(checkboxes).toHaveLength(6);
+
+    const buttons = screen.getAllByRole('button');
+    // "Save" and "Cancel" buttons are expected here.
+    expect(buttons).toHaveLength(2);
+  });
+
+  it('displays an error message if no checkboxes have been selected', async () => {
+    render(<RejectProspectForm onSubmit={handleSubmit} />);
+
+    await waitFor(() => {
+      userEvent.click(screen.getByText(/save/i));
+    });
+
+    const errorMessage = screen.getByText(
+      /Please specify at least one rejection reason./i
+    );
+    expect(errorMessage).toBeInTheDocument();
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
+
+  it('submits the form if at least one checkbox was selected', async () => {
+    render(<RejectProspectForm onSubmit={handleSubmit} />);
+
+    const chosenReason = screen.getByLabelText(/time sensitive/i);
+    await waitFor(() => {
+      userEvent.click(chosenReason);
+    });
+
+    await waitFor(() => {
+      userEvent.click(screen.getByText(/save/i));
+    });
+
+    expect(handleSubmit).toHaveBeenCalled();
+  });
+});

--- a/src/curated-corpus/components/RejectProspectForm/RejectProspectForm.tsx
+++ b/src/curated-corpus/components/RejectProspectForm/RejectProspectForm.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+
+import { FormikHelpers, FormikValues, useFormik } from 'formik';
+import {
+  Box,
+  Checkbox,
+  FormControlLabel,
+  FormGroup,
+  FormHelperText,
+  Grid,
+} from '@material-ui/core';
+import {
+  SharedFormButtons,
+  SharedFormButtonsProps,
+} from '../../../_shared/components';
+import { validationSchema } from './RejectProspectForm.validation';
+import { RejectionReason } from '../../api/curated-corpus-api/generatedTypes';
+
+interface RejectionReasonsFormProps {
+  /**
+   * What do we do with the submitted data?
+   */
+  onSubmit: (
+    values: FormikValues,
+    formikHelpers: FormikHelpers<any>
+  ) => void | Promise<any>;
+}
+
+export const RejectProspectForm: React.FC<
+  RejectionReasonsFormProps & SharedFormButtonsProps
+> = (props): JSX.Element => {
+  const { onCancel, onSubmit } = props;
+
+  const formik = useFormik({
+    initialValues: {
+      [RejectionReason.Paywall]: false,
+      [RejectionReason.PoliticalOpinion]: false,
+      [RejectionReason.OffensiveMaterial]: false,
+      [RejectionReason.TimeSensitive]: false,
+      [RejectionReason.Misinformation]: false,
+      [RejectionReason.Other]: false,
+      reasonRequired: '',
+    },
+    validateOnBlur: false,
+    validateOnChange: false,
+    validationSchema,
+    onSubmit: (values, formikHelpers) => {
+      // Do something here, but not just yet
+      onSubmit(values, formikHelpers);
+    },
+  });
+  return (
+    <>
+      <form name="reject-prospect-form" onSubmit={formik.handleSubmit}>
+        <Grid container spacing={3}>
+          <Grid item xs={12} sm={6}>
+            <FormGroup>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    color="primary"
+                    {...formik.getFieldProps({
+                      name: RejectionReason.Paywall,
+                    })}
+                  />
+                }
+                label="Paywall"
+              />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    color="primary"
+                    {...formik.getFieldProps({
+                      name: RejectionReason.PoliticalOpinion,
+                    })}
+                  />
+                }
+                label="Partisan/Political opinion"
+              />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    color="primary"
+                    {...formik.getFieldProps({
+                      name: RejectionReason.OffensiveMaterial,
+                    })}
+                  />
+                }
+                label="Offensive material"
+              />
+            </FormGroup>
+          </Grid>
+          <Grid item xs={12} sm={6}>
+            <FormGroup>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    color="primary"
+                    {...formik.getFieldProps({
+                      name: RejectionReason.TimeSensitive,
+                    })}
+                  />
+                }
+                label="Time sensitive"
+              />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    color="primary"
+                    {...formik.getFieldProps({
+                      name: RejectionReason.Misinformation,
+                    })}
+                  />
+                }
+                label="Misinformation"
+              />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    color="primary"
+                    {...formik.getFieldProps({
+                      name: RejectionReason.Other,
+                    })}
+                  />
+                }
+                label="Other"
+              />
+            </FormGroup>
+          </Grid>
+        </Grid>
+        <Box mb={2}>
+          {formik.errors && formik.errors.reasonRequired && (
+            <FormHelperText error>
+              {formik.errors.reasonRequired}
+            </FormHelperText>
+          )}
+        </Box>
+        <SharedFormButtons onCancel={onCancel} />
+      </form>
+    </>
+  );
+};

--- a/src/curated-corpus/components/RejectProspectForm/RejectProspectForm.validation.tsx
+++ b/src/curated-corpus/components/RejectProspectForm/RejectProspectForm.validation.tsx
@@ -1,0 +1,31 @@
+import * as yup from 'yup';
+import { RejectionReason } from '../../api/curated-corpus-api/generatedTypes';
+
+export const validationSchema = yup
+  .object({
+    [RejectionReason.Paywall]: yup.boolean(),
+    [RejectionReason.PoliticalOpinion]: yup.boolean(),
+    [RejectionReason.OffensiveMaterial]: yup.boolean(),
+    [RejectionReason.TimeSensitive]: yup.boolean(),
+    [RejectionReason.Misinformation]: yup.boolean(),
+    [RejectionReason.Other]: yup.boolean(),
+  })
+  .test('reasonRequired', '', (obj) => {
+    // If at least one checkbox was selected, let the form validation pass
+    if (
+      obj[RejectionReason.Paywall] ||
+      obj[RejectionReason.PoliticalOpinion] ||
+      obj[RejectionReason.OffensiveMaterial] ||
+      obj[RejectionReason.TimeSensitive] ||
+      obj[RejectionReason.Misinformation] ||
+      obj[RejectionReason.Other]
+    ) {
+      return true;
+    }
+
+    return new yup.ValidationError(
+      'Please specify at least one rejection reason.',
+      null,
+      'reasonRequired'
+    );
+  });

--- a/src/curated-corpus/components/RejectProspectModal/RejectProspectModal.tsx
+++ b/src/curated-corpus/components/RejectProspectModal/RejectProspectModal.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Modal } from '../../../_shared/components';
+import { Box, Grid, Typography } from '@material-ui/core';
+import { FormikValues } from 'formik';
+import { FormikHelpers } from 'formik/dist/types';
+import { Prospect } from '../../api/prospect-api/generatedTypes';
+import { RejectProspectForm } from '../RejectProspectForm/RejectProspectForm';
+
+interface RejectProspectModalProps {
+  prospect: Prospect;
+  isOpen: boolean;
+  onSave: (
+    values: FormikValues,
+    formikHelpers: FormikHelpers<any>
+  ) => void | Promise<any>;
+  toggleModal: () => void;
+}
+
+export const RejectProspectModal: React.FC<RejectProspectModalProps> = (
+  props
+): JSX.Element => {
+  const { prospect, isOpen, toggleModal } = props;
+
+  return (
+    <Modal
+      open={isOpen}
+      handleClose={() => {
+        toggleModal();
+      }}
+    >
+      <Grid container spacing={2}>
+        <Grid item xs={12}>
+          <h2>Reject this item from inclusion in the curated corpus</h2>
+          <Box mb={1}>
+            <Typography variant="subtitle1">
+              <em>Title</em>: {prospect.title}
+            </Typography>
+          </Box>
+        </Grid>
+        <Grid item xs={12}>
+          <Box p={3}>
+            <RejectProspectForm
+              onSubmit={() => {
+                console.log('things are happening!');
+              }}
+              onCancel={() => {
+                toggleModal();
+              }}
+            />
+          </Box>
+        </Grid>
+      </Grid>
+    </Modal>
+  );
+};

--- a/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.test.tsx
+++ b/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.test.tsx
@@ -5,7 +5,7 @@ import { render, screen } from '@testing-library/react';
 import { ScheduleItemForm } from './ScheduleItemForm';
 import { newTabs } from '../../helpers/definitions';
 
-describe('The CuratedItemSearchForm component', () => {
+describe('The ScheduleItemForm component', () => {
   const handleSubmit = jest.fn();
   const newTabList = newTabs;
 

--- a/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.tsx
+++ b/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.tsx
@@ -74,7 +74,7 @@ export const ScheduleItemForm: React.FC<
 
   return (
     <>
-      <form name="approved-item-search-form" onSubmit={formik.handleSubmit}>
+      <form name="schedule-item-form" onSubmit={formik.handleSubmit}>
         <Grid container spacing={3}>
           <Grid item xs={12}>
             <FormikSelectField

--- a/src/curated-corpus/components/index.ts
+++ b/src/curated-corpus/components/index.ts
@@ -7,5 +7,7 @@ export { NextPrevPagination } from './NextPrevPagination/NextPrevPagination';
 export { ProspectListCard } from './ProspectListCard/ProspectListCard';
 export { RejectedItemListCard } from './RejectedItemListCard/RejectedItemListCard';
 export { RejectedItemSearchForm } from './RejectedItemSearchForm/RejectedItemSearchForm';
+export { RejectProspectModal } from './RejectProspectModal/RejectProspectModal';
+export { RejectProspectForm } from './RejectProspectForm/RejectProspectForm';
 export { ScheduleItemForm } from './ScheduleItemForm/ScheduleItemForm';
 export { ScheduleItemModal } from './ScheduleItemModal/ScheduleItemModal';

--- a/src/curated-corpus/helpers/definitions.ts
+++ b/src/curated-corpus/helpers/definitions.ts
@@ -1,4 +1,5 @@
 // Here we keep sets of options for curating items
+
 export interface DropdownOption {
   code: string;
   name: string;

--- a/src/curated-corpus/pages/NewTabCurationPage/NewTabCurationPage.tsx
+++ b/src/curated-corpus/pages/NewTabCurationPage/NewTabCurationPage.tsx
@@ -1,11 +1,19 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { DateTime } from 'luxon';
 import { Box, Grid, Hidden, Typography } from '@material-ui/core';
 import { HandleApiResponse } from '../../../_shared/components';
-import { MiniNewTabScheduleList, ProspectListCard } from '../../components';
+import {
+  MiniNewTabScheduleList,
+  ProspectListCard,
+  RejectProspectModal,
+} from '../../components';
 import { client } from '../../api/prospect-api/client';
-import { useGetProspectsQuery } from '../../api/prospect-api/generatedTypes';
+import {
+  Prospect,
+  useGetProspectsQuery,
+} from '../../api/prospect-api/generatedTypes';
 import { useGetScheduledItemsQuery } from '../../api/curated-corpus-api/generatedTypes';
+import { useToggle } from '../../../_shared/hooks';
 
 export const NewTabCurationPage: React.FC = (): JSX.Element => {
   // TODO: remove hardcoded value when New Tab selector is added to the page
@@ -38,8 +46,31 @@ export const NewTabCurationPage: React.FC = (): JSX.Element => {
     },
   });
 
+  /**
+   * Set the current Prospect to be worked on (e.g., to be approved or rejected).
+   */
+  const [currentItem, setCurrentItem] = useState<Prospect | undefined>(
+    undefined
+  );
+
+  /**
+   * Keep track of whether the "Reject this prospect" modal is open or not.
+   */
+  const [rejectModalOpen, toggleRejectModal] = useToggle(false);
+
   return (
     <>
+      {currentItem && (
+        <RejectProspectModal
+          prospect={currentItem}
+          isOpen={rejectModalOpen}
+          onSave={() => {
+            // nothing to see here
+          }}
+          toggleModal={toggleRejectModal}
+        />
+      )}
+
       <h1>New Tab Curation</h1>
       <Box mb={3}>
         <Typography>
@@ -54,7 +85,16 @@ export const NewTabCurationPage: React.FC = (): JSX.Element => {
 
           {data &&
             data.getProspects.map((prospect) => {
-              return <ProspectListCard key={prospect.id} prospect={prospect} />;
+              return (
+                <ProspectListCard
+                  key={prospect.id}
+                  prospect={prospect}
+                  onReject={() => {
+                    setCurrentItem(prospect);
+                    toggleRejectModal();
+                  }}
+                />
+              );
             })}
         </Grid>
         <Hidden xsDown>


### PR DESCRIPTION
## Goal

Get the UI ready so that we can wire up rejecting a prospect.

- Added a modal and a form component for displaying rejection reasons for a prospect that is about to be rejected. 
- Added validation and tests for the RejectProspectForm component.

Tickets:

- [Curation Admin Tools - Wire up the reject button to display the rejection screen](https://getpocket.atlassian.net/browse/BACK-1148)

## UI Walkthrough


https://user-images.githubusercontent.com/22447785/143799277-4a0e365d-0321-4349-bd43-5ba65e63ac1d.mov




