### PR TITLE
fix(prospecting): Use display names for topics instead of codes with underscores

### DIFF
--- a/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.test.tsx
+++ b/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from 'react-router-dom';
 import {
   ApprovedCuratedCorpusItem,
   CuratedStatus,
+  Topics,
 } from '../../../api/generatedTypes';
 import { ApprovedItemListCard } from './ApprovedItemListCard';
 
@@ -21,7 +22,7 @@ describe('The ApprovedItemListCard component', () => {
         'Everything You Wanted to Know About React and Were Afraid To Ask',
       language: 'de',
       publisher: 'Amazing Inventions',
-      topic: 'Technology',
+      topic: Topics.SelfImprovement,
       status: CuratedStatus.Recommendation,
       isCollection: false,
       isSyndicated: false,
@@ -82,6 +83,16 @@ describe('The ApprovedItemListCard component', () => {
     );
 
     expect(screen.getByText(/^de$/i)).toBeInTheDocument();
+  });
+
+  it('shows topic correctly', () => {
+    render(
+      <MemoryRouter>
+        <ApprovedItemListCard item={item} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Self Improvement')).toBeInTheDocument();
   });
 
   it('should render approved item card with excerpt', () => {

--- a/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.tsx
+++ b/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.tsx
@@ -19,7 +19,7 @@ import {
   ApprovedCuratedCorpusItem,
   CuratedStatus,
 } from '../../../api/generatedTypes';
-import { topics } from '../../helpers/definitions';
+import { getDisplayTopic } from '../../helpers/helperFunctions';
 
 interface ApprovedItemListCardProps {
   /**
@@ -33,12 +33,6 @@ export const ApprovedItemListCard: React.FC<ApprovedItemListCardProps> = (
 ): JSX.Element => {
   const classes = useStyles();
   const { item } = props;
-
-  // This finds the corresponding display name topic from the
-  // Topics enum
-  const displayTopic = topics.find((topic) => {
-    return topic.code === item.topic;
-  })?.name;
 
   return (
     <>
@@ -107,7 +101,10 @@ export const ApprovedItemListCard: React.FC<ApprovedItemListCardProps> = (
           <ListItemIcon className={classes.listItemIcon}>
             <LabelOutlinedIcon />
           </ListItemIcon>
-          <ListItemText className={classes.topic} primary={displayTopic} />
+          <ListItemText
+            className={classes.topic}
+            primary={getDisplayTopic(item.topic)}
+          />
         </ListItem>
         <ListItem>
           <ListItemIcon className={classes.listItemIcon}>

--- a/src/curated-corpus/components/MiniScheduleCard/MiniScheduleCard.styles.tsx
+++ b/src/curated-corpus/components/MiniScheduleCard/MiniScheduleCard.styles.tsx
@@ -26,9 +26,6 @@ export const useStyles = makeStyles((theme: Theme) =>
       fontSize: '0.875rem',
       fontWeight: 500,
     },
-    listItemText: {
-      textTransform: 'capitalize',
-    },
     listItemIcon: {
       minWidth: '2rem',
     },

--- a/src/curated-corpus/components/MiniScheduleCard/MiniScheduleCard.test.tsx
+++ b/src/curated-corpus/components/MiniScheduleCard/MiniScheduleCard.test.tsx
@@ -4,9 +4,11 @@ import { MemoryRouter } from 'react-router-dom';
 import {
   CuratedStatus,
   ScheduledCuratedCorpusItem,
+  Topics,
 } from '../../../api/generatedTypes';
 
 import { MiniScheduleCard } from './MiniScheduleCard';
+import { getDisplayTopic } from '../../helpers/helperFunctions';
 
 describe('The MiniScheduleCard component', () => {
   let item: ScheduledCuratedCorpusItem;
@@ -29,7 +31,7 @@ describe('The MiniScheduleCard component', () => {
           'Everything You Wanted to Know About React and Were Afraid To Ask',
         language: 'de',
         publisher: 'Amazing Inventions',
-        topic: 'Technology',
+        topic: Topics.Technology,
         status: CuratedStatus.Recommendation,
         isCollection: false,
         isSyndicated: false,
@@ -67,7 +69,8 @@ describe('The MiniScheduleCard component', () => {
     expect(publisher).toBeInTheDocument();
 
     // The topic is also present
-    const topic = screen.getByText(item.approvedItem.topic.toLowerCase());
+    const displayTopic = getDisplayTopic(item.approvedItem.topic);
+    const topic = screen.getByText(displayTopic);
     expect(topic).toBeInTheDocument();
   });
 

--- a/src/curated-corpus/components/MiniScheduleCard/MiniScheduleCard.tsx
+++ b/src/curated-corpus/components/MiniScheduleCard/MiniScheduleCard.tsx
@@ -14,6 +14,7 @@ import LabelOutlinedIcon from '@material-ui/icons/LabelOutlined';
 import CheckCircleOutlineIcon from '@material-ui/icons/CheckCircleOutline';
 import BookmarksIcon from '@material-ui/icons/Bookmarks';
 import { useStyles } from './MiniScheduleCard.styles';
+import { getDisplayTopic } from '../../helpers/helperFunctions';
 
 interface MiniScheduleCardProps {
   item: ScheduledCuratedCorpusItem;
@@ -59,8 +60,7 @@ export const MiniScheduleCard: React.FC<MiniScheduleCardProps> = (
               <LabelOutlinedIcon fontSize="small" />
             </ListItemIcon>
             <ListItemText
-              className={classes.listItemText}
-              secondary={item.approvedItem.topic.toLowerCase()}
+              secondary={getDisplayTopic(item.approvedItem.topic)}
             />
           </ListItem>
           {item.approvedItem.isSyndicated && (
@@ -68,10 +68,7 @@ export const MiniScheduleCard: React.FC<MiniScheduleCardProps> = (
               <ListItemIcon className={classes.listItemIcon}>
                 <CheckCircleOutlineIcon fontSize="small" />
               </ListItemIcon>
-              <ListItemText
-                className={classes.listItemText}
-                secondary={'Syndicated'}
-              />
+              <ListItemText secondary={'Syndicated'} />
             </ListItem>
           )}
           {item.approvedItem.isCollection && (
@@ -79,10 +76,7 @@ export const MiniScheduleCard: React.FC<MiniScheduleCardProps> = (
               <ListItemIcon className={classes.listItemIcon}>
                 <BookmarksIcon fontSize="small" />
               </ListItemIcon>
-              <ListItemText
-                className={classes.listItemText}
-                secondary={'Collection'}
-              />
+              <ListItemText secondary={'Collection'} />
             </ListItem>
           )}
         </List>

--- a/src/curated-corpus/components/ProspectListCard/ProspectListCard.test.tsx
+++ b/src/curated-corpus/components/ProspectListCard/ProspectListCard.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { Prospect } from '../../../api/generatedTypes';
+import { Prospect, Topics } from '../../../api/generatedTypes';
 import { ProspectListCard } from './ProspectListCard';
 
 describe('The ProspectListCard component', () => {
@@ -22,7 +22,7 @@ describe('The ProspectListCard component', () => {
         'Everything You Wanted to Know About DynamoDB and Were Afraid To Ask',
       language: 'de',
       publisher: 'Amazing Inventions',
-      topic: 'Technology',
+      topic: Topics.Technology,
     };
   });
 

--- a/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
+++ b/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
@@ -14,6 +14,7 @@ import { useStyles } from './ProspectListCard.styles';
 import LanguageIcon from '@material-ui/icons/Language';
 import LabelOutlinedIcon from '@material-ui/icons/LabelOutlined';
 import { Button } from '../../../_shared/components';
+import { getDisplayTopic } from '../../helpers/helperFunctions';
 
 interface ProspectListCardProps {
   /**
@@ -93,7 +94,7 @@ export const ProspectListCard: React.FC<ProspectListCardProps> = (
             <Chip
               variant="outlined"
               color="primary"
-              label={prospect.topic ?? 'N/A'}
+              label={getDisplayTopic(prospect.topic)}
               icon={<LabelOutlinedIcon />}
             />
           </Box>

--- a/src/curated-corpus/helpers/helperFunctions.test.ts
+++ b/src/curated-corpus/helpers/helperFunctions.test.ts
@@ -2,9 +2,11 @@ import {
   CuratedStatus,
   Prospect,
   ProspectType,
+  Topics,
 } from '../../api/generatedTypes';
 import {
   fetchFileFromUrl,
+  getDisplayTopic,
   transformProspectToApprovedItem,
 } from './helperFunctions';
 
@@ -131,6 +133,28 @@ describe('helperFunctions ', () => {
 
       // assert blob has is undefined
       expect(responseBlob).toEqual(undefined);
+    });
+  });
+
+  describe('getDisplayTopic function', () => {
+    it('returns a capitalised display name for a one-word topic', () => {
+      const displayTopic = getDisplayTopic(Topics.Technology);
+      expect(displayTopic).toEqual('Technology');
+    });
+
+    it('returns a capitalised display name for a multiple-word topic', () => {
+      const displayTopic = getDisplayTopic(Topics.HealthFitness);
+      expect(displayTopic).toEqual('Health & Fitness');
+    });
+
+    it('returns "N/A" if topic is undefined', () => {
+      const displayTopic = getDisplayTopic(undefined);
+      expect(displayTopic).toEqual('N/A');
+    });
+
+    it('returns "N/A" if topic is not part of shared data topic list', () => {
+      const displayTopic = getDisplayTopic('BEST_BOOKS');
+      expect(displayTopic).toEqual('N/A');
     });
   });
 });

--- a/src/curated-corpus/helpers/helperFunctions.ts
+++ b/src/curated-corpus/helpers/helperFunctions.ts
@@ -5,9 +5,11 @@ import {
   ApprovedCuratedCorpusItem,
   CreateApprovedCuratedCorpusItemInput,
   CuratedStatus,
+  Maybe,
   Prospect,
   UrlMetadata,
 } from '../../api/generatedTypes';
+import { topics } from './definitions';
 
 /**
  *
@@ -175,4 +177,21 @@ export const readImageFileFromDisk = (
       }
     }
   };
+};
+
+/**
+ * This function transforms topic names as recorded in the database
+ * into more easily readable names, e.g. `TECHNOLOGY` -> `Technology`
+ * or `HEALTH_FITNESS` -> `Health & Fitness`.
+ *
+ * Returns `N/A` if there is no topic match from the known list of topics.
+ */
+export const getDisplayTopic = (
+  topicCode: Maybe<string> | string | undefined
+): string => {
+  const displayTopic = topics.find((topic) => {
+    return topic.code === topicCode;
+  })?.name;
+
+  return displayTopic ? displayTopic : 'N/A';
 };


### PR DESCRIPTION
## Goal

Achieve consistency throughout the curated corpus app with the way topics are displayed.

- Added a helper function that converts topic codes into display names (used
in the topic dropdown), it also provides the `N/A` option for prospects without
a topic set.

- Now using this helper on every content card - approved item card, mini schedule
card and prospect card to show topic names consistently.

- Added and updated unit tests where necessary

## Reference

Tickets:

- Not ticketed, this has been bugging me for a while (sorry @bassrock 😄)


