### PR TITLE
[BACK-1208] fix(regression): Schedule Curated Item mutation is broken

### DIFF
--- a/src/curated-corpus/pages/ApprovedItemsPage/ApprovedItemsPage.tsx
+++ b/src/curated-corpus/pages/ApprovedItemsPage/ApprovedItemsPage.tsx
@@ -145,7 +145,7 @@ export const ApprovedItemsPage: React.FC = (): JSX.Element => {
   ): void => {
     // Set out all the variables we need to pass to the mutation
     const variables = {
-      curatedItemExternalId: currentItem?.externalId,
+      approvedItemExternalId: currentItem?.externalId,
       newTabGuid: values.newTabGuid,
       scheduledDate: values.scheduledDate.toISODate(),
     };


### PR DESCRIPTION
## Goal

Fix a mutation on the Live Corpus page (the "Schedule" button that places an item on New Tab for a given date) that stopped working following a refactor on the API side.

Tickets:

- [Curation Admin Tools - (regression) Schedule Curated Item mutation is broken](https://getpocket.atlassian.net/browse/BACK-1208)
