### PR TITLE
feat(prospects): [BACK-1151] Wire up the prospect refresh button

### DIFF
--- a/src/_shared/components/_form-elements/SharedFormButtons/SharedFormButtons.test.tsx
+++ b/src/_shared/components/_form-elements/SharedFormButtons/SharedFormButtons.test.tsx
@@ -48,4 +48,11 @@ describe('The SharedFormButtons component', () => {
 
     expect(mockOnSave).toHaveBeenCalled();
   });
+
+  it('displays a custom label for the "Save" button if provided', () => {
+    render(<SharedFormButtons saveButtonLabel="Confirm" />);
+
+    expect(screen.queryByText(/save/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/confirm/i)).toBeInTheDocument();
+  });
 });

--- a/src/_shared/components/_form-elements/SharedFormButtons/SharedFormButtons.tsx
+++ b/src/_shared/components/_form-elements/SharedFormButtons/SharedFormButtons.tsx
@@ -13,7 +13,12 @@ export interface SharedFormButtonsProps {
    * Optional prop to disable the save button on a form/on this component
    */
   saveButtonDisabled?: boolean;
+  /**
+   * The default for the shared buttons is "Save", but sometimes another
+   * call to action is appropriate, e.g. "Confirm".
+   */
 
+  saveButtonLabel?: string;
   /**
    * What to do if the user clicks on the Cancel button
    */
@@ -33,6 +38,7 @@ export const SharedFormButtons: React.FC<SharedFormButtonsProps> = (
   const {
     editMode = true,
     saveButtonDisabled = false,
+    saveButtonLabel = 'Save',
     onCancel,
     onSave,
   } = props;
@@ -47,7 +53,7 @@ export const SharedFormButtons: React.FC<SharedFormButtonsProps> = (
             onClick={onSave}
             disabled={saveButtonDisabled}
           >
-            Save
+            {saveButtonLabel}
           </Button>
         </Box>
         {editMode && (

--- a/src/curated-corpus/components/ApprovedItemCardWrapper/ApprovedItemCardWrapper.test.tsx
+++ b/src/curated-corpus/components/ApprovedItemCardWrapper/ApprovedItemCardWrapper.test.tsx
@@ -35,7 +35,12 @@ describe('The ApprovedItemCardWrapper component', () => {
   it('should render an approved item card', () => {
     render(
       <MemoryRouter>
-        <ApprovedItemCardWrapper item={item} onSchedule={jest.fn()} />
+        <ApprovedItemCardWrapper
+          item={item}
+          onEdit={jest.fn()}
+          onReject={jest.fn()}
+          onSchedule={jest.fn()}
+        />
       </MemoryRouter>
     );
 
@@ -48,7 +53,12 @@ describe('The ApprovedItemCardWrapper component', () => {
   it('should render action buttons', () => {
     render(
       <MemoryRouter>
-        <ApprovedItemCardWrapper item={item} onSchedule={jest.fn()} />
+        <ApprovedItemCardWrapper
+          item={item}
+          onEdit={jest.fn()}
+          onReject={jest.fn()}
+          onSchedule={jest.fn()}
+        />
       </MemoryRouter>
     );
 

--- a/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.test.tsx
+++ b/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.test.tsx
@@ -9,8 +9,6 @@ import { ApprovedItemListCard } from './ApprovedItemListCard';
 
 describe('The ApprovedItemListCard component', () => {
   let item: ApprovedCuratedCorpusItem;
-  const onSchedule = jest.fn();
-  const onReject = jest.fn();
 
   beforeEach(() => {
     item = {

--- a/src/curated-corpus/components/RefreshProspectsModal/RefreshProspectsModal.tsx
+++ b/src/curated-corpus/components/RefreshProspectsModal/RefreshProspectsModal.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Modal, SharedFormButtons } from '../../../_shared/components';
+import { Box, Grid, Typography } from '@material-ui/core';
+
+interface RefreshProspectsModalProps {
+  isOpen: boolean;
+  onConfirm: VoidFunction;
+  toggleModal: VoidFunction;
+}
+
+export const RefreshProspectsModal: React.FC<RefreshProspectsModalProps> = (
+  props
+): JSX.Element => {
+  const { isOpen, onConfirm, toggleModal } = props;
+
+  return (
+    <Modal
+      open={isOpen}
+      handleClose={() => {
+        toggleModal();
+      }}
+    >
+      <Grid container spacing={2}>
+        <Grid item xs={12}>
+          <h2>Refresh Prospects?</h2>
+          <Typography>
+            There are still some prospects remaining on the page.
+          </Typography>
+        </Grid>
+        <Grid item xs={12}>
+          <Box p={3}>
+            <SharedFormButtons
+              onSave={onConfirm}
+              onCancel={toggleModal}
+              saveButtonLabel="Confirm"
+            />
+          </Box>
+        </Grid>
+      </Grid>
+    </Modal>
+  );
+};

--- a/src/curated-corpus/components/index.ts
+++ b/src/curated-corpus/components/index.ts
@@ -9,6 +9,7 @@ export { ProspectListCard } from './ProspectListCard/ProspectListCard';
 export { RejectedItemListCard } from './RejectedItemListCard/RejectedItemListCard';
 export { RejectedItemSearchForm } from './RejectedItemSearchForm/RejectedItemSearchForm';
 export { ScheduledItemCardWrapper } from './ScheduledItemCardWrapper/ScheduledItemCardWrapper';
+export { RefreshProspectsModal } from './RefreshProspectsModal/RefreshProspectsModal';
 export { RejectItemModal } from './RejectItemModal/RejectItemModal';
 export { RejectItemForm } from './RejectItemForm/RejectItemForm';
 export { RemoveItemFromNewTabForm } from './RemoveItemFromNewTabForm/RemoveItemFromNewTabForm';

--- a/src/curated-corpus/pages/NewTabCurationPage/NewTabCurationPage.tsx
+++ b/src/curated-corpus/pages/NewTabCurationPage/NewTabCurationPage.tsx
@@ -1,12 +1,14 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { DateTime } from 'luxon';
-import { Box, Grid, Hidden, Typography } from '@material-ui/core';
+import { Box, Button, Grid, Hidden, Typography } from '@material-ui/core';
+import CachedIcon from '@material-ui/icons/Cached';
 import { HandleApiResponse } from '../../../_shared/components';
 import {
+  ApprovedItemModal,
   NewTabGroupedList,
   ProspectListCard,
+  RefreshProspectsModal,
   RejectItemModal,
-  ApprovedItemModal,
 } from '../../components';
 import { client } from '../../api/prospect-api/client';
 import {
@@ -17,15 +19,15 @@ import {
 import {
   RejectProspectMutationVariables,
   ScheduledCuratedCorpusItemsResult,
+  useCreateApprovedCuratedCorpusItemMutation,
   useGetScheduledItemsQuery,
   useRejectProspectMutation,
   useUploadApprovedCuratedCorpusItemImageMutation,
-  useCreateApprovedCuratedCorpusItemMutation,
 } from '../../api/curated-corpus-api/generatedTypes';
 import {
+  useNotifications,
   useRunMutation,
   useToggle,
-  useNotifications,
 } from '../../../_shared/hooks';
 
 import { transformProspectToApprovedItem } from '../../helpers/helperFunctions';
@@ -37,6 +39,9 @@ export const NewTabCurationPage: React.FC = (): JSX.Element => {
 
   // Get a list of prospects on the page
   const { loading, error, data, refetch } = useGetProspectsQuery({
+    // Do not cache prospects at all. On update, remove the relevant prospect
+    // card from the screen manually once the prospect has been curated.
+    fetchPolicy: 'no-cache',
     notifyOnNetworkStatusChange: true,
     variables: { newTab: newTabGuid },
     client,
@@ -77,6 +82,12 @@ export const NewTabCurationPage: React.FC = (): JSX.Element => {
    */
   const [approvedItemModalOpen, toggleApprovedItemModal] = useToggle(false);
 
+  /**
+   * Keep track of whether the "Refresh Prospects" modal is open or not.
+   */
+  const [refreshProspectsModalOpen, toggleRefreshProspectsModal] =
+    useToggle(false);
+
   // Get a helper function that will execute each mutation, show standard notifications
   // and execute any additional actions in a callback
   const { runMutation } = useRunMutation();
@@ -88,6 +99,18 @@ export const NewTabCurationPage: React.FC = (): JSX.Element => {
     client,
   });
 
+  // Instead of working off Apollo Client's cache for the `getProspects` query
+  // let's set up another variable for the prospect card list.
+  const [prospects, setProspects] = useState<Prospect[]>([]);
+
+  // When the batch of random prospects has loaded, update our `prospects` variable
+  // with the contents of the API response. This will allow us to remove items from
+  // the response array and unmount the relevant prospect cards when they have been
+  // processed.
+  useEffect(() => {
+    setProspects(data?.getProspects!);
+  }, [data]);
+
   /**
    * Add the prospect to the rejected corpus.
    * Additionally, let Prospect API know the prospect has been processed.
@@ -95,7 +118,6 @@ export const NewTabCurationPage: React.FC = (): JSX.Element => {
    * @param values
    * @param formikHelpers
    */
-
   const onRejectSave = (
     values: FormikValues,
     formikHelpers: FormikHelpers<any>
@@ -103,7 +125,7 @@ export const NewTabCurationPage: React.FC = (): JSX.Element => {
     // Set out all the variables we need to pass to the first mutation
     const variables: RejectProspectMutationVariables = {
       data: {
-        prospectId: currentItem?.id ?? '', // TODO: sort out types here
+        prospectId: currentItem?.id!,
         url: currentItem?.url,
         title: currentItem?.title,
         topic: currentItem?.topic ?? '',
@@ -117,14 +139,13 @@ export const NewTabCurationPage: React.FC = (): JSX.Element => {
     runMutation(
       updateProspectAsCurated,
       { variables: { prospectId: currentItem?.id }, client },
-      '',
+      undefined,
       () => {
         formikHelpers.setSubmitting(false);
       },
       () => {
         formikHelpers.setSubmitting(false);
-      },
-      refetch
+      }
     );
 
     // Add the prospect to the rejected corpus
@@ -133,16 +154,21 @@ export const NewTabCurationPage: React.FC = (): JSX.Element => {
       { variables },
       `Item successfully added to the rejected corpus.`,
       () => {
+        // Hide the modal
         toggleRejectModal();
+
+        // Remove the newly rejected item from the list of prospects displayed
+        // on the page.
+        setProspects(
+          prospects.filter((prospect) => prospect.id !== currentItem?.id!)
+        );
+
         formikHelpers.setSubmitting(false);
       },
       () => {
         formikHelpers.setSubmitting(false);
       }
     );
-
-    // Mark the prospect as processed in the Prospect API datastore.
-    // TODO: add logic here. Don't forget to connect to Prospect API for this mutation
   };
 
   // Prepare the upload approved item image mutation
@@ -231,8 +257,7 @@ export const NewTabCurationPage: React.FC = (): JSX.Element => {
                       },
                       () => {
                         formikHelpers.setSubmitting(false);
-                      },
-                      refetch
+                      }
                     );
 
                     showNotification(
@@ -240,21 +265,24 @@ export const NewTabCurationPage: React.FC = (): JSX.Element => {
                       'success'
                     );
                     toggleApprovedItemModal();
-                    // manually refresh the cache
-                    refetch();
+
+                    // Remove the newly curated item from the list of prospects displayed
+                    // on the page.
+                    setProspects(
+                      prospects.filter(
+                        (prospect) => prospect.id !== currentItem?.id!
+                      )
+                    );
+
                     formikHelpers.setSubmitting(false);
                   })
                   .catch((error) => {
-                    // manually refresh the cache
-                    refetch();
                     showNotification(error.message, 'error');
                     formikHelpers.setSubmitting(false);
                   });
               }
             })
             .catch((error) => {
-              // manually refresh the cache
-              refetch();
               showNotification(error.message, 'error');
             });
         })
@@ -264,8 +292,6 @@ export const NewTabCurationPage: React.FC = (): JSX.Element => {
               `(Original error: ${error.message})`,
             'error'
           );
-          // manually refresh the cache
-          refetch();
           formikHelpers.setSubmitting(false);
         });
     } else if (prospectS3Image) {
@@ -301,12 +327,18 @@ export const NewTabCurationPage: React.FC = (): JSX.Element => {
         `Prospect "${values.title.substring(0, 50)}..." successfully approved`,
         () => {
           toggleApprovedItemModal();
+
+          // Remove the newly curated item from the list of prospects displayed
+          // on the page.
+          setProspects(
+            prospects.filter((prospect) => prospect.id !== currentItem?.id!)
+          );
+
           formikHelpers.setSubmitting(false);
         },
         () => {
           formikHelpers.setSubmitting(false);
-        },
-        refetch
+        }
       );
     } else {
       showNotification('Please upload an image before submitting', 'error');
@@ -337,20 +369,48 @@ export const NewTabCurationPage: React.FC = (): JSX.Element => {
         </>
       )}
 
-      <h1>New Tab Curation</h1>
-      <Box mb={3}>
-        <Typography>
-          I am curating for <strong>{newTabGuid}</strong> (temporarily
-          hardcoded)
-        </Typography>
-      </Box>
+      <RefreshProspectsModal
+        isOpen={refreshProspectsModalOpen}
+        onConfirm={() => {
+          refetch();
+          toggleRefreshProspectsModal();
+        }}
+        toggleModal={toggleRefreshProspectsModal}
+      />
 
+      <h1>New Tab Curation</h1>
       <Grid container spacing={3}>
         <Grid item xs={12} sm={9}>
-          {!data && <HandleApiResponse loading={loading} error={error} />}
+          <Grid container spacing={3}>
+            <Grid item xs={12} sm={6}>
+              <Typography>
+                I am curating for <strong>{newTabGuid}</strong> (temporarily
+                hardcoded)
+              </Typography>
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <Box display="flex" justifyContent="flex-end" mb={2}>
+                <Button
+                  color="default"
+                  onClick={() => {
+                    // If all the prospects have been processed already,
+                    // there is no need for a confirmation dialogue here,
+                    // let's just fetch a new batch of prospects.
+                    prospects && prospects.length > 0
+                      ? toggleRefreshProspectsModal()
+                      : refetch();
+                  }}
+                >
+                  <CachedIcon fontSize="large" />
+                </Button>
+              </Box>
+            </Grid>
+          </Grid>
 
-          {data &&
-            data.getProspects.map((prospect) => {
+          {!prospects && <HandleApiResponse loading={loading} error={error} />}
+
+          {prospects &&
+            prospects.map((prospect) => {
               return (
                 <ProspectListCard
                   key={prospect.id}


### PR DESCRIPTION
## Goal

Wire up the refresh button on the New Tab Curation page. This necessitates updating how we retrieve data and what we do when a prospect gets marked as curated, as the `getProspects` query returns a set of randomised 20 items and running a `refetch()` call after a mutation updates the entire list to a fresh batch of random results. 

That is not what we want at all - we want the originally retrieved results to stay on the page, minus the one that's just been rejected or approved. 

In the end, and after experimenting some more with Apollo Client caching (debugging it is hard given Prospects API is the third client we connect to in the app when we get to the New Tab Curation page, and the DevTools extension only connects to the first client. It was doable for Curated Corpus API, as it only necessitated turning off all of Collections code temporarily, but it's. just. too. hard to be disabling all of the Curated Corpus functionality for the simple component behaviour we need here), I went for simply tracking the list of prospects returned by the API in an array, and filtering out updated prospects out of that array when a mutation has run successfully.

## Reference

Tickets:

https://getpocket.atlassian.net/browse/BACK-1151

## Walkthrough

Shows prospects dutifully disappearing (not in a raging fire though 🤷‍♀️) after each mutation AND the rest of the prospects staying put. No new prospects are being loaded up behind the scenes with `refetch()` as before - given that the query returns a set of 20 random prospects, it was not the desired behaviour.

Shows the refresh button with a confirmation modal - dismissible on clicking "Cancel". I was testing on Dev and didn't want to use up all prospects there accidentally, but the code should not display the confirmation screen if no prospects remain on the page - it should just fetch a new batch of prospects straight away.


https://user-images.githubusercontent.com/22447785/146712381-81d1d9ea-b822-440e-82d8-3d2e592897a9.mov



