### PR TITLE
feat(pageNotFound): [BACK-1302] add a 404 page and fix log out

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { SnackbarProvider } from 'notistack';
 import theme from './theme';
 
 import { LandingPage } from './_shared/pages';
+import { PageNotFound } from './_shared/components/';
 import { CollectionsLandingPage } from './collections/pages';
 import { CuratedCorpusLandingPage } from './curated-corpus/pages';
 import { useMozillaAuth } from './_shared/hooks';
@@ -51,6 +52,7 @@ function App(): JSX.Element {
                     <CuratedCorpusLandingPage />
                   </Route>
                 )}
+                <Route path="*" component={PageNotFound} />
               </Switch>
             </>
           </BrowserRouter>

--- a/src/SecuredApp.tsx
+++ b/src/SecuredApp.tsx
@@ -24,7 +24,6 @@ const SecuredApp = (): JSX.Element => {
   const { authService } = useAuth();
 
   const login = async () => authService.authorize();
-  const logout = async () => authService.logout();
 
   if (authService.isPending()) {
     return <div>Loading...</div>;
@@ -63,7 +62,6 @@ const SecuredApp = (): JSX.Element => {
 
   return (
     <div>
-      <button onClick={logout}>Logout</button>
       <App />
     </div>
   );

--- a/src/_shared/components/HeaderConnector/HeaderConnector.tsx
+++ b/src/_shared/components/HeaderConnector/HeaderConnector.tsx
@@ -30,7 +30,7 @@ export const HeaderConnector: React.FC<HeaderConnectorProps> = (
     <Header
       hasUser={authService.getUser() != null}
       onLogout={() => {
-        authService.logout(true);
+        authService.logout();
       }}
       menuLinks={menuLinks}
       parsedIdToken={parsedIdToken}

--- a/src/_shared/components/PageNotFound/PageNotFound.tsx
+++ b/src/_shared/components/PageNotFound/PageNotFound.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export const PageNotFound = (): JSX.Element => {
+  return (
+    <>
+      <h2> Oops something went wrong </h2>
+      <p>
+        The page you&apos;re looking for does not exist or is currently
+        inaccessible
+      </p>
+      <a href="/"> Go back to home page </a>
+    </>
+  );
+};

--- a/src/_shared/components/index.ts
+++ b/src/_shared/components/index.ts
@@ -20,3 +20,4 @@ export { TabPanel } from './TabPanel/TabPanel';
 export { TabSet } from './TabSet/TabSet';
 export type { CustomTabType } from './TabSet/TabSet';
 export { ImageUpload } from '../../curated-corpus/components/ImageUpload/ImageUpload';
+export { PageNotFound } from '../components/PageNotFound/PageNotFound';


### PR DESCRIPTION
## Goal

Fine tune auth control on the front-end by showing a 404 page if an user tries to access a tool they don't have access to. We also show this 404 if they enter an incorrect route.

**As an aside**, we've also fixed the broken logout.

Tickets:
- [BACK-1302]

### Screen capture
https://user-images.githubusercontent.com/16694733/154106605-61b7f06e-510d-43c7-83e8-f926d88fb9cd.mov





[BACK-1302]: https://getpocket.atlassian.net/browse/BACK-1302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ