### PR TITLE
feat(scheduling): Show how many stories are scheduled on the calendar [BACK-1263]

### DIFF
--- a/src/curated-corpus/api/curated-corpus-api/generatedTypes.ts
+++ b/src/curated-corpus/api/curated-corpus-api/generatedTypes.ts
@@ -11,7 +11,7 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]: Maybe<T[SubKey]>;
 };
-const defaultOptions = {};
+const defaultOptions = {} as const;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -864,6 +864,20 @@ export type GetRejectedItemsQuery = {
   };
 };
 
+export type GetScheduledItemCountsQueryVariables = Exact<{
+  filters: ScheduledCuratedCorpusItemsFilterInput;
+}>;
+
+export type GetScheduledItemCountsQuery = {
+  __typename?: 'Query';
+  getScheduledCuratedCorpusItems: Array<{
+    __typename?: 'ScheduledCuratedCorpusItemsResult';
+    collectionCount: number;
+    syndicatedCount: number;
+    totalCount: number;
+  }>;
+};
+
 export type GetScheduledItemsQueryVariables = Exact<{
   filters: ScheduledCuratedCorpusItemsFilterInput;
 }>;
@@ -1545,6 +1559,68 @@ export type GetRejectedItemsLazyQueryHookResult = ReturnType<
 export type GetRejectedItemsQueryResult = Apollo.QueryResult<
   GetRejectedItemsQuery,
   GetRejectedItemsQueryVariables
+>;
+export const GetScheduledItemCountsDocument = gql`
+  query getScheduledItemCounts(
+    $filters: ScheduledCuratedCorpusItemsFilterInput!
+  ) {
+    getScheduledCuratedCorpusItems(filters: $filters) {
+      collectionCount
+      syndicatedCount
+      totalCount
+    }
+  }
+`;
+
+/**
+ * __useGetScheduledItemCountsQuery__
+ *
+ * To run a query within a React component, call `useGetScheduledItemCountsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetScheduledItemCountsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetScheduledItemCountsQuery({
+ *   variables: {
+ *      filters: // value for 'filters'
+ *   },
+ * });
+ */
+export function useGetScheduledItemCountsQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetScheduledItemCountsQuery,
+    GetScheduledItemCountsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetScheduledItemCountsQuery,
+    GetScheduledItemCountsQueryVariables
+  >(GetScheduledItemCountsDocument, options);
+}
+export function useGetScheduledItemCountsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetScheduledItemCountsQuery,
+    GetScheduledItemCountsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetScheduledItemCountsQuery,
+    GetScheduledItemCountsQueryVariables
+  >(GetScheduledItemCountsDocument, options);
+}
+export type GetScheduledItemCountsQueryHookResult = ReturnType<
+  typeof useGetScheduledItemCountsQuery
+>;
+export type GetScheduledItemCountsLazyQueryHookResult = ReturnType<
+  typeof useGetScheduledItemCountsLazyQuery
+>;
+export type GetScheduledItemCountsQueryResult = Apollo.QueryResult<
+  GetScheduledItemCountsQuery,
+  GetScheduledItemCountsQueryVariables
 >;
 export const GetScheduledItemsDocument = gql`
   query getScheduledItems($filters: ScheduledCuratedCorpusItemsFilterInput!) {

--- a/src/curated-corpus/api/curated-corpus-api/queries/getScheduledItemCounts.ts
+++ b/src/curated-corpus/api/curated-corpus-api/queries/getScheduledItemCounts.ts
@@ -1,0 +1,13 @@
+import { gql } from '@apollo/client';
+
+export const getScheduledItemCounts = gql`
+  query getScheduledItemCounts(
+    $filters: ScheduledCuratedCorpusItemsFilterInput!
+  ) {
+    getScheduledCuratedCorpusItems(filters: $filters) {
+      collectionCount
+      syndicatedCount
+      totalCount
+    }
+  }
+`;

--- a/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.test.tsx
+++ b/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.test.tsx
@@ -7,6 +7,7 @@ import {
   NewTab,
   ProspectType,
 } from '../../api/curated-corpus-api/generatedTypes';
+import { DateTime } from 'luxon';
 
 describe('The ScheduleItemForm component', () => {
   const handleSubmit = jest.fn();
@@ -35,6 +36,9 @@ describe('The ScheduleItemForm component', () => {
     render(
       <MuiPickersUtilsProvider utils={LuxonUtils}>
         <ScheduleItemForm
+          handleDateChange={jest.fn()}
+          lookupCopy=""
+          selectedDate={DateTime.local()}
           onSubmit={handleSubmit}
           newTabs={newTabs}
           approvedItemExternalId={'123abc'}
@@ -51,6 +55,9 @@ describe('The ScheduleItemForm component', () => {
     render(
       <MuiPickersUtilsProvider utils={LuxonUtils}>
         <ScheduleItemForm
+          handleDateChange={jest.fn()}
+          lookupCopy=""
+          selectedDate={DateTime.local()}
           onSubmit={handleSubmit}
           newTabs={newTabs}
           approvedItemExternalId={'123abc'}

--- a/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.tsx
+++ b/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.tsx
@@ -1,7 +1,6 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Box, Grid, LinearProgress, TextField } from '@material-ui/core';
 import { FormikHelpers, FormikValues, useFormik } from 'formik';
-import { DateTime } from 'luxon';
 import { DatePicker } from '@material-ui/pickers';
 import {
   FormikSelectField,
@@ -11,6 +10,7 @@ import {
 import { getValidationSchema } from './ScheduleItemForm.validation';
 import { MaterialUiPickersDate } from '@material-ui/pickers/typings/date';
 import { NewTab } from '../../api/curated-corpus-api/generatedTypes';
+import { DateTime } from 'luxon';
 
 interface ScheduleItemFormProps {
   /**
@@ -19,9 +19,41 @@ interface ScheduleItemFormProps {
   approvedItemExternalId: string;
 
   /**
+   * What to do when the user picks a date.
+   */
+  handleDateChange: (
+    date: MaterialUiPickersDate,
+    value?: string | null | undefined
+  ) => void;
+
+  /**
+   * The copy/JSX to show underneath the form when the user picks a date
+   * and a call to the API is triggered to look up whether any other
+   * items have been scheduled for this date.
+   */
+  lookupCopy: JSX.Element | string;
+
+  /**
    * The list of New Tabs the logged-in user has access to.
    */
   newTabs: NewTab[];
+
+  /**
+   * If a default value for the New Tab dropdown needs to be set,
+   * here is the place to specify it.
+   */
+  newTabGuid?: string;
+
+  /**
+   *
+   */
+  disableNewTab?: boolean;
+
+  /**
+   *
+   * Note that null is an option here to keep MUI types happy, nothing else.
+   */
+  selectedDate: DateTime | null;
 
   /**
    * What do we do with the submitted data?
@@ -35,28 +67,23 @@ interface ScheduleItemFormProps {
 export const ScheduleItemForm: React.FC<
   ScheduleItemFormProps & SharedFormButtonsProps
 > = (props): JSX.Element => {
-  const { approvedItemExternalId, newTabs, onCancel, onSubmit } = props;
+  const {
+    approvedItemExternalId,
+    handleDateChange,
+    lookupCopy,
+    newTabs,
+    newTabGuid,
+    disableNewTab = false,
+    selectedDate,
+    onCancel,
+    onSubmit,
+  } = props;
 
-  // Set the default scheduled date to tomorrow.
-  // Do we need to worry about timezones here? .local() returns the date
-  // in the user locale, not the UTC date.
   const tomorrow = DateTime.local().plus({ days: 1 });
-
-  // Save the date in a state var as the submitted form will contain
-  // a formatted string instead of a luxon object. Would like to work with the luxon
-  // object instead of parsing the date from string.
-  const [selectedDate, setSelectedDate] = useState<DateTime | null>(tomorrow);
-
-  const handleDateChange = (
-    date: MaterialUiPickersDate,
-    value?: string | null | undefined
-  ) => {
-    setSelectedDate(date);
-  };
 
   const formik = useFormik({
     initialValues: {
-      newTabGuid: '',
+      newTabGuid,
       approvedItemExternalId,
       scheduledDate: selectedDate,
     },
@@ -80,6 +107,7 @@ export const ScheduleItemForm: React.FC<
             <FormikSelectField
               id="newTabGuid"
               label="Choose a New Tab"
+              disabled={disableNewTab}
               fieldProps={formik.getFieldProps('newTabGuid')}
               fieldMeta={formik.getFieldMeta('newTabGuid')}
             >
@@ -131,6 +159,13 @@ export const ScheduleItemForm: React.FC<
 
         <SharedFormButtons onCancel={onCancel} />
       </form>
+      <Grid container spacing={3}>
+        <Grid item xs={12}>
+          <Box display="flex" justifyContent="center" mt={2} mb={1}>
+            <h3>{lookupCopy}</h3>
+          </Box>
+        </Grid>
+      </Grid>
     </>
   );
 };

--- a/src/curated-corpus/components/ScheduleItemFormConnector/ScheduleItemFormConnector.tsx
+++ b/src/curated-corpus/components/ScheduleItemFormConnector/ScheduleItemFormConnector.tsx
@@ -1,17 +1,31 @@
 import { ScheduleItemForm } from '../ScheduleItemForm/ScheduleItemForm';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { FormikHelpers, FormikValues } from 'formik';
 import {
   HandleApiResponse,
   SharedFormButtonsProps,
 } from '../../../_shared/components';
-import { useGetNewTabsForUserQuery } from '../../api/curated-corpus-api/generatedTypes';
+import {
+  ScheduledCuratedCorpusItemsFilterInput,
+  useGetNewTabsForUserQuery,
+  useGetScheduledItemCountsLazyQuery,
+} from '../../api/curated-corpus-api/generatedTypes';
+import { DateTime } from 'luxon';
+import { MaterialUiPickersDate } from '@material-ui/pickers/typings/date';
+import { ApolloError } from '@apollo/client';
+import { useNotifications } from '../../../_shared/hooks';
+import { CircularProgress } from '@material-ui/core';
 
 interface ScheduleItemFormConnectorProps {
   /**
    * The UUID of the Approved Curated Item about to be scheduled.
    */
   approvedItemExternalId: string;
+
+  /**
+   * The GUID of the New Tab if one's been sent through.
+   */
+  newTabGuid?: string;
 
   /**
    * What do we do with the submitted data?
@@ -25,10 +39,93 @@ interface ScheduleItemFormConnectorProps {
 export const ScheduleItemFormConnector: React.FC<
   ScheduleItemFormConnectorProps & SharedFormButtonsProps
 > = (props) => {
-  const { approvedItemExternalId, onCancel, onSubmit } = props;
+  const { approvedItemExternalId, newTabGuid, onCancel, onSubmit } = props;
 
   // Get the list of New Tabs the currently logged-in user has access to.
   const { data, loading, error } = useGetNewTabsForUserQuery();
+
+  // Set the default scheduled date to tomorrow.
+  // Do we need to worry about timezones here? .local() returns the date
+  // in the user locale, not the UTC date.
+  const tomorrow = DateTime.local().plus({ days: 1 });
+
+  // Save the date in a state var as the submitted form will contain
+  // a formatted string instead of a luxon object. Would like to work with the luxon
+  // object instead of parsing the date from string.
+  const [selectedDate, setSelectedDate] = useState<DateTime | null>(tomorrow);
+
+  // Start with no copy underneath the form that shows if there are any other
+  // scheduled items for the chosen date.
+  const [lookupCopy, setLookupCopy] = useState<JSX.Element | string>('');
+
+  // get a helper function to show an error in case scheduled item lookup fails.
+  const { showNotification } = useNotifications();
+
+  // Get the usual API response vars and a helper method to retrieve data
+  // that can be used inside hooks.
+  const [getScheduledItemCounts, { loading: loadingCounts }] =
+    useGetScheduledItemCountsLazyQuery({
+      fetchPolicy: 'no-cache',
+      notifyOnNetworkStatusChange: true,
+      onCompleted: (data) => {
+        // If there's something already scheduled for the chosen date,
+        // let the user know.
+        if (data.getScheduledCuratedCorpusItems.length > 0) {
+          const totalCount = data.getScheduledCuratedCorpusItems[0].totalCount;
+
+          setLookupCopy(
+            <>
+              Already scheduled: {totalCount}{' '}
+              {totalCount === 1 ? 'story' : 'stories'} (
+              {data.getScheduledCuratedCorpusItems[0].syndicatedCount}{' '}
+              syndicated).
+            </>
+          );
+        } else {
+          setLookupCopy('Nothing has been scheduled for this date yet.');
+        }
+      },
+      onError: (error: ApolloError) => {
+        showNotification(error.message, 'error');
+      },
+    });
+
+  // What to do when the user clicks on a date in the calendar.
+  const handleDateChange = (
+    date: MaterialUiPickersDate,
+    value?: string | null | undefined
+  ) => {
+    // Keep track of the chosen date.
+    setSelectedDate(date);
+
+    // If the New Tab has been specified, run a lookup query.
+    // Realistically, this means that the lookup will be available on the Prospecting
+    // page but not on the Corpus page.
+    if (newTabGuid) {
+      // Look up any other scheduled items for this date + new tab combination.
+      // Start with the filters. Note `startDate` and `endDate` is the same as we're
+      // interested in single day data only.
+      const filters: ScheduledCuratedCorpusItemsFilterInput = {
+        newTabGuid,
+        startDate: date?.toFormat('yyyy-MM-dd'),
+        endDate: date?.toFormat('yyyy-MM-dd'),
+      };
+
+      getScheduledItemCounts({ variables: { filters } });
+    }
+  };
+
+  // There seems to be no better way of tracking this and passing it
+  // to the child form component ¯\_(ツ)_/¯.
+  useEffect(() => {
+    if (loadingCounts) {
+      setLookupCopy(
+        <>
+          <CircularProgress /> Checking...
+        </>
+      );
+    }
+  }, [loadingCounts]);
 
   return (
     <>
@@ -36,7 +133,12 @@ export const ScheduleItemFormConnector: React.FC<
       {data && (
         <ScheduleItemForm
           approvedItemExternalId={approvedItemExternalId}
+          handleDateChange={handleDateChange}
+          lookupCopy={lookupCopy}
           newTabs={data?.getNewTabsForUser}
+          newTabGuid={newTabGuid}
+          disableNewTab={!!newTabGuid}
+          selectedDate={selectedDate}
           onSubmit={onSubmit}
           onCancel={onCancel}
         />

--- a/src/curated-corpus/components/ScheduleItemModal/ScheduleItemModal.tsx
+++ b/src/curated-corpus/components/ScheduleItemModal/ScheduleItemModal.tsx
@@ -10,6 +10,7 @@ interface ScheduleItemModalProps {
   approvedItem: ApprovedCuratedCorpusItem;
   headingCopy?: string;
   isOpen: boolean;
+  newTabGuid?: string;
   onSave: (
     values: FormikValues,
     formikHelpers: FormikHelpers<any>
@@ -24,6 +25,7 @@ export const ScheduleItemModal: React.FC<ScheduleItemModalProps> = (
     approvedItem,
     headingCopy = 'Schedule this item for New Tab',
     isOpen,
+    newTabGuid,
     onSave,
     toggleModal,
   } = props;
@@ -47,6 +49,7 @@ export const ScheduleItemModal: React.FC<ScheduleItemModalProps> = (
         <Grid item xs={12}>
           <ScheduleItemFormConnector
             approvedItemExternalId={approvedItem.externalId}
+            newTabGuid={newTabGuid}
             onSubmit={onSave}
             onCancel={() => {
               toggleModal();

--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -468,6 +468,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
           approvedItem={approvedItem}
           headingCopy="Optional: schedule this item for New Tab"
           isOpen={scheduleModalOpen}
+          newTabGuid={currentNewTabGuid}
           onSave={onScheduleSave}
           toggleModal={toggleScheduleModal}
         />


### PR DESCRIPTION
## Goal

On the Prospecting page, the optional scheduling modal now locks in the New Tab value to the New Tab the user is prospecting for. On choosing a date, there's a call to the API that displays how many other stories have been scheduled for that date.

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1263

## Video Walkthrough

https://user-images.githubusercontent.com/22447785/150520128-2ecd6a41-5acb-4125-ad16-a4a6e83aa20b.mov

