### PR TITLE
refactor(prospect): [BACK-1222] allow prospect topic to be empty

### DIFF
--- a/src/curated-corpus/api/prospect-api/generatedTypes.ts
+++ b/src/curated-corpus/api/prospect-api/generatedTypes.ts
@@ -57,7 +57,7 @@ export type Prospect = {
   publisher?: Maybe<Scalars['String']>;
   saveCount?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
-  topic: Scalars['String'];
+  topic?: Maybe<Scalars['String']>;
   url: Scalars['String'];
 };
 
@@ -75,7 +75,7 @@ export type ProspectDataFragment = {
   __typename?: 'Prospect';
   id: string;
   newTab: string;
-  topic: string;
+  topic?: string | null | undefined;
   prospectType: string;
   url: string;
   createdAt?: number | null | undefined;
@@ -101,7 +101,7 @@ export type UpdateProspectAsCuratedMutation = {
         __typename?: 'Prospect';
         id: string;
         newTab: string;
-        topic: string;
+        topic?: string | null | undefined;
         prospectType: string;
         url: string;
         createdAt?: number | null | undefined;
@@ -130,7 +130,7 @@ export type GetProspectsQuery = {
     __typename?: 'Prospect';
     id: string;
     newTab: string;
-    topic: string;
+    topic?: string | null | undefined;
     prospectType: string;
     url: string;
     createdAt?: number | null | undefined;


### PR DESCRIPTION
## Goal
A Prospect could come in without a topic. When populating the fields for the approve form, we already were accommodating it. Just the schema type needed to be synced with the back-end/prospect api service

Tickets:

- [Link to JIRA tickets](https://getpocket.atlassian.net/browse/BACK-1222)