### PR TITLE
[BACK-1146] & [BACK-1147] Wire up image upload and saving a prospect

### DIFF
--- a/src/_shared/components/_form-elements/FormikSelectField/FormikSelectField.tsx
+++ b/src/_shared/components/_form-elements/FormikSelectField/FormikSelectField.tsx
@@ -35,7 +35,7 @@ interface FormikSelectFieldProps {
   /**
    * Children elements - <option> tags
    */
-  children: JSX.Element | (JSX.Element | JSX.Element[])[];
+  children: (JSX.Element | JSX.Element[])[];
 }
 
 /**

--- a/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.tsx
+++ b/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.tsx
@@ -18,7 +18,6 @@ import LanguageIcon from '@material-ui/icons/Language';
 import ThumbUpIcon from '@material-ui/icons/ThumbUp';
 import { useStyles } from './ApprovedItemListCard.styles';
 import { ApprovedCuratedCorpusItem } from '../../api/curated-corpus-api/generatedTypes';
-//import { topics } from '../../helpers/definitions';
 
 interface ApprovedItemListCardProps {
   /**
@@ -32,10 +31,6 @@ export const ApprovedItemListCard: React.FC<ApprovedItemListCardProps> = (
 ): JSX.Element => {
   const classes = useStyles();
   const { item } = props;
-
-  // const approvedItemTopic = topics.find(
-  //   (topic) => topic.code === item.topic
-  // )?.name;
 
   return (
     <>

--- a/src/curated-corpus/components/ImageUpload/ImageUpload.tsx
+++ b/src/curated-corpus/components/ImageUpload/ImageUpload.tsx
@@ -29,8 +29,6 @@ import {
   useUploadApprovedCuratedCorpusItemImageMutation,
 } from '../../api/curated-corpus-api/generatedTypes';
 
-import { Prospect } from '../../api/prospect-api/generatedTypes';
-
 interface ImageUploadProps {
   /**
    * Any entity with a customizable image
@@ -41,8 +39,7 @@ interface ImageUploadProps {
     | CollectionPartner
     | CollectionPartnerAssociation
     | CollectionStory
-    | ApprovedCuratedCorpusItem
-    | Prospect;
+    | ApprovedCuratedCorpusItem;
 
   /**
    * A path to a placeholder image to show if no image is available

--- a/src/curated-corpus/pages/NewTabCurationPage/NewTabCurationPage.tsx
+++ b/src/curated-corpus/pages/NewTabCurationPage/NewTabCurationPage.tsx
@@ -145,17 +145,25 @@ export const NewTabCurationPage: React.FC = (): JSX.Element => {
     // TODO: add logic here. Don't forget to connect to Prospect API for this mutation
   };
 
+  // Prepare the upload approved item image mutation
   const [uploadApprovedItemImage] =
     useUploadApprovedCuratedCorpusItemImageMutation();
 
+  // Prepare the create approved item mutation
   const [createApprovedItem] = useCreateApprovedCuratedCorpusItemMutation();
 
+  // The toast notification hook
   const { showNotification } = useNotifications();
 
+  // State variable to track if the user has uploaded a new image
   const [prospectS3Image, setProspectS3Image] = useState<string | undefined>(
     undefined
   );
 
+  /**
+   *
+   * This function gets called when the user saves(approves) a prospect
+   */
   const onProspectSave = (
     values: FormikValues,
     formikHelpers: FormikHelpers<any>


### PR DESCRIPTION
## Goal
Hook up the image upload to S3. Wire up the create an approved item mutation when the user clicks `Save` on the form.

Tickets:

- [BACK-1146](https://getpocket.atlassian.net/browse/BACK-1146)
- [BACK-1147](https://getpocket.atlassian.net/browse/BACK-1147)
