### PR TITLE
feat(prospecting): [BACK-1328] Auto focus the item url text box after clicking the manual add item

### DIFF
--- a/src/curated-corpus/components/AddProspectForm/AddProspectForm.tsx
+++ b/src/curated-corpus/components/AddProspectForm/AddProspectForm.tsx
@@ -235,6 +235,7 @@ export const AddProspectForm: React.FC<
               label="Item URL"
               fieldProps={formik.getFieldProps('itemUrl')}
               fieldMeta={formik.getFieldMeta('itemUrl')}
+              autoFocus
             />
 
             <SharedFormButtons onCancel={onCancel} />


### PR DESCRIPTION
## Goal

From the ticket: "When curators click the manual add an item button they want to immediately paste their url into the text field and click submit. Currently they have to first click into the text box to paste the url."

This one-line change fixes the issue.

## Reference

- https://getpocket.atlassian.net/browse/BACK-1328

