### PR TITLE
fix(scheduling): Refresh sidebar on scheduling a prospect [BACK-1265]

### DIFF
--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -417,10 +417,23 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
         DateTime.DATE_FULL
       )}`,
       () => {
-        toggleScheduleModal();
+        // Hide the loading indicator
         formikHelpers.setSubmitting(false);
+
+        // Hide the Schedule Item Form modal
+        toggleScheduleModal();
+
+        // Refresh the sidebar if the story was scheduled for today or tomorrow
+        if (
+          [startDate, endDate].includes(
+            values.scheduledDate.toFormat('yyyy-MM-dd')
+          )
+        ) {
+          refetchScheduled();
+        }
       },
       () => {
+        // Hide the loading indicator
         formikHelpers.setSubmitting(false);
       }
     );


### PR DESCRIPTION
## Goal

Whenever we schedule a story straight from the Prospecting page, we need to refetch the query that powers the sidebar that shows today and tomorrow's scheduled items for a given New Tab.

Fixed & added comments to callback functions.

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1265

## Video Walkthrough


https://user-images.githubusercontent.com/22447785/150221574-c21cb5f4-f9b5-4fae-b092-c8dbf5d2abc6.mov


