### PR TITLE
feat(scheduling): [BACK-1329] Show number of scheduled items for default date on modal

### DIFF
--- a/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.tsx
+++ b/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Box, Grid, LinearProgress, TextField } from '@material-ui/core';
 import { FormikHelpers, FormikValues, useFormik } from 'formik';
 import { DatePicker } from '@material-ui/pickers';
@@ -80,6 +80,13 @@ export const ScheduleItemForm: React.FC<
   } = props;
 
   const tomorrow = DateTime.local().plus({ days: 1 });
+
+  // Run the lookup query for scheduled items on loading the component,
+  // so that users can see straight away how many stories have already
+  // been scheduled for the default date (tomorrow).
+  useEffect(() => {
+    handleDateChange(tomorrow);
+  }, []);
 
   const formik = useFormik({
     initialValues: {


### PR DESCRIPTION
## Goal

Make it easier for the curators to see how many items are already scheduled for the default date (tomorrow) without clicking on another date on the calendar and then clicking back on tomorrow's date again.

Now running the lookup query on initial component load. That does the trick.

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1329

## Video walkthrough


https://user-images.githubusercontent.com/22447785/155953943-ff5d46c0-662c-4709-95c0-eec37d3a1540.mov

