### PR TITLE
fix(editing): Articles not having topics assigned to them [BACK-1335]

### DIFF
--- a/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.test.tsx
+++ b/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.test.tsx
@@ -6,6 +6,7 @@ import { SnackbarProvider } from 'notistack';
 import {
   ApprovedCuratedCorpusItem,
   CuratedStatus,
+  Topics,
 } from '../../../api/generatedTypes';
 import { ApprovedItemForm } from './ApprovedItemForm';
 import { uploadApprovedItemImage } from '../../../api/mutations/uploadApprovedItemImage';
@@ -25,9 +26,9 @@ describe('The ApprovedItemForm component', () => {
       imageUrl: 'https://placeimg.com/640/480/people?random=494',
       excerpt:
         'Everything You Wanted to Know About React and Were Afraid To Ask',
-      language: 'de',
+      language: 'DE',
       publisher: 'Amazing Inventions',
-      topic: 'TECHNOLOGY',
+      topic: Topics.HealthFitness,
       status: CuratedStatus.Recommendation,
       isCollection: false,
       isSyndicated: false,
@@ -68,17 +69,31 @@ describe('The ApprovedItemForm component', () => {
     expect(excerpt).toBeInTheDocument();
     expect(excerpt).toHaveValue(item.excerpt);
 
+    // Check for the value we send to the API ("DE" here)
     const language = screen.getByLabelText(/Language/);
     expect(language).toBeInTheDocument();
-    expect(language).toHaveValue('German');
+    expect(language).toHaveValue(item.language);
 
+    // Make sure the display name for this language is correct, too ("German")
+    // (need to check both for a select field!)
+    const displayLanguage = screen.getByDisplayValue(/German/);
+    expect(displayLanguage).toBeInTheDocument();
+
+    // Check for the value we send to the API ("HEALTH_FITNESS" here)
     const topic = screen.getByLabelText(/Topic/);
     expect(topic).toBeInTheDocument();
-    expect(topic).toHaveValue('Technology');
+    expect(topic).toHaveValue(Topics.HealthFitness);
+    // Make sure the display name for this topic is correct, too ("Health & Fitness")
+    const displayTopic = screen.getByDisplayValue(/Health & Fitness/);
+    expect(displayTopic).toBeInTheDocument();
 
+    // Check for the field value ("RECOMMENDATION" here)
     const curationStatus = screen.getByLabelText(/Curation Status/);
     expect(curationStatus).toBeInTheDocument();
-    expect(curationStatus).toHaveValue('Recommendation');
+    expect(curationStatus).toHaveValue(CuratedStatus.Recommendation);
+    // Make sure the display name is correct, too ("Recommendation")
+    const displayStatus = screen.getByDisplayValue(/Recommendation/);
+    expect(displayStatus).toBeInTheDocument();
 
     const timeSensitive = screen.getByLabelText(/Time Sensitive/);
     expect(timeSensitive).toBeInTheDocument();

--- a/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.tsx
+++ b/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { FormikHelpers, FormikValues, useFormik } from 'formik';
 import { validationSchema } from './ApprovedItemForm.validation';
-import { ApprovedCuratedCorpusItem } from '../../../api/generatedTypes';
+import {
+  ApprovedCuratedCorpusItem,
+  CuratedStatus,
+} from '../../../api/generatedTypes';
 import {
   curationStatusOptions,
   DropdownOption,
@@ -67,28 +70,18 @@ export const ApprovedItemForm: React.FC<
     onImageSave: onImageSaveFromParent,
   } = props;
 
-  const approvedItemCorpus = curationStatusOptions.find(
-    (item) => item.code === approvedItem.status
-  )?.name;
-
-  const approvedItemTopic = topics.find(
-    (item) => item.code === approvedItem.topic
-  )?.name;
-
-  const approvedItemLanguage = languages.find(
-    (item) => item.code.toLowerCase() === approvedItem.language
-  )?.name;
-
   const formik = useFormik({
     initialValues: {
       url: approvedItem.url,
       title: approvedItem.title,
       publisher: approvedItem.publisher,
-      language: approvedItemLanguage ?? '',
-      topic: approvedItemTopic ?? '',
+      // The language code may be coming in pre-filled from the prospect in this form
+      // and there it's in lower case, e.g. "en" rather than "EN".
+      language: approvedItem.language.toUpperCase() ?? '',
+      topic: approvedItem.topic ?? '',
       curationStatus: isRecommendation
-        ? 'Recommendation'
-        : approvedItemCorpus ?? '',
+        ? CuratedStatus.Recommendation
+        : approvedItem.status ?? '',
       timeSensitive: approvedItem.isTimeSensitive,
       syndicated: approvedItem.isSyndicated,
       collection: approvedItem.isCollection,
@@ -184,7 +177,7 @@ export const ApprovedItemForm: React.FC<
                         <option aria-label="None" />
                         {languages.map((language: DropdownOption) => {
                           return (
-                            <option value={language.name} key={language.code}>
+                            <option value={language.code} key={language.code}>
                               {language.name}
                             </option>
                           );
@@ -201,7 +194,7 @@ export const ApprovedItemForm: React.FC<
                         <option aria-label="None" value="" />
                         {topics.map((topic: DropdownOption) => {
                           return (
-                            <option value={topic.name} key={topic.code}>
+                            <option value={topic.code} key={topic.code}>
                               {topic.name}
                             </option>
                           );
@@ -218,7 +211,7 @@ export const ApprovedItemForm: React.FC<
                         <option aria-label="None" value="" />
                         {curationStatusOptions.map((corpus: DropdownOption) => {
                           return (
-                            <option value={corpus.name} key={corpus.code}>
+                            <option value={corpus.code} key={corpus.code}>
                               {corpus.name}
                             </option>
                           );

--- a/src/curated-corpus/helpers/helperFunctions.ts
+++ b/src/curated-corpus/helpers/helperFunctions.ts
@@ -8,21 +8,6 @@ import {
   Prospect,
   UrlMetadata,
 } from '../../api/generatedTypes';
-/**
- *
- * This is a helper file that contains some helper functions. Right now
- * it only has one but we could add more to it
- */
-/**
- *
- * This is a helper file that contains some helper functions. Right now
- * it only has one but we could add more to it
- */
-/**
- *
- * This is a helper file that contains some helper functions. Right now
- * it only has one but we could add more to it
- */
 
 /**
  *
@@ -103,21 +88,17 @@ export const transformFormInputToCreateApprovedItemInput = (
   values: FormikValues,
   prospectId?: string
 ): CreateApprovedCuratedCorpusItemInput => {
-  const languageCode = values.language === 'English' ? 'en' : 'de';
-  const curationStatus = values.curationStatus.toUpperCase();
-  const topic = values.topic.toUpperCase();
-
   return {
     prospectId:
       prospectId || uuidv5(values.url, '9edace02-b9c6-4705-a0d6-16476438557b'),
     url: values.url,
     title: values.title,
     excerpt: values.excerpt,
-    status: curationStatus,
-    language: languageCode,
+    status: values.curationStatus,
+    language: values.language,
     publisher: values.publisher,
     imageUrl: values.imageUrl,
-    topic,
+    topic: values.topic,
     isCollection: values.collection,
     isTimeSensitive: values.timeSensitive,
     isSyndicated: values.syndicated,

--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -321,9 +321,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
     formikHelpers: FormikHelpers<any>
   ): Promise<void> => {
     //build an approved item
-    const languageCode: string = values.language === 'English' ? 'en' : 'de';
-    const curationStatus = values.curationStatus.toUpperCase();
-    const topic: string = values.topic.toUpperCase();
+
     const imageUrl: string = s3ImageUrl;
 
     const approvedItem = {
@@ -331,11 +329,11 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
       url: values.url,
       title: values.title,
       excerpt: values.excerpt,
-      status: curationStatus,
-      language: languageCode,
+      status: values.curationStatus,
+      language: values.language,
       publisher: values.publisher,
       imageUrl,
-      topic,
+      topic: values.topic,
       isCollection: values.collection,
       isTimeSensitive: values.timeSensitive,
       isSyndicated: values.syndicated,


### PR DESCRIPTION

## Goal

Fix a bug where for some prospects (initially thought to be syndicated articles) the topic appeared to be saved when the prospect was recommended but it wasn't showing up on the card of this item on the Corpus page.

Narrowed down the initial bug report to multi-word topic names: instead of saving `HEALTH_FITNESS` on the backend, for example, the frontend was sending through `HEALTH & FITNESS` to the API, capitalising the display name instead of using the enum code from the shared data.

- Updated the `topic` select in the `ApprovedItemForm` component, and made similar changes to the `language` and `curationStatus` selects. Updated tests to check both option values and display values for all three fields.

## Reference

- https://getpocket.atlassian.net/browse/BACK-1335

