### PR TITLE
fix(collections): add 'target=_blank' to story links

### DIFF
--- a/src/collections/components/StoryCard/StoryCard.test.tsx
+++ b/src/collections/components/StoryCard/StoryCard.test.tsx
@@ -42,6 +42,10 @@ describe('The StoryCard component', () => {
       'href',
       expect.stringMatching(story.url)
     );
+    expect(linkToStory).toHaveAttribute(
+      'target',
+      expect.stringMatching('_blank')
+    );
 
     // the title is present
     const title = screen.getByText(story.title);

--- a/src/collections/components/StoryCard/StoryCard.tsx
+++ b/src/collections/components/StoryCard/StoryCard.tsx
@@ -37,7 +37,9 @@ export const StoryCard: React.FC<StoryCardProps> = (props): JSX.Element => {
         align="left"
         gutterBottom
       >
-        <a href={story.url}>{story.title}</a>
+        <a href={story.url} target="_blank" rel="noreferrer">
+          {story.title}
+        </a>
       </Typography>
 
       <Typography


### PR DESCRIPTION
## Goal

As discussed in Slack - collection stories opening by default in the same tab lead curators away from the single-page app unintentionally.

- Added `target="_blank" to links on the collection story card. Updated tests. ESLint also made me add `rel="noreferrer"` as that apparently mitigates a security risk in older browsers.

Not ticketed in JIRA.
