### PR TITLE
fix(topic): [BACK-1249] Bug when displaying/using topics with spaces

### DIFF
--- a/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.tsx
+++ b/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.tsx
@@ -18,6 +18,7 @@ import LanguageIcon from '@material-ui/icons/Language';
 import ThumbUpIcon from '@material-ui/icons/ThumbUp';
 import { useStyles } from './ApprovedItemListCard.styles';
 import { ApprovedCuratedCorpusItem } from '../../api/curated-corpus-api/generatedTypes';
+import { topics } from '../../helpers/definitions';
 
 interface ApprovedItemListCardProps {
   /**
@@ -31,6 +32,12 @@ export const ApprovedItemListCard: React.FC<ApprovedItemListCardProps> = (
 ): JSX.Element => {
   const classes = useStyles();
   const { item } = props;
+
+  // This finds the corresponding display name topic from the
+  // Topics enum
+  const displayTopic = topics.find((topic) => {
+    return topic.code === item.topic;
+  })?.name;
 
   return (
     <>
@@ -85,10 +92,7 @@ export const ApprovedItemListCard: React.FC<ApprovedItemListCardProps> = (
           <ListItemIcon className={classes.listItemIcon}>
             <LabelOutlinedIcon />
           </ListItemIcon>
-          <ListItemText
-            className={classes.topic}
-            primary={item.topic.toLowerCase()}
-          />
+          <ListItemText className={classes.topic} primary={displayTopic} />
         </ListItem>
         <ListItem divider>
           <ListItemIcon className={classes.listItemIcon}>

--- a/src/curated-corpus/helpers/definitions.ts
+++ b/src/curated-corpus/helpers/definitions.ts
@@ -2,6 +2,7 @@
 import {
   CuratedStatus,
   ProspectType,
+  Topics,
 } from '../api/curated-corpus-api/generatedTypes';
 
 export interface DropdownOption {
@@ -10,22 +11,22 @@ export interface DropdownOption {
 }
 // This is a list of topics. The 15 "standard" topics + coronavirus.
 export const topics: DropdownOption[] = [
-  { code: 'BUSINESS', name: 'Business' },
-  { code: 'CAREER', name: 'Career' },
-  { code: 'CORONAVIRUS', name: 'Coronavirus' },
-  { code: 'EDUCATION', name: 'Education' },
-  { code: 'ENTERTAINMENT', name: 'Entertainment' },
-  { code: 'FOOD', name: 'Food' },
-  { code: 'GAMING', name: 'Gaming' },
-  { code: 'HEALTH_FITNESS', name: 'Health & Fitness' },
-  { code: 'PARENTING', name: 'Parenting' },
-  { code: 'PERSONAL_FINANCE', name: 'Personal Finance' },
-  { code: 'POLITICS', name: 'Politics' },
-  { code: 'SCIENCE', name: 'Science' },
-  { code: 'SELF_IMPROVEMENT', name: 'Self Improvement' },
-  { code: 'SPORTS', name: 'Sports' },
-  { code: 'TECHNOLOGY', name: 'Technology' },
-  { code: 'TRAVEL', name: 'Travel' },
+  { code: Topics.Business, name: 'Business' },
+  { code: Topics.Career, name: 'Career' },
+  { code: Topics.Coronavirus, name: 'Coronavirus' },
+  { code: Topics.Education, name: 'Education' },
+  { code: Topics.Entertainment, name: 'Entertainment' },
+  { code: Topics.Food, name: 'Food' },
+  { code: Topics.Gaming, name: 'Gaming' },
+  { code: Topics.HealthFitness, name: 'Health & Fitness' },
+  { code: Topics.Parenting, name: 'Parenting' },
+  { code: Topics.PersonalFinance, name: 'Personal Finance' },
+  { code: Topics.Politics, name: 'Politics' },
+  { code: Topics.Science, name: 'Science' },
+  { code: Topics.SelfImprovement, name: 'Self Improvement' },
+  { code: Topics.Sports, name: 'Sports' },
+  { code: Topics.Technology, name: 'Technology' },
+  { code: Topics.Travel, name: 'Travel' },
 ];
 
 // All the possible Prospect types for filtering


### PR DESCRIPTION
## Goal

For items with topics `Health & Fitness`, `Personal Finance` and `Self Improvement`, the `topic` field on the edit item form would get set _empty_. This was due to the topics not being mapped correctly on the front-end. 

[Back-end fix for this was done a while ago](https://getpocket.atlassian.net/browse/BACK-1230)

This also fixes the filtering. Previously filtering for above topics would not return any results.
 
I re-seeded the dev curated-corpus DB for the previous bug fix to take effect.

- [Link to JIRA tickets](https://getpocket.atlassian.net/browse/BACK-1249)