### PR TITLE
refactor(isShortLived): [BACK-1253] Change shortLived to timeSensitive

### DIFF
--- a/src/curated-corpus/api/curated-corpus-api/fragments/curatedItemData.ts
+++ b/src/curated-corpus/api/curated-corpus-api/fragments/curatedItemData.ts
@@ -16,7 +16,7 @@ export const CuratedItemData = gql`
     status
     topic
     isCollection
-    isShortLived
+    isTimeSensitive
     isSyndicated
     createdBy
     createdAt

--- a/src/curated-corpus/api/curated-corpus-api/generatedTypes.ts
+++ b/src/curated-corpus/api/curated-corpus-api/generatedTypes.ts
@@ -1,6 +1,5 @@
-import * as Apollo from '@apollo/client';
 import { gql } from '@apollo/client';
-
+import * as Apollo from '@apollo/client';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = {
@@ -54,13 +53,13 @@ export type ApprovedCuratedCorpusItem = {
   imageUrl: Scalars['Url'];
   /** Whether this story is a Pocket Collection. */
   isCollection: Scalars['Boolean'];
-  /**
-   * A flag to ML to not recommend this item long term after it is added to the corpus.
-   * Example: a story covering an election.
-   */
-  isShortLived: Scalars['Boolean'];
   /** Whether this item is a syndicated article. */
   isSyndicated: Scalars['Boolean'];
+  /**
+   * A flag to ML to not recommend this item long term after it is added to the corpus.
+   * Example: a story covering an election, or "The best of 202x" collection.
+   */
+  isTimeSensitive: Scalars['Boolean'];
   /** What language this story is in. This is a two-letter code, for example, 'en' for English. */
   language: Scalars['String'];
   /** The GUID of the corresponding Prospect ID. */
@@ -129,13 +128,13 @@ export type CreateApprovedCuratedCorpusItemInput = {
   imageUrl: Scalars['Url'];
   /** Whether this story is a Pocket Collection. */
   isCollection: Scalars['Boolean'];
-  /**
-   * A flag to ML to not recommend this item long term after it is added to the corpus.
-   * Example: a story covering an election.
-   */
-  isShortLived: Scalars['Boolean'];
   /** Whether this item is a syndicated article. */
   isSyndicated: Scalars['Boolean'];
+  /**
+   * A flag to ML to not recommend this item long term after it is added to the corpus.
+   * Example: a story covering an election, or "The best of 202x" collection.
+   */
+  isTimeSensitive: Scalars['Boolean'];
   /** What language this item is in. This is a two-letter code, for example, 'en' for English. */
   language: Scalars['String'];
   /** Optionally, specify the GUID of the New Tab this item should be scheduled for. */
@@ -523,13 +522,13 @@ export type UpdateApprovedCuratedCorpusItemInput = {
   imageUrl: Scalars['Url'];
   /** Whether this story is a Pocket Collection. */
   isCollection: Scalars['Boolean'];
-  /**
-   * A flag to ML to not recommend this item long term after it is added to the corpus.
-   * Example: a story covering an election.
-   */
-  isShortLived: Scalars['Boolean'];
   /** Whether this item is a syndicated article. */
   isSyndicated: Scalars['Boolean'];
+  /**
+   * A flag to ML to not recommend this item long term after it is added to the corpus.
+   * Example: a story covering an election, or "The best of 202x" collection.
+   */
+  isTimeSensitive: Scalars['Boolean'];
   /** What language this item is in. This is a two-letter code, for example, 'en' for English. */
   language: Scalars['String'];
   /** The GUID of the corresponding Prospect ID. */
@@ -545,8 +544,6 @@ export type UpdateApprovedCuratedCorpusItemInput = {
    * Temporarily a string value that will be provided by Prospect API, possibly an enum in the future.
    */
   topic: Scalars['String'];
-  /** The URL of the Approved Item. */
-  url: Scalars['Url'];
 };
 
 export type CuratedItemDataFragment = {
@@ -562,7 +559,7 @@ export type CuratedItemDataFragment = {
   status: CuratedStatus;
   topic: string;
   isCollection: boolean;
-  isShortLived: boolean;
+  isTimeSensitive: boolean;
   isSyndicated: boolean;
   createdBy: string;
   createdAt: number;
@@ -603,7 +600,7 @@ export type CreateApprovedCuratedCorpusItemMutation = {
     status: CuratedStatus;
     topic: string;
     isCollection: boolean;
-    isShortLived: boolean;
+    isTimeSensitive: boolean;
     isSyndicated: boolean;
     createdBy: string;
     createdAt: number;
@@ -641,7 +638,7 @@ export type CreateNewTabFeedScheduledItemMutation = {
       status: CuratedStatus;
       topic: string;
       isCollection: boolean;
-      isShortLived: boolean;
+      isTimeSensitive: boolean;
       isSyndicated: boolean;
       createdBy: string;
       createdAt: number;
@@ -678,7 +675,7 @@ export type DeleteScheduledItemMutation = {
       status: CuratedStatus;
       topic: string;
       isCollection: boolean;
-      isShortLived: boolean;
+      isTimeSensitive: boolean;
       isSyndicated: boolean;
       createdBy: string;
       createdAt: number;
@@ -707,7 +704,7 @@ export type RejectApprovedItemMutation = {
     status: CuratedStatus;
     topic: string;
     isCollection: boolean;
-    isShortLived: boolean;
+    isTimeSensitive: boolean;
     isSyndicated: boolean;
     createdBy: string;
     createdAt: number;
@@ -756,7 +753,7 @@ export type UpdateApprovedCuratedCorpusItemMutation = {
     status: CuratedStatus;
     topic: string;
     isCollection: boolean;
-    isShortLived: boolean;
+    isTimeSensitive: boolean;
     isSyndicated: boolean;
     createdBy: string;
     createdAt: number;
@@ -810,7 +807,7 @@ export type GetApprovedItemsQuery = {
         status: CuratedStatus;
         topic: string;
         isCollection: boolean;
-        isShortLived: boolean;
+        isTimeSensitive: boolean;
         isSyndicated: boolean;
         createdBy: string;
         createdAt: number;
@@ -904,7 +901,7 @@ export type GetScheduledItemsQuery = {
         status: CuratedStatus;
         topic: string;
         isCollection: boolean;
-        isShortLived: boolean;
+        isTimeSensitive: boolean;
         isSyndicated: boolean;
         createdBy: string;
         createdAt: number;
@@ -928,7 +925,7 @@ export const CuratedItemDataFragmentDoc = gql`
     status
     topic
     isCollection
-    isShortLived
+    isTimeSensitive
     isSyndicated
     createdBy
     createdAt

--- a/src/curated-corpus/components/ApprovedItemCardWrapper/ApprovedItemCardWrapper.test.tsx
+++ b/src/curated-corpus/components/ApprovedItemCardWrapper/ApprovedItemCardWrapper.test.tsx
@@ -25,7 +25,7 @@ describe('The ApprovedItemCardWrapper component', () => {
       status: CuratedStatus.Recommendation,
       isCollection: false,
       isSyndicated: false,
-      isShortLived: false,
+      isTimeSensitive: false,
       createdAt: 1635014926,
       createdBy: 'Amy',
       updatedAt: 1635114926,

--- a/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.test.tsx
+++ b/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.test.tsx
@@ -31,7 +31,7 @@ describe('The ApprovedItemForm component', () => {
       status: CuratedStatus.Recommendation,
       isCollection: false,
       isSyndicated: false,
-      isShortLived: false,
+      isTimeSensitive: false,
       createdAt: 1635014926,
       createdBy: 'Amy',
       updatedAt: 1635114926,
@@ -80,9 +80,9 @@ describe('The ApprovedItemForm component', () => {
     expect(curationStatus).toBeInTheDocument();
     expect(curationStatus).toHaveValue('Recommendation');
 
-    const shortLived = screen.getByLabelText(/Short Lived/);
-    expect(shortLived).toBeInTheDocument();
-    expect(shortLived).toHaveProperty('checked', item.isShortLived);
+    const timeSensitive = screen.getByLabelText(/Time Sensitive/);
+    expect(timeSensitive).toBeInTheDocument();
+    expect(timeSensitive).toHaveProperty('checked', item.isTimeSensitive);
 
     const collection = screen.getByLabelText(/Collection/);
     expect(collection).toBeInTheDocument();

--- a/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.tsx
+++ b/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.tsx
@@ -83,7 +83,7 @@ export const ApprovedItemForm: React.FC<
       language: approvedItemLanguage ?? '',
       topic: approvedItemTopic ?? '',
       curationStatus: approvedItemCorpus ?? '',
-      shortLived: approvedItem.isShortLived,
+      timeSensitive: approvedItem.isTimeSensitive,
       syndicated: approvedItem.isSyndicated,
       collection: approvedItem.isCollection,
       excerpt: approvedItem.excerpt,
@@ -225,11 +225,11 @@ export const ApprovedItemForm: React.FC<
                         control={
                           <Switch
                             color="primary"
-                            checked={formik.values.shortLived}
-                            {...formik.getFieldProps('shortLived')}
+                            checked={formik.values.timeSensitive}
+                            {...formik.getFieldProps('timeSensitive')}
                           />
                         }
-                        label={'Short Lived'}
+                        label={'Time Sensitive'}
                         labelPlacement="end"
                       />
                     </Grid>

--- a/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.validation.tsx
+++ b/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.validation.tsx
@@ -27,7 +27,7 @@ export const validationSchema = yup.object({
     .required('Please add an excerpt.')
     .min(20, 'Excerpt needs to be longer than 20 characters.'),
 
-  shortLived: yup.boolean().required(),
+  timeSensitive: yup.boolean().required(),
 
   imageUrl: yup.string().required('Please upload an image'),
 });

--- a/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.test.tsx
+++ b/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.test.tsx
@@ -25,7 +25,7 @@ describe('The ApprovedItemListCard component', () => {
       status: CuratedStatus.Recommendation,
       isCollection: false,
       isSyndicated: false,
-      isShortLived: false,
+      isTimeSensitive: false,
       createdAt: 1635014926,
       createdBy: 'Amy',
       updatedAt: 1635114926,
@@ -109,14 +109,14 @@ describe('The ApprovedItemListCard component', () => {
 
     expect(screen.queryByText(/collection/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/syndicated/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/short lived/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/time sensitive/i)).not.toBeInTheDocument();
   });
 
   it('should render any extra flags if item has these props set', () => {
     item = {
       ...item,
       isCollection: true,
-      isShortLived: true,
+      isTimeSensitive: true,
       isSyndicated: true,
     };
 
@@ -128,6 +128,6 @@ describe('The ApprovedItemListCard component', () => {
 
     expect(screen.getByText(/collection/i)).toBeInTheDocument();
     expect(screen.getByText(/syndicated/i)).toBeInTheDocument();
-    expect(screen.getByText(/short-lived/i)).toBeInTheDocument();
+    expect(screen.getByText(/time sensitive/i)).toBeInTheDocument();
   });
 });

--- a/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.tsx
+++ b/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.tsx
@@ -116,12 +116,12 @@ export const ApprovedItemListCard: React.FC<ApprovedItemListCardProps> = (
             <ListItemText secondary={'Collection'} />
           </ListItem>
         )}
-        {item.isShortLived && (
+        {item.isTimeSensitive && (
           <ListItem>
             <ListItemIcon className={classes.listItemIcon}>
               <AlarmIcon fontSize="small" />
             </ListItemIcon>
-            <ListItemText secondary={'Short-lived'} />
+            <ListItemText secondary={'Time Sensitive'} />
           </ListItem>
         )}
       </List>

--- a/src/curated-corpus/components/MiniNewTabScheduleCard/MiniNewTabScheduleCard.test.tsx
+++ b/src/curated-corpus/components/MiniNewTabScheduleCard/MiniNewTabScheduleCard.test.tsx
@@ -33,7 +33,7 @@ describe('The MiniNewTabScheduleCard component', () => {
         status: CuratedStatus.Recommendation,
         isCollection: false,
         isSyndicated: false,
-        isShortLived: false,
+        isTimeSensitive: false,
         createdAt: 1635014926,
         createdBy: 'Amy',
         updatedAt: 1635114926,

--- a/src/curated-corpus/components/NewTabGroupedList/NewTabGroupedList.test.tsx
+++ b/src/curated-corpus/components/NewTabGroupedList/NewTabGroupedList.test.tsx
@@ -33,7 +33,7 @@ describe('The NewTabGroupedList component', () => {
         status: CuratedStatus.Recommendation,
         isCollection: false,
         isSyndicated: false,
-        isShortLived: false,
+        isTimeSensitive: false,
         createdAt: 1635014926,
         createdBy: 'Amy',
         updatedAt: 1635114926,

--- a/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.test.tsx
+++ b/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.test.tsx
@@ -32,7 +32,7 @@ describe('The ScheduledItemCardWrapper component', () => {
         status: CuratedStatus.Recommendation,
         isCollection: false,
         isSyndicated: false,
-        isShortLived: false,
+        isTimeSensitive: false,
         createdAt: 1635014926,
         createdBy: 'Amy',
         updatedAt: 1635114926,

--- a/src/curated-corpus/helpers/helperFunctions.ts
+++ b/src/curated-corpus/helpers/helperFunctions.ts
@@ -33,7 +33,7 @@ export const transformProspectToApprovedItem = (
     status: isRecommendation
       ? CuratedStatus.Recommendation
       : CuratedStatus.Corpus,
-    isShortLived: false,
+    isTimeSensitive: false,
     isSyndicated: prospect.isSyndicated ?? false,
     isCollection: prospect.isCollection ?? false,
     excerpt: prospect.excerpt ?? '',

--- a/src/curated-corpus/pages/ApprovedItemsPage/ApprovedItemsPage.tsx
+++ b/src/curated-corpus/pages/ApprovedItemsPage/ApprovedItemsPage.tsx
@@ -226,7 +226,6 @@ export const ApprovedItemsPage: React.FC = (): JSX.Element => {
       data: {
         externalId: currentItem?.externalId,
         prospectId: currentItem?.prospectId,
-        url: values.url,
         title: values.title,
         excerpt: values.excerpt,
         status: curationStatus,
@@ -235,7 +234,7 @@ export const ApprovedItemsPage: React.FC = (): JSX.Element => {
         imageUrl: values.imageUrl,
         topic: topic,
         isCollection: values.collection,
-        isShortLived: values.shortLived,
+        isTimeSensitive: values.timeSensitive,
         isSyndicated: values.syndicated,
       },
     };

--- a/src/curated-corpus/pages/NewTabCurationPage/NewTabCurationPage.tsx
+++ b/src/curated-corpus/pages/NewTabCurationPage/NewTabCurationPage.tsx
@@ -305,7 +305,7 @@ export const NewTabCurationPage: React.FC = (): JSX.Element => {
       imageUrl: imageUrl,
       topic: topic,
       isCollection: values.collection,
-      isShortLived: values.shortLived,
+      isTimeSensitive: values.timeSensitive,
       isSyndicated: values.syndicated,
     };
 


### PR DESCRIPTION
## Goal

Refactor the front-end variables and form display text from `isShortLived / Short-Lived` to `isTimeSensitive / Time Sensitive` 

#### Related Back-end PR:
https://github.com/Pocket/curated-corpus-api/pull/364#pullrequestreview-844829535

Tickets:

- [BACK-1253](https://getpocket.atlassian.net/browse/BACK-1253)

#### Screen shot
![Screen Shot 2022-01-05 at 12 58 14 PM](https://user-images.githubusercontent.com/16694733/148265963-2d93c997-f208-43b7-a113-d10ea6b7bd5d.png)

