### PR TITLE
feat(scheduling): ScheduleItemForm should use `getNewTabsForUser` query (BACK-1253)

### DIFF
--- a/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.test.tsx
+++ b/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.test.tsx
@@ -3,18 +3,40 @@ import LuxonUtils from '@date-io/luxon';
 import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 import { render, screen } from '@testing-library/react';
 import { ScheduleItemForm } from './ScheduleItemForm';
-import { newTabs } from '../../helpers/definitions';
+import {
+  NewTab,
+  ProspectType,
+} from '../../api/curated-corpus-api/generatedTypes';
 
 describe('The ScheduleItemForm component', () => {
   const handleSubmit = jest.fn();
-  const newTabList = newTabs;
+
+  // This is the shape of the data the form receives via the `getNewTabsForUser` query
+  const newTabs: NewTab[] = [
+    {
+      name: 'en-US',
+      guid: 'EN_US',
+      utcOffset: -4000,
+      prospectTypes: [
+        ProspectType.Global,
+        ProspectType.OrganicTimespent,
+        ProspectType.Syndicated,
+      ],
+    },
+    {
+      name: 'de-DE',
+      guid: 'DE_DE',
+      utcOffset: 1000,
+      prospectTypes: [ProspectType.Global],
+    },
+  ];
 
   it('renders successfully', () => {
     render(
       <MuiPickersUtilsProvider utils={LuxonUtils}>
         <ScheduleItemForm
           onSubmit={handleSubmit}
-          newTabList={newTabList}
+          newTabs={newTabs}
           approvedItemExternalId={'123abc'}
         />
       </MuiPickersUtilsProvider>
@@ -30,7 +52,7 @@ describe('The ScheduleItemForm component', () => {
       <MuiPickersUtilsProvider utils={LuxonUtils}>
         <ScheduleItemForm
           onSubmit={handleSubmit}
-          newTabList={newTabList}
+          newTabs={newTabs}
           approvedItemExternalId={'123abc'}
         />
       </MuiPickersUtilsProvider>

--- a/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.tsx
+++ b/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.tsx
@@ -8,9 +8,9 @@ import {
   SharedFormButtons,
   SharedFormButtonsProps,
 } from '../../../_shared/components';
-import { validationSchema } from './ScheduleItemForm.validation';
+import { getValidationSchema } from './ScheduleItemForm.validation';
 import { MaterialUiPickersDate } from '@material-ui/pickers/typings/date';
-import { NewTab } from '../../helpers/definitions';
+import { NewTab } from '../../api/curated-corpus-api/generatedTypes';
 
 interface ScheduleItemFormProps {
   /**
@@ -21,7 +21,7 @@ interface ScheduleItemFormProps {
   /**
    * The list of New Tabs the logged-in user has access to.
    */
-  newTabList: NewTab[];
+  newTabs: NewTab[];
 
   /**
    * What do we do with the submitted data?
@@ -35,7 +35,7 @@ interface ScheduleItemFormProps {
 export const ScheduleItemForm: React.FC<
   ScheduleItemFormProps & SharedFormButtonsProps
 > = (props): JSX.Element => {
-  const { approvedItemExternalId, newTabList, onCancel, onSubmit } = props;
+  const { approvedItemExternalId, newTabs, onCancel, onSubmit } = props;
 
   // Set the default scheduled date to tomorrow.
   // Do we need to worry about timezones here? .local() returns the date
@@ -62,7 +62,7 @@ export const ScheduleItemForm: React.FC<
     },
     validateOnBlur: false,
     validateOnChange: false,
-    validationSchema,
+    validationSchema: getValidationSchema(newTabs),
     onSubmit: (values, formikHelpers) => {
       // Make sure the date is the one selected by the user
       // (Without this, Formik passes on the initial date = tomorrow.)
@@ -84,7 +84,7 @@ export const ScheduleItemForm: React.FC<
               fieldMeta={formik.getFieldMeta('newTabGuid')}
             >
               <option aria-label="None" value="" />
-              {newTabList.map((newTab: NewTab) => {
+              {newTabs.map((newTab: NewTab) => {
                 return (
                   <option value={newTab.guid} key={newTab.guid}>
                     {newTab.name}

--- a/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.validation.tsx
+++ b/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.validation.tsx
@@ -1,26 +1,33 @@
 import * as yup from 'yup';
-import { NewTab, newTabs } from '../../helpers/definitions';
 import { DateTime } from 'luxon';
+import { NewTab } from '../../api/curated-corpus-api/generatedTypes';
 
-// TODO: When auth is in, this should be limited to values the user has access to.
-const newTabAllowedValues = newTabs.map((newTab: NewTab) => {
-  return newTab.guid;
-});
+/**
+ * Generate the validation schema with the given New Tabs
+ * that come from the `getNewTabsForUser` query.
+ *
+ * @param newTabs
+ */
+export const getValidationSchema = (newTabs: NewTab[]) => {
+  const newTabAllowedValues = newTabs.map((newTab: NewTab) => {
+    return newTab.guid;
+  });
 
-export const validationSchema = yup.object({
-  // This is a hidden field that we pass along
-  approvedItemExternalId: yup.string().trim().required(),
+  return yup.object({
+    // This is a hidden field that we pass along
+    approvedItemExternalId: yup.string().trim().required(),
 
-  newTabGuid: yup
-    .string()
-    .oneOf(newTabAllowedValues)
-    .trim()
-    .required('Please choose a New Tab.'),
+    newTabGuid: yup
+      .string()
+      .oneOf(newTabAllowedValues)
+      .trim()
+      .required('Please choose a New Tab.'),
 
-  scheduledDate: yup
-    .date()
-    .min(DateTime.local())
-    .max(DateTime.local().plus({ days: 60 }))
-    .required('Please choose a date no more than 60 days in advance.')
-    .nullable(),
-});
+    scheduledDate: yup
+      .date()
+      .min(DateTime.local())
+      .max(DateTime.local().plus({ days: 60 }))
+      .required('Please choose a date no more than 60 days in advance.')
+      .nullable(),
+  });
+};

--- a/src/curated-corpus/components/ScheduleItemFormConnector/ScheduleItemFormConnector.tsx
+++ b/src/curated-corpus/components/ScheduleItemFormConnector/ScheduleItemFormConnector.tsx
@@ -1,0 +1,46 @@
+import { ScheduleItemForm } from '../ScheduleItemForm/ScheduleItemForm';
+import React from 'react';
+import { FormikHelpers, FormikValues } from 'formik';
+import {
+  HandleApiResponse,
+  SharedFormButtonsProps,
+} from '../../../_shared/components';
+import { useGetNewTabsForUserQuery } from '../../api/curated-corpus-api/generatedTypes';
+
+interface ScheduleItemFormConnectorProps {
+  /**
+   * The UUID of the Approved Curated Item about to be scheduled.
+   */
+  approvedItemExternalId: string;
+
+  /**
+   * What do we do with the submitted data?
+   */
+  onSubmit: (
+    values: FormikValues,
+    formikHelpers: FormikHelpers<any>
+  ) => void | Promise<any>;
+}
+
+export const ScheduleItemFormConnector: React.FC<
+  ScheduleItemFormConnectorProps & SharedFormButtonsProps
+> = (props) => {
+  const { approvedItemExternalId, onCancel, onSubmit } = props;
+
+  // Get the list of New Tabs the currently logged-in user has access to.
+  const { data, loading, error } = useGetNewTabsForUserQuery();
+
+  return (
+    <>
+      {!data && <HandleApiResponse loading={loading} error={error} />}
+      {data && (
+        <ScheduleItemForm
+          approvedItemExternalId={approvedItemExternalId}
+          newTabs={data?.getNewTabsForUser}
+          onSubmit={onSubmit}
+          onCancel={onCancel}
+        />
+      )}
+    </>
+  );
+};

--- a/src/curated-corpus/components/ScheduleItemModal/ScheduleItemModal.tsx
+++ b/src/curated-corpus/components/ScheduleItemModal/ScheduleItemModal.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { Modal } from '../../../_shared/components';
-import { Box, Grid, Typography } from '@material-ui/core';
-import { ScheduleItemForm } from '..';
-import { newTabs } from '../../helpers/definitions';
-import { ApprovedCuratedCorpusItem } from '../../api/curated-corpus-api/generatedTypes';
 import { FormikValues } from 'formik';
 import { FormikHelpers } from 'formik/dist/types';
+import { Box, Grid, Typography } from '@material-ui/core';
+import { ApprovedCuratedCorpusItem } from '../../api/curated-corpus-api/generatedTypes';
+import { Modal } from '../../../_shared/components';
+import { ScheduleItemFormConnector } from '../';
 
 interface ScheduleItemModalProps {
   approvedItem: ApprovedCuratedCorpusItem;
@@ -39,9 +38,8 @@ export const ScheduleItemModal: React.FC<ScheduleItemModalProps> = (
           </Box>
         </Grid>
         <Grid item xs={12}>
-          <ScheduleItemForm
+          <ScheduleItemFormConnector
             approvedItemExternalId={approvedItem.externalId}
-            newTabList={newTabs}
             onSubmit={onSave}
             onCancel={() => {
               toggleModal();

--- a/src/curated-corpus/components/index.ts
+++ b/src/curated-corpus/components/index.ts
@@ -15,6 +15,7 @@ export { RejectItemModal } from './RejectItemModal/RejectItemModal';
 export { RejectItemForm } from './RejectItemForm/RejectItemForm';
 export { RemoveItemFromNewTabForm } from './RemoveItemFromNewTabForm/RemoveItemFromNewTabForm';
 export { RemoveItemFromNewTabModal } from './RemoveItemFromNewTabModal/RemoveItemFromNewTabModal';
+export { ScheduleItemFormConnector } from './ScheduleItemFormConnector/ScheduleItemFormConnector';
 export { ScheduleItemForm } from './ScheduleItemForm/ScheduleItemForm';
 export { ScheduleItemModal } from './ScheduleItemModal/ScheduleItemModal';
 export { SplitButton } from './SplitButton/SplitButton';

--- a/src/curated-corpus/helpers/definitions.ts
+++ b/src/curated-corpus/helpers/definitions.ts
@@ -37,35 +37,6 @@ export const prospectFilterOptions: DropdownOption[] = [
   { code: ProspectType.Syndicated, name: 'Syndicated' },
 ];
 
-// New Tab as it exists on Prospect API.
-export type NewTab = {
-  name: string;
-  guid: string;
-  utcOffset: number;
-  prospectTypes: ProspectType[];
-};
-
-// And this can be used for New Tab scheduling dropdowns.
-// 'name' as a display value and 'guid' as actual value sent to the API
-export const newTabs: NewTab[] = [
-  {
-    name: 'en-US',
-    guid: 'EN_US',
-    utcOffset: -4000,
-    prospectTypes: [
-      ProspectType.Global,
-      ProspectType.OrganicTimespent,
-      ProspectType.Syndicated,
-    ],
-  },
-  {
-    name: 'de-DE',
-    guid: 'DE_DE',
-    utcOffset: 1000,
-    prospectTypes: [ProspectType.Global],
-  },
-];
-
 // Language codes. Currently only English and German are needed.
 export const languages: DropdownOption[] = [
   { code: 'EN', name: 'English' },


### PR DESCRIPTION
## Goal

Use an API query that will have SSO built in instead of displaying the list of New Tabs from hard-coded values.

- Added a wrapper component - ScheduleItemFormConnector - that queries the new tab data for user and passes that onto the form.

- Removed hardcoded New Tab values from the repository.

- Updated tests.

Note that in the interests of unblocking other tickets that depend on this update, I have not spent any time on tests for the new component. They are coming though - I've added them to my todo list.

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1254

## Implementation Decisions

Using the Connector pattern (courtesy of @collectedmind who has signed up to be our guiding light out of spaghetti code world) to isolate the query to a single component instead of dumping everything on the page the `ScheduleItemForm` is used.
