### PR TITLE
feat(surface select): auto-select surface if only one is available

### DIFF
--- a/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.test.tsx
+++ b/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.test.tsx
@@ -13,7 +13,7 @@ describe('The ScheduleItemForm component', () => {
   const scheduledSurfaces: ScheduledSurface[] = [
     {
       name: 'en-US',
-      guid: 'EN_US',
+      guid: 'NEW_TAB_EN_US',
       utcOffset: -4000,
       prospectTypes: [
         ProspectType.Global,
@@ -23,7 +23,7 @@ describe('The ScheduleItemForm component', () => {
     },
     {
       name: 'de-DE',
-      guid: 'DE_DE',
+      guid: 'NEW_TAB_DE_DE',
       utcOffset: 1000,
       prospectTypes: [ProspectType.Global],
     },
@@ -65,5 +65,85 @@ describe('The ScheduleItemForm component', () => {
     const buttons = screen.getAllByRole('button');
     // "Save" and "Cancel" buttons.
     expect(buttons).toHaveLength(2);
+  });
+
+  it('does not pre-select a scheduled surface if none was passed in and the user has access to many', () => {
+    render(
+      <MuiPickersUtilsProvider utils={LuxonUtils}>
+        <ScheduleItemForm
+          data-testId="surface-selector"
+          handleDateChange={jest.fn()}
+          lookupCopy=""
+          selectedDate={DateTime.local()}
+          onSubmit={handleSubmit}
+          scheduledSurfaces={scheduledSurfaces}
+          approvedItemExternalId={'123abc'}
+        />
+      </MuiPickersUtilsProvider>
+    );
+
+    const select = screen.getByLabelText(
+      'Choose a Scheduled Surface'
+    ) as HTMLSelectElement;
+
+    // there should be an empty option and a single scheduled surface option
+    expect(select.options.length).toEqual(scheduledSurfaces.length + 1);
+
+    // the empty option should be selected
+    expect(select.options[0].selected).toBeTruthy();
+  });
+
+  it('pre-selects the passed in scheduled surface', () => {
+    render(
+      <MuiPickersUtilsProvider utils={LuxonUtils}>
+        <ScheduleItemForm
+          data-testId="surface-selector"
+          handleDateChange={jest.fn()}
+          lookupCopy=""
+          selectedDate={DateTime.local()}
+          onSubmit={handleSubmit}
+          scheduledSurfaces={scheduledSurfaces}
+          scheduledSurfaceGuid="NEW_TAB_EN_US"
+          approvedItemExternalId={'123abc'}
+        />
+      </MuiPickersUtilsProvider>
+    );
+
+    const select = screen.getByLabelText(
+      'Choose a Scheduled Surface'
+    ) as HTMLSelectElement;
+
+    // there should be an empty option and a single scheduled surface option
+    expect(select.options.length).toEqual(scheduledSurfaces.length + 1);
+
+    // the `NEW_TAB_EN_US` option should be selected
+    expect(select.options[1].selected).toBeTruthy();
+    expect(select.options[1].value).toEqual('NEW_TAB_EN_US');
+  });
+
+  it('pre-selects the only available scheduled surface if none was specified and the user only has access to a single one', () => {
+    render(
+      <MuiPickersUtilsProvider utils={LuxonUtils}>
+        <ScheduleItemForm
+          data-testId="surface-selector"
+          handleDateChange={jest.fn()}
+          lookupCopy=""
+          selectedDate={DateTime.local()}
+          onSubmit={handleSubmit}
+          scheduledSurfaces={[scheduledSurfaces[0]]}
+          approvedItemExternalId={'123abc'}
+        />
+      </MuiPickersUtilsProvider>
+    );
+
+    const select = screen.getByLabelText(
+      'Choose a Scheduled Surface'
+    ) as HTMLSelectElement;
+
+    // there should be an empty option and a single scheduled surface option
+    expect(select.options.length).toEqual(2);
+
+    // the scheduled surface should be selected
+    expect(select.options[1].selected).toBeTruthy();
   });
 });

--- a/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.tsx
+++ b/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.tsx
@@ -88,9 +88,18 @@ export const ScheduleItemForm: React.FC<
     handleDateChange(tomorrow);
   }, []);
 
+  // if a scheduledSurfaceGuid was not supplied (meaning this is a manually
+  // added item), check to see if the user only has access to a single
+  // scheduled surface. if so, auto-select that one. if they have access to
+  // multiple, the default value should be an empty string (as react does *not*
+  // like `null` or `undefined` in this case).
+  const selectedScheduledSurfaceGuid =
+    scheduledSurfaceGuid ||
+    (scheduledSurfaces.length === 1 ? scheduledSurfaces[0].guid : '');
+
   const formik = useFormik({
     initialValues: {
-      scheduledSurfaceGuid,
+      scheduledSurfaceGuid: selectedScheduledSurfaceGuid,
       approvedItemExternalId,
       scheduledDate: selectedDate,
     },

--- a/src/curated-corpus/helpers/helperFunctions.ts
+++ b/src/curated-corpus/helpers/helperFunctions.ts
@@ -54,10 +54,8 @@ export const transformUrlMetaDataToProspect = (
   metadata: UrlMetadata
 ): Prospect => {
   return {
-    // Encode some sort of id that will be used by the backend to send
-    // in a Snowplow event
-    id: uuidv5(metadata.url, '9edace02-b9c6-4705-a0d6-16476438557b'),
-
+    // manually added items don't have a prospect id!
+    id: '',
     // Set whatever properties the Parser could retrieve for us
     url: metadata.url,
     title: metadata.title ?? '',


### PR DESCRIPTION
## Goal

when scheduling an item and having access to only one scheduled surface, auto-select that surface.

- set id to an empty string for manually added prospects
- do not call prospect api after manually adding a prospect
- add some tests

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1336
- https://getpocket.atlassian.net/browse/BACK-1357
