### PR TITLE
feat(reset filters): [BACK-1333] add a reset filters button to the approved and reject item search form

### DIFF
--- a/src/curated-corpus/components/AddProspectFormConnector/AddProspectFormConnector.tsx
+++ b/src/curated-corpus/components/AddProspectFormConnector/AddProspectFormConnector.tsx
@@ -28,6 +28,12 @@ interface AddProspectFormConnectorProps {
    * when the manually added prospect is ready to be saved.
    */
   setCurrentProspect: (currentProspect: Prospect) => void;
+
+  /**
+   * Sets the state variable isRecommendation in the ProspectingPage component
+   * We need to call this to be able to set the Curation Status field to Recommendation in the approved item form
+   */
+  setIsRecommendation: (isRecommendation: boolean) => void;
 }
 
 /**
@@ -39,7 +45,12 @@ interface AddProspectFormConnectorProps {
 export const AddProspectFormConnector: React.FC<
   AddProspectFormConnectorProps
 > = (props) => {
-  const { toggleModal, toggleApprovedItemModal, setCurrentProspect } = props;
+  const {
+    toggleModal,
+    toggleApprovedItemModal,
+    setCurrentProspect,
+    setIsRecommendation,
+  } = props;
 
   // state variable to store the itemUrl field from the form
   const [itemUrl, setItemUrl] = useState<string>('');
@@ -105,6 +116,9 @@ export const AddProspectFormConnector: React.FC<
 
       // set state variable so that it can be used by the ApprovedItem form
       setCurrentProspect(prospect);
+
+      // set the isRecommendation state variable in the ProspectingPage component to true
+      setIsRecommendation(true);
 
       // Hide the AddProspect form
       toggleModal();

--- a/src/curated-corpus/components/AddProspectModal/AddProspectModal.tsx
+++ b/src/curated-corpus/components/AddProspectModal/AddProspectModal.tsx
@@ -26,6 +26,13 @@ interface AddProspectModalProps {
    * find a detailed explanation why it's needed there.
    */
   setCurrentProspect: (currentProspect: Prospect) => void;
+
+  /**
+   * Passing in the setter for the state variable isRecommendation in this component's parent:
+   * ProspectingPage. We need to pass this down to the AddProspectFormConnector where this will be
+   * called with `true` to set the Curation Status field to Recommendation in the approved item form
+   */
+  setIsRecommendation: (isRecommendation: boolean) => void;
 }
 
 /**
@@ -34,8 +41,13 @@ interface AddProspectModalProps {
 export const AddProspectModal: React.FC<AddProspectModalProps> = (
   props
 ): JSX.Element => {
-  const { isOpen, toggleModal, setCurrentProspect, toggleApprovedItemModal } =
-    props;
+  const {
+    isOpen,
+    toggleModal,
+    setCurrentProspect,
+    setIsRecommendation,
+    toggleApprovedItemModal,
+  } = props;
 
   return (
     <Modal open={isOpen} handleClose={toggleModal}>
@@ -48,6 +60,7 @@ export const AddProspectModal: React.FC<AddProspectModalProps> = (
             toggleModal={toggleModal}
             toggleApprovedItemModal={toggleApprovedItemModal}
             setCurrentProspect={setCurrentProspect}
+            setIsRecommendation={setIsRecommendation}
           />
         </Grid>
       </Grid>

--- a/src/curated-corpus/components/ApprovedItemSearchForm/ApprovedItemSearchForm.test.tsx
+++ b/src/curated-corpus/components/ApprovedItemSearchForm/ApprovedItemSearchForm.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { ApprovedItemSearchForm } from './ApprovedItemSearchForm';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+
+import { ApprovedItemSearchForm } from './ApprovedItemSearchForm';
 
 describe('The CuratedItemSearchForm component', () => {
   const handleSubmit = jest.fn();
@@ -14,10 +15,21 @@ describe('The CuratedItemSearchForm component', () => {
     expect(form).toBeInTheDocument();
   });
 
-  it('has a single "Search" button', () => {
+  it('has a "Search" button', () => {
     render(<ApprovedItemSearchForm onSubmit={handleSubmit} />);
 
-    const button = screen.getByRole('button');
+    const button = screen.getByRole('button', {
+      name: /search/i,
+    });
+    expect(button).toBeInTheDocument();
+  });
+
+  it('has a "Reset Filters" button', () => {
+    render(<ApprovedItemSearchForm onSubmit={handleSubmit} />);
+
+    const button = screen.getByRole('button', {
+      name: /reset filters/i,
+    });
     expect(button).toBeInTheDocument();
   });
 
@@ -43,11 +55,13 @@ describe('The CuratedItemSearchForm component', () => {
   it('allows users to search without any filters', async () => {
     render(<ApprovedItemSearchForm onSubmit={handleSubmit} />);
 
-    const button = screen.getByRole('button');
+    const searchButton = screen.getByRole('button', {
+      name: /search/i,
+    });
 
     // All filters are optional, so the form should submit without anything in it.
     await waitFor(() => {
-      userEvent.click(button);
+      userEvent.click(searchButton);
     });
     expect(handleSubmit).toHaveBeenCalled();
   });
@@ -57,12 +71,14 @@ describe('The CuratedItemSearchForm component', () => {
 
     const titleField = screen.getByLabelText(/filter by title/i);
     const urlField = screen.getByLabelText(/filter by url/i);
-    const button = screen.getByRole('button');
+    const searchButton = screen.getByRole('button', {
+      name: /search/i,
+    });
 
     // When filtering by title, we expect the user to provide at least two characters.
     userEvent.type(titleField, '1');
     await waitFor(() => {
-      userEvent.click(button);
+      userEvent.click(searchButton);
     });
     expect(
       screen.getByText('Please enter at least two characters.')
@@ -74,7 +90,7 @@ describe('The CuratedItemSearchForm component', () => {
     // We have the same expectations for the URL filter
     userEvent.type(urlField, 'a');
     await waitFor(() => {
-      userEvent.click(button);
+      userEvent.click(searchButton);
     });
 
     expect(
@@ -86,9 +102,35 @@ describe('The CuratedItemSearchForm component', () => {
     userEvent.clear(urlField);
     userEvent.type(urlField, 'abc');
     await waitFor(() => {
-      userEvent.click(button);
+      userEvent.click(searchButton);
     });
 
     expect(handleSubmit).toHaveBeenCalled();
+  });
+
+  it('resets all form filters when Reset Filters button is clicked', async () => {
+    render(<ApprovedItemSearchForm onSubmit={handleSubmit} />);
+
+    // get text input fields
+    const titleField = screen.getByLabelText(/filter by title/i);
+    const urlField = screen.getByLabelText(/filter by url/i);
+
+    // get the reset filters button
+    const resetButton = screen.getByRole('button', {
+      name: /reset filters/i,
+    });
+
+    // type something in the text fields
+    userEvent.type(titleField, 'test title');
+    userEvent.type(urlField, 'test url');
+
+    // reset the filters by clicking on the reset filters button
+    await waitFor(() => {
+      userEvent.click(resetButton);
+    });
+
+    // assert that the filters have been reset
+    expect(titleField).toHaveValue('');
+    expect(urlField).toHaveValue('');
   });
 });

--- a/src/curated-corpus/components/ApprovedItemSearchForm/ApprovedItemSearchForm.tsx
+++ b/src/curated-corpus/components/ApprovedItemSearchForm/ApprovedItemSearchForm.tsx
@@ -118,9 +118,21 @@ export const ApprovedItemSearchForm: React.FC<ApprovedItemSearchFormProps> = (
             })}
           </FormikSelectField>
         </Grid>
-        <Grid item xs={12}>
+      </Grid>
+      <Grid container spacing={1}>
+        <Grid item xs={12} md={10}>
           <Button buttonType="positive" type="submit" fullWidth>
             Search
+          </Button>
+        </Grid>
+        <Grid item xs={12} md={2}>
+          <Button
+            buttonType="hollow-neutral"
+            type="reset"
+            fullWidth
+            onClick={() => formik.resetForm()}
+          >
+            Reset Filters
           </Button>
         </Grid>
       </Grid>

--- a/src/curated-corpus/components/RejectedItemSearchForm/RejectedItemSearchForm.tsx
+++ b/src/curated-corpus/components/RejectedItemSearchForm/RejectedItemSearchForm.tsx
@@ -105,9 +105,21 @@ export const RejectedItemSearchForm: React.FC<RejectedItemSearchFormProps> = (
             })}
           </FormikSelectField>
         </Grid>
-        <Grid item xs={12}>
+      </Grid>
+      <Grid container spacing={1}>
+        <Grid item xs={12} md={10}>
           <Button buttonType="positive" type="submit" fullWidth>
             Search
+          </Button>
+        </Grid>
+        <Grid item xs={12} md={2}>
+          <Button
+            buttonType="hollow-neutral"
+            type="reset"
+            fullWidth
+            onClick={() => formik.resetForm()}
+          >
+            Reset Filters
           </Button>
         </Grid>
       </Grid>

--- a/src/curated-corpus/components/RejectedItemSearchForm/RejectedtemSearchForm.test.tsx
+++ b/src/curated-corpus/components/RejectedItemSearchForm/RejectedtemSearchForm.test.tsx
@@ -14,11 +14,20 @@ describe('The RejectedItemSearchForm component', () => {
     expect(form).toBeInTheDocument();
   });
 
-  it('should render with a single "Search" button', () => {
+  it('should render with a "Search" button', () => {
     render(<RejectedItemSearchForm onSubmit={handleSubmit} />);
 
     const button = screen.getByRole('button', {
       name: /search/i,
+    });
+    expect(button).toBeInTheDocument();
+  });
+
+  it('should render with a "Reset Filters" button', () => {
+    render(<RejectedItemSearchForm onSubmit={handleSubmit} />);
+
+    const button = screen.getByRole('button', {
+      name: /reset filters/i,
     });
     expect(button).toBeInTheDocument();
   });
@@ -42,11 +51,12 @@ describe('The RejectedItemSearchForm component', () => {
   it('should allow users to search without any filters', async () => {
     render(<RejectedItemSearchForm onSubmit={handleSubmit} />);
 
-    const button = screen.getByRole('button');
-
+    const searchButton = screen.getByRole('button', {
+      name: /search/i,
+    });
     // All filters are optional, so the form should submit without anything in it.
     await waitFor(() => {
-      userEvent.click(button);
+      userEvent.click(searchButton);
     });
     expect(handleSubmit).toHaveBeenCalled();
   });
@@ -56,12 +66,13 @@ describe('The RejectedItemSearchForm component', () => {
 
     const titleField = screen.getByLabelText(/filter by title/i);
     const urlField = screen.getByLabelText(/filter by url/i);
-    const button = screen.getByRole('button');
-
+    const searchButton = screen.getByRole('button', {
+      name: /search/i,
+    });
     // When filtering by title, we expect the user to provide at least two characters.
     userEvent.type(titleField, '1');
     await waitFor(() => {
-      userEvent.click(button);
+      userEvent.click(searchButton);
     });
     expect(
       screen.getByText('Please enter at least two characters.')
@@ -73,7 +84,7 @@ describe('The RejectedItemSearchForm component', () => {
     // We have the same expectations for the URL filter
     userEvent.type(urlField, 'a');
     await waitFor(() => {
-      userEvent.click(button);
+      userEvent.click(searchButton);
     });
 
     expect(
@@ -85,9 +96,35 @@ describe('The RejectedItemSearchForm component', () => {
     userEvent.clear(urlField);
     userEvent.type(urlField, 'abc');
     await waitFor(() => {
-      userEvent.click(button);
+      userEvent.click(searchButton);
     });
 
     expect(handleSubmit).toHaveBeenCalled();
+  });
+
+  it('resets all form filters when Reset Filters button is clicked', async () => {
+    render(<RejectedItemSearchForm onSubmit={handleSubmit} />);
+
+    // get text input fields
+    const titleField = screen.getByLabelText(/filter by title/i);
+    const urlField = screen.getByLabelText(/filter by url/i);
+
+    // get the reset filters button
+    const resetButton = screen.getByRole('button', {
+      name: /reset filters/i,
+    });
+
+    // type something in the text fields
+    userEvent.type(titleField, 'test title');
+    userEvent.type(urlField, 'test url');
+
+    // reset the filters by clicking on the reset filters button
+    await waitFor(() => {
+      userEvent.click(resetButton);
+    });
+
+    // assert that the filters have been reset
+    expect(titleField).toHaveValue('');
+    expect(urlField).toHaveValue('');
   });
 });

--- a/src/curated-corpus/pages/ApprovedItemsPage/ApprovedItemsPage.tsx
+++ b/src/curated-corpus/pages/ApprovedItemsPage/ApprovedItemsPage.tsx
@@ -298,7 +298,7 @@ export const ApprovedItemsPage: React.FC = (): JSX.Element => {
         {data && (
           <Grid item xs={12}>
             <Typography>
-              Found {data.getApprovedCuratedCorpusItems.totalCount} results.
+              Found {data.getApprovedCuratedCorpusItems.totalCount} result(s).
             </Typography>
           </Grid>
         )}

--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -477,6 +477,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
             onSave={onCuratedItemSave}
             toggleModal={toggleApprovedItemModal}
             onImageSave={setUserUploadedS3ImageUrl}
+            isRecommendation={isRecommendation}
           />
         </>
       )}
@@ -494,6 +495,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
         toggleModal={toggleAddProspectModal}
         toggleApprovedItemModal={toggleApprovedItemModal}
         setCurrentProspect={setCurrentProspect}
+        setIsRecommendation={setIsRecommendation}
       />
 
       {approvedItem && (

--- a/src/curated-corpus/pages/RejectedItemsPage/RejectedItemsPage.tsx
+++ b/src/curated-corpus/pages/RejectedItemsPage/RejectedItemsPage.tsx
@@ -134,7 +134,7 @@ export const RejectedItemsPage: React.FC = (): JSX.Element => {
         {data && (
           <Grid item xs={12}>
             <Typography>
-              Found {data.getRejectedCuratedCorpusItems.totalCount} results.
+              Found {data.getRejectedCuratedCorpusItems.totalCount} result(s).
             </Typography>
           </Grid>
         )}


### PR DESCRIPTION
## Goal

1. Add a **Reset Filters** button to the Rejected and Approved corpus search forms
2. **Aside**: Set **_Curation Status_** to `Recommendation` in the `ApprovedItemForm` when manually adding a prospect

Tickets:

- [BACK-1333]

### Screencapture

https://user-images.githubusercontent.com/16694733/156667776-9bb75610-50df-4249-869e-8b4f4df8d3dd.mov



[BACK-1333]: https://getpocket.atlassian.net/browse/BACK-1333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ