### PR TITLE
chore(prospects): Update frontend following refactor of Prospect API

### DIFF
--- a/src/curated-corpus/api/prospect-api/generatedTypes.ts
+++ b/src/curated-corpus/api/prospect-api/generatedTypes.ts
@@ -39,7 +39,7 @@ export type Mutation = {
 };
 
 export type MutationUpdateProspectAsCuratedArgs = {
-  prospectId: Scalars['String'];
+  prospectId: Scalars['ID'];
 };
 
 export type Prospect = {
@@ -47,7 +47,7 @@ export type Prospect = {
   createdAt?: Maybe<Scalars['Int']>;
   domain?: Maybe<Scalars['String']>;
   excerpt?: Maybe<Scalars['String']>;
-  id: Scalars['String'];
+  id: Scalars['ID'];
   imageUrl?: Maybe<Scalars['String']>;
   isCollection?: Maybe<Scalars['Boolean']>;
   isSyndicated?: Maybe<Scalars['Boolean']>;
@@ -91,7 +91,7 @@ export type ProspectDataFragment = {
 };
 
 export type UpdateProspectAsCuratedMutationVariables = Exact<{
-  prospectId: Scalars['String'];
+  prospectId: Scalars['ID'];
 }>;
 
 export type UpdateProspectAsCuratedMutation = {
@@ -166,7 +166,7 @@ export const ProspectDataFragmentDoc = gql`
   }
 `;
 export const UpdateProspectAsCuratedDocument = gql`
-  mutation updateProspectAsCurated($prospectId: String!) {
+  mutation updateProspectAsCurated($prospectId: ID!) {
     updateProspectAsCurated(prospectId: $prospectId) {
       ...ProspectData
     }

--- a/src/curated-corpus/api/prospect-api/mutations/updateProspectAsCurated.ts
+++ b/src/curated-corpus/api/prospect-api/mutations/updateProspectAsCurated.ts
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client';
 import { ProspectData } from '../fragments/prospect';
 
-export const rejectApprovedItem = gql`
-  mutation updateProspectAsCurated($prospectId: String!) {
+export const updateProspectAsCurated = gql`
+  mutation updateProspectAsCurated($prospectId: ID!) {
     updateProspectAsCurated(prospectId: $prospectId) {
       ...ProspectData
     }


### PR DESCRIPTION
## Goal

Update frontend following refactor of Prospect API in https://github.com/Pocket/prospect-api/pull/158. 

Updated generated types, set type of `prospectId` from `String` to `ID` so that the 'mark prospect as curated' mutation works after the API update.

