### PR TITLE
fix(schedule): stop caching schedule data

### DIFF
--- a/src/curated-corpus/pages/NewTabCurationPage/NewTabCurationPage.tsx
+++ b/src/curated-corpus/pages/NewTabCurationPage/NewTabCurationPage.tsx
@@ -125,6 +125,7 @@ export const NewTabCurationPage: React.FC = (): JSX.Element => {
     data: dataScheduled,
     refetch: refetchScheduled,
   } = useGetScheduledItemsQuery({
+    fetchPolicy: 'no-cache',
     notifyOnNetworkStatusChange: true,
     variables: {
       filters: {

--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -77,6 +77,7 @@ export const SchedulePage: React.FC = (): JSX.Element => {
   // for this New Tab
   const { loading, error, data, fetchMore, refetch } =
     useGetScheduledItemsQuery({
+      fetchPolicy: 'no-cache',
       notifyOnNetworkStatusChange: true,
       variables: {
         filters: {


### PR DESCRIPTION
## Goal

keep schedule data up to date and fix a bug where navigating away from and back to the schedule page could show data for a different new tab.

steps to check:

- schedule an item and immediately navigate to both the schedule page and the prospect page. both schedules should show the item you just scheduled.
- on the schedule page, switch to de-de. navigate away from the page and back again - the selector should be en-US and the data should be en-US.

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1243

## Implementation Decisions

from the ticket:

> after looking at this ticket for a bit, i think we can solve most of the issues with implementing a no-cache policy on schedule queries. because seeing up to date schedule data is a core feature of the schedule views, this data should only be lightly cached anyway. couple that with our very low user base and low/negligible system strain to re-fetch every time, we can keep code simple.
