### PR TITLE
chore(refactor): [BACK-1330] Refactor manual scheduling workflow to fix a bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,6 @@
         "react-beautiful-dnd": "13.1.0",
         "react-dom": "17.0.2",
         "react-dropzone": "11.5.3",
-        "react-error-overlay": "6.0.10",
         "react-markdown": "6.0.3",
         "react-oauth2-pkce": "2.0.7",
         "react-router-dom": "5.3.0",
@@ -61,7 +60,8 @@
         "eslint-config-prettier": "8.3.0",
         "eslint-plugin-prettier": "4.0.0",
         "eslint-plugin-react": "7.28.0",
-        "prettier": "2.5.1"
+        "prettier": "2.5.1",
+        "react-error-overlay": "^6.0.9"
       }
     },
     "node_modules/@apollo/client": {
@@ -18807,9 +18807,9 @@
       }
     },
     "node_modules/react-error-overlay": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.10.tgz",
-      "integrity": "sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA=="
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
+      "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
     },
     "node_modules/react-fast-compare": {
       "version": "2.0.4",
@@ -38507,9 +38507,9 @@
       }
     },
     "react-error-overlay": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.10.tgz",
-      "integrity": "sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA=="
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
+      "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
     },
     "react-fast-compare": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "react-beautiful-dnd": "13.1.0",
     "react-dom": "17.0.2",
     "react-dropzone": "11.5.3",
-    "react-error-overlay": "6.0.10",
     "react-markdown": "6.0.3",
     "react-oauth2-pkce": "2.0.7",
     "react-router-dom": "5.3.0",
@@ -83,6 +82,7 @@
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-prettier": "4.0.0",
     "eslint-plugin-react": "7.28.0",
-    "prettier": "2.5.1"
+    "prettier": "2.5.1",
+    "react-error-overlay": "^6.0.9"
   }
 }

--- a/src/curated-corpus/components/AddProspectForm/AddProspectForm.test.tsx
+++ b/src/curated-corpus/components/AddProspectForm/AddProspectForm.test.tsx
@@ -3,36 +3,14 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MockedProvider } from '@apollo/client/testing';
 import { SnackbarProvider } from 'notistack';
-
-import { AddProspectModal } from './../AddProspectModal/AddProspectModal';
 import { AddProspectForm } from './AddProspectForm';
 
-import { getApprovedItemByUrl } from '../../../api/queries/getApprovedItemByUrl';
-import { getUrlMetadata } from '../../../api/queries/getUrlMetadata';
-
 describe('The AddProspectForm component', () => {
-  const toggleModal = jest.fn();
+  const onSubmit = jest.fn();
   const onCancel = jest.fn();
 
   it('should render all the form fields and elements', () => {
-    // this test also renders the AddProspectModal component which in turn tests AddProspectModal component
-
-    render(
-      <MockedProvider>
-        <SnackbarProvider maxSnack={3}>
-          <AddProspectModal isOpen={true} toggleModal={toggleModal}>
-            <AddProspectForm
-              toggleAddProspectModal={toggleModal}
-              onCancel={onCancel}
-            />
-          </AddProspectModal>
-        </SnackbarProvider>
-      </MockedProvider>
-    );
-
-    // Check if the modal title is rendered
-    const title = screen.getByText(/add a new curated item/i);
-    expect(title).toBeInTheDocument();
+    render(<AddProspectForm onSubmit={onSubmit} onCancel={onCancel} />);
 
     // Check if form input and buttons are rendered
     const urlInputField = screen.getByLabelText(/item url/i);
@@ -45,21 +23,14 @@ describe('The AddProspectForm component', () => {
     expect(cancelButton).toBeInTheDocument();
   });
 
-  it('should render error message when no url is provided', async () => {
+  it('should render error message when no URL is provided', async () => {
     render(
       <MockedProvider>
         <SnackbarProvider maxSnack={3}>
-          <AddProspectForm
-            toggleAddProspectModal={toggleModal}
-            onCancel={onCancel}
-          />
+          <AddProspectForm onSubmit={onSubmit} onCancel={onCancel} />
         </SnackbarProvider>
       </MockedProvider>
     );
-
-    //const urlInputField = screen.getByLabelText(/item url/i);
-
-    //userEvent.type(urlInputField, null);
 
     const saveButton = screen.getByText(/save/i);
 
@@ -69,14 +40,11 @@ describe('The AddProspectForm component', () => {
     expect(emptyInputError).toBeInTheDocument();
   });
 
-  it('should render error message when an incorrect url is provided', async () => {
+  it('should render error message when an incorrect URL is provided', async () => {
     render(
       <MockedProvider>
         <SnackbarProvider maxSnack={3}>
-          <AddProspectForm
-            toggleAddProspectModal={toggleModal}
-            onCancel={onCancel}
-          />
+          <AddProspectForm onSubmit={onSubmit} onCancel={onCancel} />
         </SnackbarProvider>
       </MockedProvider>
     );
@@ -94,72 +62,5 @@ describe('The AddProspectForm component', () => {
     );
 
     expect(incorrectUrlError).toBeInTheDocument();
-  });
-
-  it('should render approved item modal when a correct url is provided', async () => {
-    // mock meta data object that will be used in the apollo provider mock
-    // to be returned as one of the query results
-    const mockUrlMetadata = {
-      url: 'https://www.test-website.com/test',
-      title: 'mock-test-title',
-      imageUrl: 'mock-test-image-url',
-      publisher: 'mock-test-publisher',
-      language: 'mock-test-language',
-      isSyndicated: false,
-      isCollection: false,
-      excerpt: 'mock-test-excerpt',
-    };
-
-    // mocks for the MockApolloProvider to mock query requests and responses
-    const providerMocks = [
-      {
-        request: {
-          query: getApprovedItemByUrl,
-          variables: {
-            url: 'https://www.test-website.com/test',
-          },
-        },
-        result: {
-          data: {
-            getApprovedCuratedCorpusItemByUrl: null,
-          },
-        },
-      },
-      {
-        request: {
-          query: getUrlMetadata,
-          variables: {
-            url: 'https://www.test-website.com/test',
-          },
-        },
-        result: {
-          data: {
-            getUrlMetadata: { ...mockUrlMetadata },
-          },
-        },
-      },
-    ];
-    render(
-      <MockedProvider mocks={providerMocks}>
-        <SnackbarProvider maxSnack={3}>
-          <AddProspectForm
-            toggleAddProspectModal={toggleModal}
-            onCancel={onCancel}
-          />
-        </SnackbarProvider>
-      </MockedProvider>
-    );
-
-    const urlInputField = screen.getByLabelText(/item url/i);
-
-    userEvent.type(urlInputField, 'https://www.test-website.com/test');
-
-    const saveButton = screen.getByText(/save/i);
-
-    userEvent.click(saveButton);
-
-    const approvedItemModal = await screen.findByText(/review item/i);
-
-    expect(approvedItemModal).toBeInTheDocument();
   });
 });

--- a/src/curated-corpus/components/AddProspectForm/AddProspectForm.tsx
+++ b/src/curated-corpus/components/AddProspectForm/AddProspectForm.tsx
@@ -1,6 +1,5 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Box, Grid, LinearProgress } from '@material-ui/core';
-import { DateTime } from 'luxon';
 
 import { FormikHelpers, FormikValues, useFormik } from 'formik';
 import {
@@ -12,31 +11,11 @@ import {
 import { validationSchema } from './AddProspectForm.validation';
 import { useStyles } from './AddProspectForm.styles';
 
-import {
-  ApprovedCuratedCorpusItem,
-  CreateApprovedCuratedCorpusItemInput,
-  CreateScheduledCuratedCorpusItemInput,
-  useCreateApprovedCuratedCorpusItemMutation,
-  useCreateScheduledCuratedCorpusItemMutation,
-  useGetApprovedItemByUrlLazyQuery,
-  useGetUrlMetadataLazyQuery,
-  useUploadApprovedCuratedCorpusItemImageMutation,
-} from '../../../api/generatedTypes';
-import {
-  useNotifications,
-  useRunMutation,
-  useToggle,
-} from '../../../_shared/hooks';
-import { ApprovedItemModal, ScheduleItemModal } from '..';
-import {
-  downloadAndUploadApprovedItemImageToS3,
-  transformFormInputToCreateApprovedItemInput,
-  transformUrlMetaDataToApprovedItem,
-} from '../../helpers/helperFunctions';
-
 interface AddProspectFormProps {
-  onCancel: VoidFunction;
-  toggleAddProspectModal: VoidFunction;
+  onSubmit: (
+    values: FormikValues,
+    formikHelpers: FormikHelpers<any>
+  ) => void | Promise<any>;
 }
 
 /**
@@ -49,157 +28,7 @@ export const AddProspectForm: React.FC<
   const classes = useStyles();
 
   // de-structure props
-  const { onCancel, toggleAddProspectModal } = props;
-
-  // state variable to store the itemUrl field from the form
-  const [itemUrl, setItemUrl] = useState<string>('');
-
-  // state variable to store the approved item built after
-  // getting the item metadata
-  const [approvedItem, setApprovedItem] = useState<ApprovedCuratedCorpusItem>();
-
-  // set up some hooks
-  const { showNotification } = useNotifications();
-
-  // Keep track of whether the "Approve Item" modal is open or not
-  const [approvedItemModalOpen, toggleApprovedItemModal] = useToggle(false);
-  //Keep track of whether the "Schedule this item" modal is open or not.
-  const [scheduleModalOpen, toggleScheduleModal] = useToggle(false);
-
-  // function to toggle both modals
-  const toggleApprovedItemAndProspectModal = () => {
-    toggleApprovedItemModal();
-    toggleAddProspectModal();
-  };
-
-  // prepare the runMutation helper hook
-  const { runMutation } = useRunMutation();
-
-  // prepare mutation hook to upload image to s3
-  const [uploadApprovedItemImage] =
-    useUploadApprovedCuratedCorpusItemImageMutation();
-
-  // prepare mutation hook to create approved item
-  const [createApprovedItemMutation] =
-    useCreateApprovedCuratedCorpusItemMutation();
-
-  // prepare mutation hook to schedule the approved item
-  const [scheduleCuratedItem] = useCreateScheduledCuratedCorpusItemMutation();
-
-  // lazy query to check if url already exists in the corpus
-  const [getApprovedItemByUrl] = useGetApprovedItemByUrlLazyQuery({
-    notifyOnNetworkStatusChange: true,
-    fetchPolicy: 'no-cache',
-    onCompleted: (data) => {
-      const approvedItem = data?.getApprovedCuratedCorpusItemByUrl;
-
-      // show error toast if the url exists already
-      if (approvedItem) {
-        showNotification('This URL already exists in the Corpus', 'error');
-        return;
-      }
-
-      // fetch metadata for url if it doesn't exist in the corpus
-      if (approvedItem === null) {
-        getUrlMetadata({
-          variables: {
-            url: itemUrl,
-          },
-        });
-      }
-    },
-  });
-
-  // lazy query to get metadata for an url
-  const [getUrlMetadata] = useGetUrlMetadataLazyQuery({
-    notifyOnNetworkStatusChange: true,
-    fetchPolicy: 'no-cache',
-    onCompleted: (data) => {
-      // create an approved item object from the url metadata to be consumed by the edit form
-      const approvedItem = transformUrlMetaDataToApprovedItem(
-        data.getUrlMetadata,
-        false
-      );
-
-      // set state variable so that it can be used by the edit form
-      setApprovedItem(approvedItem);
-      // show edit form
-      toggleApprovedItemModal();
-    },
-  });
-
-  // callback which will be called after clicking save on the edit form
-  // it uploads the item's image to S3 first and then calls the mutation to
-  // create a new approved item with s3 image url
-  const createApprovedItem = async (
-    values: FormikValues,
-    formikHelpers: FormikHelpers<any>
-  ): Promise<void> => {
-    // upload item image to s3
-    const s3ImageUrl = await downloadAndUploadApprovedItemImageToS3(
-      values.imageUrl,
-      uploadApprovedItemImage
-    );
-
-    // build an approved item using the helper and replace the imageUrl with the s3ImageUrl
-    const createApprovedItemInput: CreateApprovedCuratedCorpusItemInput = {
-      ...transformFormInputToCreateApprovedItemInput(values),
-      imageUrl: s3ImageUrl,
-    };
-    // call the create approved item mutation
-    runMutation(
-      createApprovedItemMutation,
-      { variables: { data: { ...createApprovedItemInput } } },
-      'Item successfully added to the curated corpus.',
-      (data) => {
-        // set the state variable approvedItem to the newly created approved item
-        // that will be used by the schedule modal
-        data.createApprovedCuratedCorpusItem &&
-          setApprovedItem({
-            ...data.createApprovedCuratedCorpusItem,
-          });
-
-        //close approved item modal
-        toggleApprovedItemModal();
-        // open schedule modal
-        toggleScheduleModal();
-        formikHelpers.setSubmitting(false);
-      }
-    );
-  };
-
-  // callback which will be passed to the ScheduleItem modal and will execute
-  // the mutation to schedule an approved item
-  const onScheduleSave = (
-    values: FormikValues,
-    formikHelpers: FormikHelpers<any>
-  ): void => {
-    // Set out all the variables we need to pass to the mutation
-    const variables: CreateScheduledCuratedCorpusItemInput = {
-      approvedItemExternalId: approvedItem?.externalId!,
-      scheduledSurfaceGuid: values.scheduledSurfaceGuid,
-      scheduledDate: values.scheduledDate.toISODate(),
-    };
-
-    // Run the mutation
-    runMutation(
-      scheduleCuratedItem,
-      { variables },
-      `Item scheduled successfully for ${values.scheduledDate.toLocaleString(
-        DateTime.DATE_FULL
-      )}`,
-      () => {
-        // close schedule modal
-        toggleScheduleModal();
-        // close add prospect modal
-        toggleAddProspectModal();
-        formikHelpers.setSubmitting(false);
-      },
-      () => {
-        formikHelpers.setSubmitting(false);
-      }
-    );
-  };
+  const { onCancel, onSubmit } = props;
 
   // set up formik object for this form
   const formik = useFormik({
@@ -209,16 +38,7 @@ export const AddProspectForm: React.FC<
     validateOnBlur: false,
     validateOnChange: false,
     validationSchema,
-    onSubmit: (values, formikHelpers) => {
-      setItemUrl(values.itemUrl);
-      getApprovedItemByUrl({
-        variables: {
-          url: values.itemUrl,
-        },
-      });
-
-      formikHelpers.resetForm();
-    },
+    onSubmit,
   });
 
   return (
@@ -249,29 +69,6 @@ export const AddProspectForm: React.FC<
             <LinearProgress />
           </Box>
         </Grid>
-      )}
-
-      {approvedItem && (
-        <>
-          <ApprovedItemModal
-            heading="Review Item"
-            isRecommendation={true}
-            isOpen={approvedItemModalOpen}
-            onSave={createApprovedItem}
-            toggleModal={toggleApprovedItemAndProspectModal}
-            approvedItem={approvedItem}
-          />
-          <ScheduleItemModal
-            headingCopy="Optional: schedule this item"
-            approvedItem={approvedItem}
-            isOpen={scheduleModalOpen}
-            toggleModal={() => {
-              toggleScheduleModal();
-              toggleAddProspectModal();
-            }}
-            onSave={onScheduleSave}
-          />
-        </>
       )}
     </>
   );

--- a/src/curated-corpus/components/AddProspectFormConnector/AddProspectFormConnector.tsx
+++ b/src/curated-corpus/components/AddProspectFormConnector/AddProspectFormConnector.tsx
@@ -1,0 +1,229 @@
+import React, { useState } from 'react';
+import { SharedFormButtonsProps } from '../../../_shared/components';
+import {
+  ApprovedCuratedCorpusItem,
+  CreateApprovedCuratedCorpusItemInput,
+  CreateScheduledCuratedCorpusItemInput,
+  useCreateApprovedCuratedCorpusItemMutation,
+  useCreateScheduledCuratedCorpusItemMutation,
+  useGetApprovedItemByUrlLazyQuery,
+  useGetUrlMetadataLazyQuery,
+  useUploadApprovedCuratedCorpusItemImageMutation,
+} from '../../../api/generatedTypes';
+import {
+  useNotifications,
+  useRunMutation,
+  useToggle,
+} from '../../../_shared/hooks';
+import {
+  downloadAndUploadApprovedItemImageToS3,
+  transformFormInputToCreateApprovedItemInput,
+  transformUrlMetaDataToApprovedItem,
+} from '../../helpers/helperFunctions';
+import { FormikHelpers, FormikValues } from 'formik';
+import { DateTime } from 'luxon';
+import { ApprovedItemModal } from '../ApprovedItemModal/ApprovedItemModal';
+import { ScheduleItemModal } from '../ScheduleItemModal/ScheduleItemModal';
+import { AddProspectForm } from '../AddProspectForm/AddProspectForm';
+
+interface AddProspectFormConnectorProps {
+  toggleModal: VoidFunction;
+}
+
+export const AddProspectFormConnector: React.FC<
+  AddProspectFormConnectorProps & SharedFormButtonsProps
+> = (props) => {
+  const { onCancel, toggleModal } = props;
+
+  // state variable to store the itemUrl field from the form
+  const [itemUrl, setItemUrl] = useState<string>('');
+
+  // state variable to store the approved item built after
+  // getting the item metadata
+  const [approvedItem, setApprovedItem] = useState<ApprovedCuratedCorpusItem>();
+
+  // set up some hooks
+  const { showNotification } = useNotifications();
+
+  // Keep track of whether the "Approve Item" modal is open or not
+  const [approvedItemModalOpen, toggleApprovedItemModal] = useToggle(false);
+  //Keep track of whether the "Schedule this item" modal is open or not.
+  const [scheduleModalOpen, toggleScheduleModal] = useToggle(false);
+
+  // function to toggle both modals
+  const toggleApprovedItemAndProspectModal = () => {
+    toggleApprovedItemModal();
+    toggleModal();
+  };
+
+  const onSubmit = (
+    values: FormikValues,
+    formikHelpers: FormikHelpers<any>
+  ) => {
+    setItemUrl(values.itemUrl);
+    getApprovedItemByUrl({
+      variables: {
+        url: values.itemUrl,
+      },
+    });
+
+    formikHelpers.resetForm();
+  };
+
+  // prepare the runMutation helper hook
+  const { runMutation } = useRunMutation();
+
+  // prepare mutation hook to upload image to s3
+  const [uploadApprovedItemImage] =
+    useUploadApprovedCuratedCorpusItemImageMutation();
+
+  // prepare mutation hook to create approved item
+  const [createApprovedItemMutation] =
+    useCreateApprovedCuratedCorpusItemMutation();
+
+  // prepare mutation hook to schedule the approved item
+  const [scheduleCuratedItem] = useCreateScheduledCuratedCorpusItemMutation();
+
+  // lazy query to check if url already exists in the corpus
+  const [getApprovedItemByUrl] = useGetApprovedItemByUrlLazyQuery({
+    notifyOnNetworkStatusChange: true,
+    fetchPolicy: 'no-cache',
+    onCompleted: (data) => {
+      const approvedItem = data?.getApprovedCuratedCorpusItemByUrl;
+
+      // show error toast if the url exists already
+      if (approvedItem) {
+        showNotification('This URL already exists in the Corpus', 'error');
+        return;
+      }
+
+      // fetch metadata for url if it doesn't exist in the corpus
+      if (approvedItem === null) {
+        getUrlMetadata({
+          variables: {
+            url: itemUrl,
+          },
+        });
+      }
+    },
+  });
+
+  // lazy query to get metadata for an url
+  const [getUrlMetadata] = useGetUrlMetadataLazyQuery({
+    notifyOnNetworkStatusChange: true,
+    fetchPolicy: 'no-cache',
+    onCompleted: (data) => {
+      // create an approved item object from the url metadata to be consumed by the edit form
+      const approvedItem = transformUrlMetaDataToApprovedItem(
+        data.getUrlMetadata,
+        false
+      );
+
+      // set state variable so that it can be used by the edit form
+      setApprovedItem(approvedItem);
+      // show edit form
+      toggleApprovedItemModal();
+    },
+  });
+
+  // callback which will be called after clicking save on the edit form
+  // it uploads the item's image to S3 first and then calls the mutation to
+  // create a new approved item with s3 image url
+  const createApprovedItem = async (
+    values: FormikValues,
+    formikHelpers: FormikHelpers<any>
+  ): Promise<void> => {
+    // upload item image to s3
+    const s3ImageUrl = await downloadAndUploadApprovedItemImageToS3(
+      values.imageUrl,
+      uploadApprovedItemImage
+    );
+
+    // build an approved item using the helper and replace the imageUrl with the s3ImageUrl
+    const createApprovedItemInput: CreateApprovedCuratedCorpusItemInput = {
+      ...transformFormInputToCreateApprovedItemInput(values),
+      imageUrl: s3ImageUrl,
+    };
+    // call the create approved item mutation
+    runMutation(
+      createApprovedItemMutation,
+      { variables: { data: { ...createApprovedItemInput } } },
+      'Item successfully added to the curated corpus.',
+      (data) => {
+        // set the state variable approvedItem to the newly created approved item
+        // that will be used by the schedule modal
+        data.createApprovedCuratedCorpusItem &&
+          setApprovedItem({
+            ...data.createApprovedCuratedCorpusItem,
+          });
+
+        //close approved item modal
+        toggleApprovedItemModal();
+        // open schedule modal
+        toggleScheduleModal();
+        formikHelpers.setSubmitting(false);
+      }
+    );
+  };
+
+  // callback which will be passed to the ScheduleItem modal and will execute
+  // the mutation to schedule an approved item
+  const onScheduleSave = (
+    values: FormikValues,
+    formikHelpers: FormikHelpers<any>
+  ): void => {
+    // Set out all the variables we need to pass to the mutation
+    const variables: CreateScheduledCuratedCorpusItemInput = {
+      approvedItemExternalId: approvedItem?.externalId!,
+      scheduledSurfaceGuid: values.scheduledSurfaceGuid,
+      scheduledDate: values.scheduledDate.toISODate(),
+    };
+
+    // Run the mutation
+    runMutation(
+      scheduleCuratedItem,
+      { variables },
+      `Item scheduled successfully for ${values.scheduledDate.toLocaleString(
+        DateTime.DATE_FULL
+      )}`,
+      () => {
+        // close schedule modal
+        toggleScheduleModal();
+        // close add prospect modal
+        toggleModal();
+        formikHelpers.setSubmitting(false);
+      },
+      () => {
+        formikHelpers.setSubmitting(false);
+      }
+    );
+  };
+
+  return (
+    <>
+      <AddProspectForm onCancel={onCancel} onSubmit={onSubmit} />
+      {approvedItem && (
+        <>
+          <ApprovedItemModal
+            heading="Review Item"
+            isRecommendation={true}
+            isOpen={approvedItemModalOpen}
+            onSave={createApprovedItem}
+            toggleModal={toggleApprovedItemAndProspectModal}
+            approvedItem={approvedItem}
+          />
+          <ScheduleItemModal
+            headingCopy="Optional: schedule this item"
+            approvedItem={approvedItem}
+            isOpen={scheduleModalOpen}
+            toggleModal={() => {
+              toggleScheduleModal();
+              toggleModal();
+            }}
+            onSave={onScheduleSave}
+          />
+        </>
+      )}
+    </>
+  );
+};

--- a/src/curated-corpus/components/AddProspectFormConnector/AddProspectFormConnector.tsx
+++ b/src/curated-corpus/components/AddProspectFormConnector/AddProspectFormConnector.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { SharedFormButtonsProps } from '../../../_shared/components';
 import {
   ApprovedCuratedCorpusItem,
   CreateApprovedCuratedCorpusItemInput,
@@ -27,20 +26,33 @@ import { ScheduleItemModal } from '../ScheduleItemModal/ScheduleItemModal';
 import { AddProspectForm } from '../AddProspectForm/AddProspectForm';
 
 interface AddProspectFormConnectorProps {
+  /**
+   *
+   */
   toggleModal: VoidFunction;
+
+  /**
+   *
+   */
+  approvedItem: ApprovedCuratedCorpusItem | undefined;
+
+  /**
+   *
+   */
+  setApprovedItem: (approvedItem: ApprovedCuratedCorpusItem) => void;
 }
 
 export const AddProspectFormConnector: React.FC<
-  AddProspectFormConnectorProps & SharedFormButtonsProps
+  AddProspectFormConnectorProps
 > = (props) => {
-  const { onCancel, toggleModal } = props;
+  const { toggleModal, approvedItem, setApprovedItem } = props;
 
   // state variable to store the itemUrl field from the form
   const [itemUrl, setItemUrl] = useState<string>('');
 
   // state variable to store the approved item built after
   // getting the item metadata
-  const [approvedItem, setApprovedItem] = useState<ApprovedCuratedCorpusItem>();
+  // const [approvedItem, setApprovedItem] = useState<ApprovedCuratedCorpusItem>();
 
   // set up some hooks
   const { showNotification } = useNotifications();
@@ -201,7 +213,7 @@ export const AddProspectFormConnector: React.FC<
 
   return (
     <>
-      <AddProspectForm onCancel={onCancel} onSubmit={onSubmit} />
+      <AddProspectForm onCancel={toggleModal} onSubmit={onSubmit} />
       {approvedItem && (
         <>
           <ApprovedItemModal

--- a/src/curated-corpus/components/AddProspectModal/AddProspectModal.tsx
+++ b/src/curated-corpus/components/AddProspectModal/AddProspectModal.tsx
@@ -1,8 +1,8 @@
 import { Grid } from '@material-ui/core';
 import React from 'react';
-import { AddProspectForm } from '..';
+import { AddProspectFormConnector } from '..';
 
-import { SharedFormButtonsProps, Modal } from '../../../_shared/components';
+import { Modal, SharedFormButtonsProps } from '../../../_shared/components';
 
 interface AddProspectModalProps {
   isOpen: boolean;
@@ -25,9 +25,9 @@ export const AddProspectModal: React.FC<
           <h2>Add a New Curated Item</h2>
         </Grid>
         <Grid item>
-          <AddProspectForm
+          <AddProspectFormConnector
             onCancel={toggleModal}
-            toggleAddProspectModal={toggleModal}
+            toggleModal={toggleModal}
           />
         </Grid>
       </Grid>

--- a/src/curated-corpus/components/AddProspectModal/AddProspectModal.tsx
+++ b/src/curated-corpus/components/AddProspectModal/AddProspectModal.tsx
@@ -3,11 +3,22 @@ import React from 'react';
 import { AddProspectFormConnector } from '..';
 
 import { Modal, SharedFormButtonsProps } from '../../../_shared/components';
+import { ApprovedCuratedCorpusItem } from '../../../api/generatedTypes';
 
 interface AddProspectModalProps {
   isOpen: boolean;
 
   toggleModal: VoidFunction;
+
+  /**
+   *
+   */
+  approvedItem: ApprovedCuratedCorpusItem | undefined;
+
+  /**
+   *
+   */
+  setApprovedItem: (approvedItem: ApprovedCuratedCorpusItem) => void;
 }
 
 /**
@@ -16,7 +27,7 @@ interface AddProspectModalProps {
 export const AddProspectModal: React.FC<
   AddProspectModalProps & SharedFormButtonsProps
 > = (props): JSX.Element => {
-  const { isOpen, toggleModal } = props;
+  const { isOpen, toggleModal, approvedItem, setApprovedItem } = props;
 
   return (
     <Modal open={isOpen} handleClose={toggleModal}>
@@ -26,8 +37,9 @@ export const AddProspectModal: React.FC<
         </Grid>
         <Grid item>
           <AddProspectFormConnector
-            onCancel={toggleModal}
             toggleModal={toggleModal}
+            approvedItem={approvedItem}
+            setApprovedItem={setApprovedItem}
           />
         </Grid>
       </Grid>

--- a/src/curated-corpus/components/AddProspectModal/AddProspectModal.tsx
+++ b/src/curated-corpus/components/AddProspectModal/AddProspectModal.tsx
@@ -1,33 +1,41 @@
-import { Grid } from '@material-ui/core';
 import React from 'react';
+import { Grid } from '@material-ui/core';
+import { Prospect } from '../../../api/generatedTypes';
 import { AddProspectFormConnector } from '..';
-
-import { Modal, SharedFormButtonsProps } from '../../../_shared/components';
-import { ApprovedCuratedCorpusItem } from '../../../api/generatedTypes';
+import { Modal } from '../../../_shared/components';
 
 interface AddProspectModalProps {
+  /**
+   * Whether the modal is visible on the screen or not.
+   */
   isOpen: boolean;
 
+  /**
+   * Toggle the AddProspectModal to show/hide as necessary.
+   */
   toggleModal: VoidFunction;
 
   /**
-   *
+   * Toggle the modal that contains the ApprovedItem form as necessary.
    */
-  approvedItem: ApprovedCuratedCorpusItem | undefined;
+  toggleApprovedItemModal: VoidFunction;
 
   /**
-   *
+   * A setter for the current prospect to be worked on. This is passed
+   * through straight to the AddProspectFormConnector component where you will
+   * find a detailed explanation why it's needed there.
    */
-  setApprovedItem: (approvedItem: ApprovedCuratedCorpusItem) => void;
+  setCurrentProspect: (currentProspect: Prospect) => void;
 }
 
 /**
- * Parent component for the AddProspectForm component
+ * Parent component for the AddProspectFormConnector component
  */
-export const AddProspectModal: React.FC<
-  AddProspectModalProps & SharedFormButtonsProps
-> = (props): JSX.Element => {
-  const { isOpen, toggleModal, approvedItem, setApprovedItem } = props;
+export const AddProspectModal: React.FC<AddProspectModalProps> = (
+  props
+): JSX.Element => {
+  const { isOpen, toggleModal, setCurrentProspect, toggleApprovedItemModal } =
+    props;
 
   return (
     <Modal open={isOpen} handleClose={toggleModal}>
@@ -38,8 +46,8 @@ export const AddProspectModal: React.FC<
         <Grid item>
           <AddProspectFormConnector
             toggleModal={toggleModal}
-            approvedItem={approvedItem}
-            setApprovedItem={setApprovedItem}
+            toggleApprovedItemModal={toggleApprovedItemModal}
+            setCurrentProspect={setCurrentProspect}
           />
         </Grid>
       </Grid>

--- a/src/curated-corpus/components/index.ts
+++ b/src/curated-corpus/components/index.ts
@@ -1,5 +1,6 @@
 export { AddProspectModal } from './AddProspectModal/AddProspectModal';
 export { AddProspectForm } from './AddProspectForm/AddProspectForm';
+export { AddProspectFormConnector } from './AddProspectFormConnector/AddProspectFormConnector';
 export { ApprovedItemCardWrapper } from './ApprovedItemCardWrapper/ApprovedItemCardWrapper';
 export { ApprovedItemListCard } from './ApprovedItemListCard/ApprovedItemListCard';
 export { ApprovedItemModal } from './ApprovedItemModal/ApprovedItemModal';

--- a/src/curated-corpus/helpers/helperFunctions.ts
+++ b/src/curated-corpus/helpers/helperFunctions.ts
@@ -43,35 +43,36 @@ export const transformProspectToApprovedItem = (
 };
 
 /**
- * Transforms the UrlMetaData object to an ApprovedCuratedCorpusItem type object to be consumed by ApprovedItemForm component
+ * Transforms the UrlMetaData object into a Prospect
  *
  * @param metadata
- * @param isRecommendation
- * @returns ApprovedCuratedCorpusItem
+ * @returns Prospect
  */
-export const transformUrlMetaDataToApprovedItem = (
-  metadata: UrlMetadata,
-  isRecommendation?: boolean
-): ApprovedCuratedCorpusItem => {
+export const transformUrlMetaDataToProspect = (
+  metadata: UrlMetadata
+): Prospect => {
   return {
-    externalId: '',
-    prospectId: uuidv5(metadata.url, '9edace02-b9c6-4705-a0d6-16476438557b'),
+    // Encode some sort of id that will be used by the backend to send
+    // in a Snowplow event
+    id: uuidv5(metadata.url, '9edace02-b9c6-4705-a0d6-16476438557b'),
+
+    // Set whatever properties the Parser could retrieve for us
     url: metadata.url,
     title: metadata.title ?? '',
     imageUrl: metadata.imageUrl ?? '',
     publisher: metadata.publisher ?? '',
     language: metadata.language ?? '',
-    topic: '',
-    status: isRecommendation
-      ? CuratedStatus.Recommendation
-      : CuratedStatus.Corpus,
-    isTimeSensitive: false,
     isSyndicated: metadata.isSyndicated ?? false,
     isCollection: metadata.isCollection ?? false,
     excerpt: metadata.excerpt ?? '',
-    createdAt: 0,
-    createdBy: '',
-    updatedAt: 0,
+
+    // The curators will have to choose a topic manually
+    topic: '',
+
+    // These two properties are ok to set to empty strings
+    // as they won't be recorded anywhere on the backend.
+    prospectType: '',
+    scheduledSurfaceGuid: '',
   };
 };
 

--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -157,7 +157,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
   /**
    * Set the current Prospect to be worked on (e.g., to be approved or rejected).
    */
-  const [currentItem, setCurrentItem] = useState<Prospect | undefined>(
+  const [currentProspect, setCurrentProspect] = useState<Prospect | undefined>(
     undefined
   );
 
@@ -251,11 +251,11 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
     // Set out all the variables we need to pass to the first mutation
     const variables: RejectProspectMutationVariables = {
       data: {
-        url: currentItem?.url,
-        title: currentItem?.title,
-        topic: currentItem?.topic ?? '',
-        language: currentItem?.language,
-        publisher: currentItem?.publisher,
+        url: currentProspect?.url,
+        title: currentProspect?.title,
+        topic: currentProspect?.topic ?? '',
+        language: currentProspect?.language,
+        publisher: currentProspect?.publisher,
         reason: values.reason,
       },
     };
@@ -263,7 +263,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
     // Mark the prospect as processed in the Prospect API datastore.
     runMutation(
       updateProspectAsCurated,
-      { variables: { prospectId: currentItem?.id } },
+      { variables: { prospectId: currentProspect?.id } },
       undefined,
       () => {
         formikHelpers.setSubmitting(false);
@@ -285,7 +285,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
         // Remove the newly rejected item from the list of prospects displayed
         // on the page.
         setProspects(
-          prospects.filter((prospect) => prospect.id !== currentItem?.id!)
+          prospects.filter((prospect) => prospect.id !== currentProspect?.id!)
         );
 
         formikHelpers.setSubmitting(false);
@@ -325,7 +325,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
     const imageUrl: string = s3ImageUrl;
 
     const approvedItem = {
-      prospectId: currentItem?.id!,
+      prospectId: currentProspect?.id!,
       url: values.url,
       title: values.title,
       excerpt: values.excerpt,
@@ -348,7 +348,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
         // call the mutation to mark prospect as approved
         runMutation(
           updateProspectAsCurated,
-          { variables: { prospectId: currentItem?.id } },
+          { variables: { prospectId: currentProspect?.id } },
           undefined,
           () => {
             toggleApprovedItemModal();
@@ -361,7 +361,9 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
             // Remove the newly curated item from the list of prospects displayed
             // on the page.
             setProspects(
-              prospects.filter((prospect) => prospect.id !== currentItem?.id!)
+              prospects.filter(
+                (prospect) => prospect.id !== currentProspect?.id!
+              )
             );
 
             formikHelpers.setSubmitting(false);
@@ -456,10 +458,10 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
 
   return (
     <>
-      {currentItem && (
+      {currentProspect && (
         <>
           <RejectItemModal
-            prospect={currentItem}
+            prospect={currentProspect}
             isOpen={rejectModalOpen}
             onSave={onRejectSave}
             toggleModal={toggleRejectModal}
@@ -467,7 +469,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
 
           <ApprovedItemModal
             approvedItem={transformProspectToApprovedItem(
-              currentItem,
+              currentProspect,
               isRecommendation
             )}
             heading={isRecommendation ? 'Recommend' : 'Add to Corpus'}
@@ -490,8 +492,8 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
       <AddProspectModal
         isOpen={addProspectModalOpen}
         toggleModal={toggleAddProspectModal}
-        approvedItem={approvedItem}
-        setApprovedItem={setApprovedItem}
+        toggleApprovedItemModal={toggleApprovedItemModal}
+        setCurrentProspect={setCurrentProspect}
       />
 
       {approvedItem && (
@@ -568,17 +570,17 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
                   key={prospect.id}
                   prospect={prospect}
                   onAddToCorpus={() => {
-                    setCurrentItem(prospect);
+                    setCurrentProspect(prospect);
                     setIsRecommendation(false);
                     toggleApprovedItemModal();
                   }}
                   onRecommend={() => {
-                    setCurrentItem(prospect);
+                    setCurrentProspect(prospect);
                     setIsRecommendation(true);
                     toggleApprovedItemModal();
                   }}
                   onReject={() => {
-                    setCurrentItem(prospect);
+                    setCurrentProspect(prospect);
                     toggleRejectModal();
                   }}
                 />

--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -490,6 +490,8 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
       <AddProspectModal
         isOpen={addProspectModalOpen}
         toggleModal={toggleAddProspectModal}
+        approvedItem={approvedItem}
+        setApprovedItem={setApprovedItem}
       />
 
       {approvedItem && (


### PR DESCRIPTION
## Goal

Fix a bug - "The mini schedule should perform a refresh (or not use a cache?) after a user schedules a manually added item on the prospecting page."

- Manually added and scheduled items have had its own separate workflow
set up that has a lot in common with the workflow for prospects on the Prospecting
page. Uniting these two workflows into one fixes a UI bug with scheduling -
stories added manually and scheduling straight away do not appear on the sidebar
if they've been scheduled for the next couple of days.

- This initial commit refactors all of the business logic out of the `AddProspectForm`
component into a new `AddProspectFormConnector` component, leaving the form component
to be in charge of the form layout only.

- Updated the code so that adding a manual item workflow delegates back to the main workflow on the Prospecting page when metadata has been fetched for a URL. This fixes two bugs - one described in [BACK-1330] and another one that I found while working with the manual add workflow - on the optional scheduling tab, it was giving the user a choice of new tabs instead of defaulting to the one the prospect feed was from. 


## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1330

## Video Walkthrough (with sound)


https://user-images.githubusercontent.com/22447785/156545256-1f05747f-bbf9-4a73-8a8e-0b687f9ad512.mov




[BACK-1330]: https://getpocket.atlassian.net/browse/BACK-1330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ