### PR TITLE
feat(UI): [BACK-1327] Any time we link to an article, open it in a new tab

### DIFF
--- a/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.test.tsx
+++ b/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.test.tsx
@@ -47,6 +47,8 @@ describe('The ApprovedItemListCard component', () => {
     const link = screen.getByRole('link');
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute('href', expect.stringContaining(item.url));
+    // The link also opens in a new tab
+    expect(link).toHaveAttribute('target', expect.stringContaining('_blank'));
 
     // The excerpt is also present
     const excerpt = screen.getByText(/wanted to know about react/i);

--- a/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.tsx
+++ b/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.tsx
@@ -60,7 +60,7 @@ export const ApprovedItemListCard: React.FC<ApprovedItemListCardProps> = (
           align="left"
           gutterBottom
         >
-          <Link href={item.url} className={classes.link}>
+          <Link href={item.url} target="_blank" className={classes.link}>
             {item.title}
           </Link>
         </Typography>

--- a/src/curated-corpus/components/MiniScheduleCard/MiniScheduleCard.test.tsx
+++ b/src/curated-corpus/components/MiniScheduleCard/MiniScheduleCard.test.tsx
@@ -59,6 +59,8 @@ describe('The MiniScheduleCard component', () => {
       'href',
       expect.stringContaining(item.approvedItem.url)
     );
+    // The link also opens in a new tab
+    expect(link).toHaveAttribute('target', expect.stringContaining('_blank'));
 
     // There is a publisher on the page
     const publisher = screen.getByText(item.approvedItem.publisher);

--- a/src/curated-corpus/components/MiniScheduleCard/MiniScheduleCard.tsx
+++ b/src/curated-corpus/components/MiniScheduleCard/MiniScheduleCard.tsx
@@ -42,7 +42,11 @@ export const MiniScheduleCard: React.FC<MiniScheduleCardProps> = (
           align="left"
           gutterBottom
         >
-          <Link href={item.approvedItem.url} className={classes.link}>
+          <Link
+            href={item.approvedItem.url}
+            target="_blank"
+            className={classes.link}
+          >
             {item.approvedItem.title}
           </Link>
         </Typography>

--- a/src/curated-corpus/components/ProspectListCard/ProspectListCard.test.tsx
+++ b/src/curated-corpus/components/ProspectListCard/ProspectListCard.test.tsx
@@ -46,6 +46,8 @@ describe('The ProspectListCard component', () => {
     const link = screen.getByRole('link');
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute('href', expect.stringContaining(prospect.url));
+    // The link also opens in a new tab
+    expect(link).toHaveAttribute('target', expect.stringContaining('_blank'));
 
     // The excerpt is also present
     const excerpt = screen.getByText(/wanted to know about dynamo/i);

--- a/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
+++ b/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
@@ -63,7 +63,7 @@ export const ProspectListCard: React.FC<ProspectListCardProps> = (
           </Typography>
         </Grid>
         <Grid item xs={12} sm={9}>
-          <Link href={prospect.url} className={classes.link}>
+          <Link href={prospect.url} target="_blank" className={classes.link}>
             <Typography
               className={classes.title}
               variant="h3"

--- a/src/curated-corpus/components/RejectedItemListCard/RejectedItemListCard.test.tsx
+++ b/src/curated-corpus/components/RejectedItemListCard/RejectedItemListCard.test.tsx
@@ -36,6 +36,8 @@ describe('The RejectedItemListCard component', () => {
       'href',
       expect.stringContaining(rejectedItem.url)
     );
+    // The link also opens in a new tab
+    expect(link).toHaveAttribute('target', expect.stringContaining('_blank'));
   });
 
   it('should render rejected item card with language', () => {

--- a/src/curated-corpus/components/RejectedItemListCard/RejectedItemListCard.tsx
+++ b/src/curated-corpus/components/RejectedItemListCard/RejectedItemListCard.tsx
@@ -42,7 +42,7 @@ export const RejectedItemListCard: React.FC<RejectedItemListCardProps> = (
           align="left"
           gutterBottom
         >
-          <Link href={item.url} className={classes.link}>
+          <Link href={item.url} target="_blank" className={classes.link}>
             {item.title}
           </Link>
         </Typography>


### PR DESCRIPTION
## Goal

- Updated links to outbound links from the app to have `target="_blank"`.

- Updated unit tests to look out for that in all relevant components.



## Reference

- https://getpocket.atlassian.net/browse/BACK-1327


