### PR TITLE
refactor(approvedItemForm): BACK-1259 remove isCollection and isSyndicated fields from edit form submission

### DIFF
--- a/src/curated-corpus/api/curated-corpus-api/generatedTypes.ts
+++ b/src/curated-corpus/api/curated-corpus-api/generatedTypes.ts
@@ -520,10 +520,6 @@ export type UpdateApprovedCuratedCorpusItemInput = {
   externalId: Scalars['ID'];
   /** The image URL for this item's accompanying picture. */
   imageUrl: Scalars['Url'];
-  /** Whether this story is a Pocket Collection. */
-  isCollection: Scalars['Boolean'];
-  /** Whether this item is a syndicated article. */
-  isSyndicated: Scalars['Boolean'];
   /**
    * A flag to ML to not recommend this item long term after it is added to the corpus.
    * Example: a story covering an election, or "The best of 202x" collection.

--- a/src/curated-corpus/pages/ApprovedItemsPage/ApprovedItemsPage.tsx
+++ b/src/curated-corpus/pages/ApprovedItemsPage/ApprovedItemsPage.tsx
@@ -233,9 +233,7 @@ export const ApprovedItemsPage: React.FC = (): JSX.Element => {
         publisher: values.publisher,
         imageUrl: values.imageUrl,
         topic: topic,
-        isCollection: values.collection,
         isTimeSensitive: values.timeSensitive,
-        isSyndicated: values.syndicated,
       },
     };
 


### PR DESCRIPTION
## Goal

Remove the `isCollection` and `isSyndicated` fields from the edit form submission since they're not required for the update approved item mutation input.

- [Link to JIRA tickets](https://getpocket.atlassian.net/browse/BACK-1259)