### PR TITLE
feat(vpc): [BACK-1339] move curation tools out of the vpc

### DIFF
--- a/.aws/src/pocketAlbApplication.ts
+++ b/.aws/src/pocketAlbApplication.ts
@@ -79,7 +79,7 @@ export function createPocketAlbApplication(
   });
 
   return new PocketALBApplication(scope, 'application', {
-    internal: true,
+    internal: false, //set to true to put it inside our vpc
     prefix: config.prefix,
     alb6CharacterPrefix: config.shortName,
     tags: config.tags,


### PR DESCRIPTION
## Goal

Moving it outside of our VPC so that users can access it without a VPN now that we have authentication implemented

Tickets:

- [BACK-1339]

[BACK-1339]: https://getpocket.atlassian.net/browse/BACK-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ