### PR TITLE
fix(formatting): Reformat files that break the app after upgrade to Prettier

### DIFF
--- a/src/_shared/components/_form-elements/FormikSelectField/FormikSelectField.tsx
+++ b/src/_shared/components/_form-elements/FormikSelectField/FormikSelectField.tsx
@@ -46,30 +46,31 @@ interface FormikSelectFieldProps {
  * down the properties of interest to the field itself.
  */
 
-export const FormikSelectField: React.FC<FormikSelectFieldProps & SelectProps> =
-  (props): JSX.Element => {
-    const { id, label, fieldProps, fieldMeta, children, ...otherProps } = props;
-    const classes = useStyles();
+export const FormikSelectField: React.FC<
+  FormikSelectFieldProps & SelectProps
+> = (props): JSX.Element => {
+  const { id, label, fieldProps, fieldMeta, children, ...otherProps } = props;
+  const classes = useStyles();
 
-    return (
-      <FormControl variant="outlined" className={classes.formControl}>
-        <InputLabel htmlFor={id}>{label}</InputLabel>
-        <Select
-          native
-          label={label}
-          inputProps={{
-            name: id,
-            id,
-          }}
-          {...fieldProps}
-          error={!!(fieldMeta.touched && fieldMeta.error)}
-          {...otherProps}
-        >
-          {children}
-        </Select>
-        <FormHelperText error>
-          {fieldMeta.error ? fieldMeta.error : null}
-        </FormHelperText>
-      </FormControl>
-    );
-  };
+  return (
+    <FormControl variant="outlined" className={classes.formControl}>
+      <InputLabel htmlFor={id}>{label}</InputLabel>
+      <Select
+        native
+        label={label}
+        inputProps={{
+          name: id,
+          id,
+        }}
+        {...fieldProps}
+        error={!!(fieldMeta.touched && fieldMeta.error)}
+        {...otherProps}
+      >
+        {children}
+      </Select>
+      <FormHelperText error>
+        {fieldMeta.error ? fieldMeta.error : null}
+      </FormHelperText>
+    </FormControl>
+  );
+};

--- a/src/_shared/components/_form-elements/FormikTextField/FormikTextField.tsx
+++ b/src/_shared/components/_form-elements/FormikTextField/FormikTextField.tsx
@@ -34,25 +34,25 @@ interface FormikTextFieldProps {
  * This component relies on the form itself to call the useFormik() hook and pass
  * down the properties of interest to the field itself.
  */
+export const FormikTextField: React.FC<
+  FormikTextFieldProps & TextFieldProps
+> = (props): JSX.Element => {
+  const { id, label, fieldProps, fieldMeta, ...otherProps } = props;
 
-export const FormikTextField: React.FC<FormikTextFieldProps & TextFieldProps> =
-  (props): JSX.Element => {
-    const { id, label, fieldProps, fieldMeta, ...otherProps } = props;
-
-    return (
-      <TextField
-        id={id}
-        label={label}
-        fullWidth
-        InputLabelProps={{
-          shrink: true,
-        }}
-        size="small"
-        variant="outlined"
-        {...fieldProps}
-        error={!!(fieldMeta.touched && fieldMeta.error)}
-        helperText={fieldMeta.error ? fieldMeta.error : null}
-        {...otherProps}
-      />
-    );
-  };
+  return (
+    <TextField
+      id={id}
+      label={label}
+      fullWidth
+      InputLabelProps={{
+        shrink: true,
+      }}
+      size="small"
+      variant="outlined"
+      {...fieldProps}
+      error={!!(fieldMeta.touched && fieldMeta.error)}
+      helperText={fieldMeta.error ? fieldMeta.error : null}
+      {...otherProps}
+    />
+  );
+};

--- a/src/collections/components/CollectionPartnerAssociationInfo/CollectionPartnerAssociationInfo.tsx
+++ b/src/collections/components/CollectionPartnerAssociationInfo/CollectionPartnerAssociationInfo.tsx
@@ -47,151 +47,150 @@ interface AssociationPreviewProps {
  * @param props
  * @constructor
  */
-export const CollectionPartnerAssociationInfo: React.FC<AssociationPreviewProps> =
-  (props): JSX.Element => {
-    const { association, refetch } = props;
-    const [showEditForm, toggleEditForm] = useToggle();
+export const CollectionPartnerAssociationInfo: React.FC<
+  AssociationPreviewProps
+> = (props): JSX.Element => {
+  const { association, refetch } = props;
+  const [showEditForm, toggleEditForm] = useToggle();
 
-    // Get a helper function that will execute a mutation and show notifications
-    const { runMutation } = useRunMutation();
+  // Get a helper function that will execute a mutation and show notifications
+  const { runMutation } = useRunMutation();
 
-    // Load the partners for the dropdown in the partnership form
-    const { loading, error, data } = useGetCollectionPartnersQuery({
-      variables: { perPage: config.pagination.valuesPerDropdown },
-    });
+  // Load the partners for the dropdown in the partnership form
+  const { loading, error, data } = useGetCollectionPartnersQuery({
+    variables: { perPage: config.pagination.valuesPerDropdown },
+  });
 
-    // Prepare the "Delete association" mutate function
-    const [deleteAssociation] = useDeleteCollectionPartnerAssociationMutation();
+  // Prepare the "Delete association" mutate function
+  const [deleteAssociation] = useDeleteCollectionPartnerAssociationMutation();
 
-    // Delete the association when the user requests this action
-    const onDelete = (): void => {
-      runMutation(
-        deleteAssociation,
-        {
-          variables: {
-            externalId: association.externalId,
-          },
-        },
-        'Partnership deleted successfully',
-        undefined,
-        undefined,
-        refetch
-      );
-    };
-
-    // prepare the "update association" mutation
-    const [updateAssociation] = useUpdateCollectionPartnerAssociationMutation();
-
-    // Update the association when the edit form is submitted
-    const onUpdate = (
-      values: FormikValues,
-      formikHelpers: FormikHelpers<any>
-    ): void => {
-      const options = {
+  // Delete the association when the user requests this action
+  const onDelete = (): void => {
+    runMutation(
+      deleteAssociation,
+      {
         variables: {
           externalId: association.externalId,
-          type: values.type,
-          partnerExternalId: values.partnerExternalId,
-          name: values.name ? values.name : null,
-          url: values.url ? values.url : null,
-          imageUrl: association.imageUrl, // we'll update it separately
-          blurb: values.blurb ? values.blurb : null,
         },
-      };
-
-      runMutation(
-        updateAssociation,
-        options,
-        'Partnership updated successfully',
-        () => {
-          toggleEditForm();
-          formikHelpers.setSubmitting(false);
-        },
-        () => {
-          formikHelpers.setSubmitting(false);
-        },
-        refetch
-      );
-    };
-
-    // prepare the "update story image url" mutation
-    const [updateImageUrl] =
-      useUpdateCollectionPartnerAssociationImageUrlMutation();
-
-    /**
-     * Save the S3 URL we get back from the API to the collection story record
-     */
-    const handleImageUploadSave = (url: string): void => {
-      runMutation(
-        updateImageUrl,
-        {
-          variables: {
-            externalId: association.externalId,
-            imageUrl: url,
-          },
-        },
-        'Image saved successfully'
-      );
-    };
-
-    return (
-      <>
-        <Grid container spacing={2}>
-          <Grid item xs={3}>
-            <ImageUpload
-              entity={association.imageUrl ? association : association.partner}
-              placeholder="/placeholders/collection.svg"
-              onImageSave={handleImageUploadSave}
-            />
-          </Grid>
-          <Grid item xs={7} sm={8}>
-            <Typography variant="button">
-              {association.type === CollectionPartnershipType.Partnered
-                ? 'In partnership with '
-                : 'Brought to you by '}
-              <a href={association.url ?? association.partner.url}>
-                {association.name ?? association.partner.name}
-              </a>
-            </Typography>
-            <Box marginTop={2}>
-              <ReactMarkdown>
-                {association.blurb ?? association.partner.blurb}
-              </ReactMarkdown>
-            </Box>
-          </Grid>
-          <Grid item xs={1} sm={1}>
-            <ButtonGroup orientation="vertical" variant="text" color="primary">
-              <Button color="primary" onClick={toggleEditForm}>
-                <EditIcon />
-              </Button>
-              <Button color="primary" onClick={onDelete}>
-                <DeleteOutlineIcon />
-              </Button>
-            </ButtonGroup>
-          </Grid>
-        </Grid>
-        <Collapse in={showEditForm}>
-          <Paper elevation={4}>
-            <Box p={2} mt={3}>
-              <Grid container spacing={4}>
-                <Grid item xs={12}>
-                  <h3>Edit partnership</h3>
-                  {!data && (
-                    <HandleApiResponse loading={loading} error={error} />
-                  )}
-                  {data && (
-                    <CollectionPartnerAssociationForm
-                      association={association}
-                      partners={data.getCollectionPartners.partners}
-                      onCancel={toggleEditForm}
-                      onSubmit={onUpdate}
-                    />
-                  )}
-                </Grid>
-              </Grid>
-            </Box>
-          </Paper>
-        </Collapse>
-      </>
+      },
+      'Partnership deleted successfully',
+      undefined,
+      undefined,
+      refetch
     );
   };
+
+  // prepare the "update association" mutation
+  const [updateAssociation] = useUpdateCollectionPartnerAssociationMutation();
+
+  // Update the association when the edit form is submitted
+  const onUpdate = (
+    values: FormikValues,
+    formikHelpers: FormikHelpers<any>
+  ): void => {
+    const options = {
+      variables: {
+        externalId: association.externalId,
+        type: values.type,
+        partnerExternalId: values.partnerExternalId,
+        name: values.name ? values.name : null,
+        url: values.url ? values.url : null,
+        imageUrl: association.imageUrl, // we'll update it separately
+        blurb: values.blurb ? values.blurb : null,
+      },
+    };
+
+    runMutation(
+      updateAssociation,
+      options,
+      'Partnership updated successfully',
+      () => {
+        toggleEditForm();
+        formikHelpers.setSubmitting(false);
+      },
+      () => {
+        formikHelpers.setSubmitting(false);
+      },
+      refetch
+    );
+  };
+
+  // prepare the "update story image url" mutation
+  const [updateImageUrl] =
+    useUpdateCollectionPartnerAssociationImageUrlMutation();
+
+  /**
+   * Save the S3 URL we get back from the API to the collection story record
+   */
+  const handleImageUploadSave = (url: string): void => {
+    runMutation(
+      updateImageUrl,
+      {
+        variables: {
+          externalId: association.externalId,
+          imageUrl: url,
+        },
+      },
+      'Image saved successfully'
+    );
+  };
+
+  return (
+    <>
+      <Grid container spacing={2}>
+        <Grid item xs={3}>
+          <ImageUpload
+            entity={association.imageUrl ? association : association.partner}
+            placeholder="/placeholders/collection.svg"
+            onImageSave={handleImageUploadSave}
+          />
+        </Grid>
+        <Grid item xs={7} sm={8}>
+          <Typography variant="button">
+            {association.type === CollectionPartnershipType.Partnered
+              ? 'In partnership with '
+              : 'Brought to you by '}
+            <a href={association.url ?? association.partner.url}>
+              {association.name ?? association.partner.name}
+            </a>
+          </Typography>
+          <Box marginTop={2}>
+            <ReactMarkdown>
+              {association.blurb ?? association.partner.blurb}
+            </ReactMarkdown>
+          </Box>
+        </Grid>
+        <Grid item xs={1} sm={1}>
+          <ButtonGroup orientation="vertical" variant="text" color="primary">
+            <Button color="primary" onClick={toggleEditForm}>
+              <EditIcon />
+            </Button>
+            <Button color="primary" onClick={onDelete}>
+              <DeleteOutlineIcon />
+            </Button>
+          </ButtonGroup>
+        </Grid>
+      </Grid>
+      <Collapse in={showEditForm}>
+        <Paper elevation={4}>
+          <Box p={2} mt={3}>
+            <Grid container spacing={4}>
+              <Grid item xs={12}>
+                <h3>Edit partnership</h3>
+                {!data && <HandleApiResponse loading={loading} error={error} />}
+                {data && (
+                  <CollectionPartnerAssociationForm
+                    association={association}
+                    partners={data.getCollectionPartners.partners}
+                    onCancel={toggleEditForm}
+                    onSubmit={onUpdate}
+                  />
+                )}
+              </Grid>
+            </Grid>
+          </Box>
+        </Paper>
+      </Collapse>
+    </>
+  );
+};

--- a/src/collections/components/PartnerForm/PartnerForm.tsx
+++ b/src/collections/components/PartnerForm/PartnerForm.tsx
@@ -26,73 +26,74 @@ interface PartnerFormProps {
 /**
  * A form for adding authors or editing information for existing authors
  */
-export const PartnerForm: React.FC<PartnerFormProps & SharedFormButtonsProps> =
-  (props): JSX.Element => {
-    const { partner, onSubmit, editMode, onCancel } = props;
+export const PartnerForm: React.FC<
+  PartnerFormProps & SharedFormButtonsProps
+> = (props): JSX.Element => {
+  const { partner, onSubmit, editMode, onCancel } = props;
 
-    /**
-     * Set up form validation
-     */
-    const formik = useFormik({
-      initialValues: {
-        name: partner.name ?? '',
-        url: partner.url ?? '',
-        blurb: partner.blurb ?? '',
-      },
-      // We don't want to irritate users by displaying validation errors
-      // before they actually submit the form
-      validateOnChange: false,
-      validateOnBlur: false,
-      validationSchema,
-      onSubmit: (values, formikHelpers) => {
-        onSubmit(values, formikHelpers);
-      },
-    });
+  /**
+   * Set up form validation
+   */
+  const formik = useFormik({
+    initialValues: {
+      name: partner.name ?? '',
+      url: partner.url ?? '',
+      blurb: partner.blurb ?? '',
+    },
+    // We don't want to irritate users by displaying validation errors
+    // before they actually submit the form
+    validateOnChange: false,
+    validateOnBlur: false,
+    validationSchema,
+    onSubmit: (values, formikHelpers) => {
+      onSubmit(values, formikHelpers);
+    },
+  });
 
-    return (
-      <form name="partner-form" onSubmit={formik.handleSubmit}>
-        <Grid container spacing={3}>
-          <Grid item xs={12}>
-            <FormikTextField
-              id="name"
-              label="Name"
-              fieldProps={formik.getFieldProps('name')}
-              fieldMeta={formik.getFieldMeta('name')}
-            />
-          </Grid>
-
-          <Grid item xs={12}>
-            <FormikTextField
-              id="url"
-              label="URL"
-              fieldProps={formik.getFieldProps('url')}
-              fieldMeta={formik.getFieldMeta('url')}
-            />
-          </Grid>
-
-          <Grid item xs={12}>
-            <MarkdownPreview minHeight={15.5} source={formik.values.blurb}>
-              <FormikTextField
-                id="blurb"
-                label="Blurb"
-                fieldProps={formik.getFieldProps('blurb')}
-                fieldMeta={formik.getFieldMeta('blurb')}
-                multiline
-                rows={12}
-              />
-            </MarkdownPreview>
-          </Grid>
-
-          {formik.isSubmitting && (
-            <Grid item xs={12}>
-              <LinearProgress />
-            </Grid>
-          )}
-
-          <Grid item xs={12}>
-            <SharedFormButtons editMode={editMode} onCancel={onCancel} />
-          </Grid>
+  return (
+    <form name="partner-form" onSubmit={formik.handleSubmit}>
+      <Grid container spacing={3}>
+        <Grid item xs={12}>
+          <FormikTextField
+            id="name"
+            label="Name"
+            fieldProps={formik.getFieldProps('name')}
+            fieldMeta={formik.getFieldMeta('name')}
+          />
         </Grid>
-      </form>
-    );
-  };
+
+        <Grid item xs={12}>
+          <FormikTextField
+            id="url"
+            label="URL"
+            fieldProps={formik.getFieldProps('url')}
+            fieldMeta={formik.getFieldMeta('url')}
+          />
+        </Grid>
+
+        <Grid item xs={12}>
+          <MarkdownPreview minHeight={15.5} source={formik.values.blurb}>
+            <FormikTextField
+              id="blurb"
+              label="Blurb"
+              fieldProps={formik.getFieldProps('blurb')}
+              fieldMeta={formik.getFieldMeta('blurb')}
+              multiline
+              rows={12}
+            />
+          </MarkdownPreview>
+        </Grid>
+
+        {formik.isSubmitting && (
+          <Grid item xs={12}>
+            <LinearProgress />
+          </Grid>
+        )}
+
+        <Grid item xs={12}>
+          <SharedFormButtons editMode={editMode} onCancel={onCancel} />
+        </Grid>
+      </Grid>
+    </form>
+  );
+};

--- a/src/collections/components/ReorderableCollectionStoryList/ReorderableCollectionStoryList.tsx
+++ b/src/collections/components/ReorderableCollectionStoryList/ReorderableCollectionStoryList.tsx
@@ -42,51 +42,52 @@ interface CollectionStoryListProps {
  * @param props
  * @constructor
  */
-export const ReorderableCollectionStoryList: React.FC<CollectionStoryListProps> =
-  (props): JSX.Element => {
-    const { stories, showFromPartner, reorder, refetch } = props;
+export const ReorderableCollectionStoryList: React.FC<
+  CollectionStoryListProps
+> = (props): JSX.Element => {
+  const { stories, showFromPartner, reorder, refetch } = props;
 
-    return (
-      <DragDropContext onDragEnd={reorder}>
-        <Droppable droppableId="characters">
-          {(provided) => (
-            <Typography
-              component="div"
-              className="characters"
-              {...provided.droppableProps}
-              ref={provided.innerRef}
-            >
-              {stories.map((story: CollectionStory, index: number) => {
-                return (
-                  <Draggable
-                    key={story.externalId}
-                    draggableId={story.externalId}
-                    index={index}
-                  >
-                    {(provided) => {
-                      return (
-                        <Typography
-                          component="div"
-                          ref={provided.innerRef}
-                          {...provided.draggableProps}
-                          {...provided.dragHandleProps}
-                        >
-                          <StoryListCard
-                            key={story.externalId}
-                            story={story}
-                            refetch={refetch}
-                            showFromPartner={showFromPartner}
-                          />
-                        </Typography>
-                      );
-                    }}
-                  </Draggable>
-                );
-              })}
-              {provided.placeholder}
-            </Typography>
-          )}
-        </Droppable>
-      </DragDropContext>
-    );
-  };
+  return (
+    <DragDropContext onDragEnd={reorder}>
+      <Droppable droppableId="characters">
+        {(provided) => (
+          <Typography
+            component="div"
+            className="characters"
+            {...provided.droppableProps}
+            ref={provided.innerRef}
+          >
+            {stories.map((story: CollectionStory, index: number) => {
+              return (
+                <Draggable
+                  key={story.externalId}
+                  draggableId={story.externalId}
+                  index={index}
+                >
+                  {(provided) => {
+                    return (
+                      <Typography
+                        component="div"
+                        ref={provided.innerRef}
+                        {...provided.draggableProps}
+                        {...provided.dragHandleProps}
+                      >
+                        <StoryListCard
+                          key={story.externalId}
+                          story={story}
+                          refetch={refetch}
+                          showFromPartner={showFromPartner}
+                        />
+                      </Typography>
+                    );
+                  }}
+                </Draggable>
+              );
+            })}
+            {provided.placeholder}
+          </Typography>
+        )}
+      </Droppable>
+    </DragDropContext>
+  );
+};

--- a/src/curated-corpus/components/MiniNewTabScheduleCard/MiniNewTabScheduleCard.tsx
+++ b/src/curated-corpus/components/MiniNewTabScheduleCard/MiniNewTabScheduleCard.tsx
@@ -27,61 +27,62 @@ interface MiniScheduledItemListCardProps {
  * @param props
  * @constructor
  */
-export const MiniNewTabScheduleCard: React.FC<MiniScheduledItemListCardProps> =
-  (props): JSX.Element => {
-    const classes = useStyles();
-    const { item } = props;
+export const MiniNewTabScheduleCard: React.FC<
+  MiniScheduledItemListCardProps
+> = (props): JSX.Element => {
+  const classes = useStyles();
+  const { item } = props;
 
-    return (
-      <Card className={classes.root}>
-        <CardContent className={classes.content}>
-          <Typography
-            className={classes.title}
-            variant="h3"
-            align="left"
-            gutterBottom
-          >
-            <Link href={item.approvedItem.url} className={classes.link}>
-              {item.approvedItem.title}
-            </Link>
-          </Typography>
-          <Typography className={classes.publisher} gutterBottom>
-            {item.approvedItem.publisher}
-          </Typography>
-          <List dense disablePadding>
+  return (
+    <Card className={classes.root}>
+      <CardContent className={classes.content}>
+        <Typography
+          className={classes.title}
+          variant="h3"
+          align="left"
+          gutterBottom
+        >
+          <Link href={item.approvedItem.url} className={classes.link}>
+            {item.approvedItem.title}
+          </Link>
+        </Typography>
+        <Typography className={classes.publisher} gutterBottom>
+          {item.approvedItem.publisher}
+        </Typography>
+        <List dense disablePadding>
+          <ListItem disableGutters>
+            <ListItemIcon className={classes.listItemIcon}>
+              <LabelOutlinedIcon fontSize="small" />
+            </ListItemIcon>
+            <ListItemText
+              className={classes.listItemText}
+              secondary={item.approvedItem.topic.toLowerCase()}
+            />
+          </ListItem>
+          {item.approvedItem.isSyndicated && (
             <ListItem disableGutters>
               <ListItemIcon className={classes.listItemIcon}>
-                <LabelOutlinedIcon fontSize="small" />
+                <CheckCircleOutlineIcon fontSize="small" />
               </ListItemIcon>
               <ListItemText
                 className={classes.listItemText}
-                secondary={item.approvedItem.topic.toLowerCase()}
+                secondary={'Syndicated'}
               />
             </ListItem>
-            {item.approvedItem.isSyndicated && (
-              <ListItem disableGutters>
-                <ListItemIcon className={classes.listItemIcon}>
-                  <CheckCircleOutlineIcon fontSize="small" />
-                </ListItemIcon>
-                <ListItemText
-                  className={classes.listItemText}
-                  secondary={'Syndicated'}
-                />
-              </ListItem>
-            )}
-            {item.approvedItem.isCollection && (
-              <ListItem disableGutters>
-                <ListItemIcon className={classes.listItemIcon}>
-                  <BookmarksIcon fontSize="small" />
-                </ListItemIcon>
-                <ListItemText
-                  className={classes.listItemText}
-                  secondary={'Collection'}
-                />
-              </ListItem>
-            )}
-          </List>
-        </CardContent>
-      </Card>
-    );
-  };
+          )}
+          {item.approvedItem.isCollection && (
+            <ListItem disableGutters>
+              <ListItemIcon className={classes.listItemIcon}>
+                <BookmarksIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText
+                className={classes.listItemText}
+                secondary={'Collection'}
+              />
+            </ListItem>
+          )}
+        </List>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/curated-corpus/components/MiniNewTabScheduleList/MiniNewTabScheduleList.tsx
+++ b/src/curated-corpus/components/MiniNewTabScheduleList/MiniNewTabScheduleList.tsx
@@ -14,28 +14,29 @@ interface MiniNewTabScheduleGroupedListProps {
  * @param props
  * @constructor
  */
-export const MiniNewTabScheduleList: React.FC<MiniNewTabScheduleGroupedListProps> =
-  (props): JSX.Element => {
-    const { scheduledItems } = props;
+export const MiniNewTabScheduleList: React.FC<
+  MiniNewTabScheduleGroupedListProps
+> = (props): JSX.Element => {
+  const { scheduledItems } = props;
 
-    const groupedByDate = groupByObjectPropertyValue(
-      scheduledItems,
-      'scheduledDate'
+  const groupedByDate = groupByObjectPropertyValue(
+    scheduledItems,
+    'scheduledDate'
+  );
+
+  // This is decidedly not pretty, but we can't iterate over object props
+  // within JSX.
+  const lists: JSX.Element[] = [];
+  for (const scheduledDate in groupedByDate) {
+    lists.push(
+      <NewTabGroupedList
+        key={scheduledDate}
+        scheduledDate={scheduledDate}
+        scheduledItems={groupedByDate[scheduledDate]}
+        isSidebar
+      />
     );
+  }
 
-    // This is decidedly not pretty, but we can't iterate over object props
-    // within JSX.
-    const lists: JSX.Element[] = [];
-    for (const scheduledDate in groupedByDate) {
-      lists.push(
-        <NewTabGroupedList
-          key={scheduledDate}
-          scheduledDate={scheduledDate}
-          scheduledItems={groupedByDate[scheduledDate]}
-          isSidebar
-        />
-      );
-    }
-
-    return <>{lists}</>;
-  };
+  return <>{lists}</>;
+};


### PR DESCRIPTION
## Goal

Let the app compile in development mode again. It appears that merging a minor update to Prettier here: https://github.com/Pocket/curation-admin-tools/pull/530 has uncovered some files that Prettier would like to be formatted differently. Fixed by saving each file again and allowing Prettier to reformat them according to the rules stipulated in version 2.5.0.
