### PR TITLE
feat(prospects): [BACK-1137] Filter prospects by prospect type

### DIFF
--- a/src/curated-corpus/components/SplitButton/SplitButton.styles.tsx
+++ b/src/curated-corpus/components/SplitButton/SplitButton.styles.tsx
@@ -1,0 +1,12 @@
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+
+/**
+ * Styles for the SplitButton component.
+ */
+export const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    optionName: {
+      minWidth: '9rem',
+    },
+  })
+);

--- a/src/curated-corpus/components/SplitButton/SplitButton.test.tsx
+++ b/src/curated-corpus/components/SplitButton/SplitButton.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { SplitButton } from './SplitButton';
+import { DropdownOption } from '../../helpers/definitions';
+import FilterListIcon from '@material-ui/icons/FilterList';
+import userEvent from '@testing-library/user-event';
+
+describe('The SplitButton component', () => {
+  const onClick = jest.fn();
+
+  const options: DropdownOption[] = [
+    { code: 'test1', name: 'Option 1' },
+    { code: 'test2', name: 'Option 2' },
+  ];
+
+  it('renders with required props', () => {
+    render(<SplitButton onMenuOptionClick={onClick} options={options} />);
+
+    // The first dropdown option should be displayed as the button label
+    const button = screen.getByText(/option 1/i);
+
+    expect(button).toBeInTheDocument();
+  });
+
+  it('renders with optional icon', () => {
+    render(
+      <SplitButton
+        icon={<FilterListIcon fontSize="large" data-testid="my-filter-icon" />}
+        onMenuOptionClick={onClick}
+        options={options}
+      />
+    );
+
+    const icon = screen.getByTestId('my-filter-icon');
+    expect(icon).toBeInTheDocument();
+  });
+
+  it('updates selected option', async () => {
+    render(<SplitButton onMenuOptionClick={onClick} options={options} />);
+    const dropdownArrow = screen.getByLabelText(/dropdown options/i);
+
+    await waitFor(() => {
+      userEvent.click(dropdownArrow);
+    });
+
+    // The second option in the dropdown should now be visible
+    const option2 = screen.getByText(/option 2/i);
+    expect(option2).toBeInTheDocument();
+
+    await waitFor(() => {
+      userEvent.click(option2);
+    });
+
+    expect(onClick).toHaveBeenCalled();
+  });
+});

--- a/src/curated-corpus/components/SplitButton/SplitButton.tsx
+++ b/src/curated-corpus/components/SplitButton/SplitButton.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import {
+  Button,
+  ButtonGroup,
+  ClickAwayListener,
+  Grow,
+  MenuItem,
+  MenuList,
+  Paper,
+  Popper,
+} from '@material-ui/core';
+import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
+import { useStyles } from './SplitButton.styles';
+import { DropdownOption } from '../../helpers/definitions';
+
+interface SplitButtonProps {
+  /**
+   * An optional icon to show alongside the chosen menu option.
+   */
+  icon?: JSX.Element;
+  /**
+   * Do some custom processing once a user selected a menu option
+   *
+   * @param option
+   */
+  onMenuOptionClick: (option: DropdownOption) => void;
+
+  /**
+   * A list of options to display in the dropdown.
+   */
+  options: DropdownOption[];
+}
+
+/**
+ * A fancy split button component that takes in a list of options and a function
+ * to run when an option from the dropdown menu is chosen.
+ *
+ * Heavily inspired by the Split Button example in
+ * https://v4.mui.com/components/button-group/#split-button
+ * @constructor
+ */
+export const SplitButton: React.FC<SplitButtonProps> = (props) => {
+  const classes = useStyles();
+  const { icon, onMenuOptionClick, options } = props;
+  const [open, setOpen] = React.useState(false);
+  const anchorRef = React.useRef<HTMLDivElement>(null);
+  const [selectedIndex, setSelectedIndex] = React.useState(0);
+
+  const handleMenuItemClick = (
+    event: React.MouseEvent<HTMLLIElement, MouseEvent>,
+    index: number,
+    code: string
+  ) => {
+    setSelectedIndex(index);
+    setOpen(false);
+
+    // Do custom processing in a function passed from the parent component.
+    onMenuOptionClick(options[index]);
+  };
+
+  const handleToggle = () => {
+    setOpen((prevOpen) => !prevOpen);
+  };
+
+  const handleClose = (event: React.MouseEvent<Document, MouseEvent>) => {
+    if (
+      anchorRef.current &&
+      anchorRef.current.contains(event.target as HTMLElement)
+    ) {
+      return;
+    }
+
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <ButtonGroup
+        variant="text"
+        color="default"
+        ref={anchorRef}
+        aria-label="split button"
+      >
+        <Button className={classes.optionName}>
+          {icon} {options[selectedIndex].name}
+        </Button>
+        <Button
+          color="default"
+          size="small"
+          aria-controls={open ? 'split-button-menu' : undefined}
+          aria-expanded={open ? 'true' : undefined}
+          aria-label="dropdown options"
+          aria-haspopup="menu"
+          onClick={handleToggle}
+        >
+          <ArrowDropDownIcon />
+        </Button>
+      </ButtonGroup>
+      <Popper
+        open={open}
+        anchorEl={anchorRef.current}
+        role={undefined}
+        transition
+        disablePortal
+      >
+        {({ TransitionProps, placement }) => (
+          <Grow
+            {...TransitionProps}
+            style={{
+              transformOrigin:
+                placement === 'bottom' ? 'center top' : 'center bottom',
+            }}
+          >
+            <Paper>
+              <ClickAwayListener onClickAway={handleClose}>
+                <MenuList id="split-button-menu">
+                  {options.map((option, index) => (
+                    <MenuItem
+                      key={option.code}
+                      selected={index === selectedIndex}
+                      onClick={(event) =>
+                        handleMenuItemClick(event, index, option.code)
+                      }
+                    >
+                      {option.name}
+                    </MenuItem>
+                  ))}
+                </MenuList>
+              </ClickAwayListener>
+            </Paper>
+          </Grow>
+        )}
+      </Popper>
+    </>
+  );
+};

--- a/src/curated-corpus/components/index.ts
+++ b/src/curated-corpus/components/index.ts
@@ -1,5 +1,6 @@
 export { ApprovedItemCardWrapper } from './ApprovedItemCardWrapper/ApprovedItemCardWrapper';
 export { ApprovedItemListCard } from './ApprovedItemListCard/ApprovedItemListCard';
+export { ApprovedItemModal } from './ApprovedItemModal/ApprovedItemModal';
 export { ApprovedItemSearchForm } from './ApprovedItemSearchForm/ApprovedItemSearchForm';
 export { LoadExtraButton } from './LoadExtraButton/LoadExtraButton';
 export { MiniNewTabScheduleCard } from './MiniNewTabScheduleCard/MiniNewTabScheduleCard';
@@ -16,4 +17,4 @@ export { RemoveItemFromNewTabForm } from './RemoveItemFromNewTabForm/RemoveItemF
 export { RemoveItemFromNewTabModal } from './RemoveItemFromNewTabModal/RemoveItemFromNewTabModal';
 export { ScheduleItemForm } from './ScheduleItemForm/ScheduleItemForm';
 export { ScheduleItemModal } from './ScheduleItemModal/ScheduleItemModal';
-export { ApprovedItemModal } from './ApprovedItemModal/ApprovedItemModal';
+export { SplitButton } from './SplitButton/SplitButton';

--- a/src/curated-corpus/helpers/definitions.ts
+++ b/src/curated-corpus/helpers/definitions.ts
@@ -1,4 +1,8 @@
 // Here we keep sets of options for curating items
+import {
+  CuratedStatus,
+  ProspectType,
+} from '../api/curated-corpus-api/generatedTypes';
 
 export interface DropdownOption {
   code: string;
@@ -24,12 +28,13 @@ export const topics: DropdownOption[] = [
   { code: 'TRAVEL', name: 'Travel' },
 ];
 
-// This will come from Prospect API's generated types in due course
-export enum ProspectType {
-  GLOBAL = 'GLOBAL',
-  TIMESPENT = 'ORGANIC_TIMESPENT',
-  SYNDICATED = 'SYNDICATED',
-}
+// All the possible Prospect types for filtering
+export const prospectFilters: DropdownOption[] = [
+  { code: 'all', name: 'All Sources' },
+  { code: ProspectType.Global, name: 'Global' },
+  { code: ProspectType.OrganicTimespent, name: 'Time Spent' },
+  { code: ProspectType.Syndicated, name: 'Syndicated' },
+];
 
 // New Tab as it exists on Prospect API.
 export type NewTab = {
@@ -47,16 +52,16 @@ export const newTabs: NewTab[] = [
     guid: 'EN_US',
     utcOffset: -4000,
     prospectTypes: [
-      ProspectType.GLOBAL,
-      ProspectType.TIMESPENT,
-      ProspectType.SYNDICATED,
+      ProspectType.Global,
+      ProspectType.OrganicTimespent,
+      ProspectType.Syndicated,
     ],
   },
   {
     name: 'de-DE',
     guid: 'DE_DE',
     utcOffset: 1000,
-    prospectTypes: [ProspectType.GLOBAL],
+    prospectTypes: [ProspectType.Global],
   },
 ];
 
@@ -68,6 +73,6 @@ export const languages: DropdownOption[] = [
 
 // This maps to the status (CuratedStatus type) field in DB for an ApprovedItem
 export const curationStatusOptions: DropdownOption[] = [
-  { code: 'RECOMMENDATION', name: 'Recommendation' },
-  { code: 'CORPUS', name: 'Corpus' },
+  { code: CuratedStatus.Recommendation, name: 'Recommendation' },
+  { code: CuratedStatus.Corpus, name: 'Corpus' },
 ];


### PR DESCRIPTION
## Goal

Allow curators to filter prospects by type. 

I think I have the UI worked out - a split button fits the bill perfectly. 

- Added a SplitButton component that shows a dropdown menu and updates data on choosing a different filter option on prospects. This button updates query variables in the background, however does not re-execute the query: as stipulated in the ticket, users need to click the refresh button to fetch new, filtered prospects.

- Added unit tests for the new SplitButton component.

- Updated hardcoded New Tab values to use ProspectType enum values as an interim step to moving to `getNewTabs` query.

## Todo

- [x] Remember to change PR base to `main` and rebase once the branch this code depends on in part is merged.

## Reference

Tickets:

- [Link to JIRA tickets
](https://getpocket.atlassian.net/browse/BACK-1137)

## Walkthrough


https://user-images.githubusercontent.com/22447785/147075755-93d28e67-d5c5-45fe-b170-f48d934a7e29.mov

