### PR TITLE
feat(prospecting): [BACK-1338] When prospecting, jump straight to scheduling if corpus item already exists

### DIFF
--- a/src/curated-corpus/components/AddProspectModal/AddProspectModal.tsx
+++ b/src/curated-corpus/components/AddProspectModal/AddProspectModal.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { Grid } from '@material-ui/core';
-import { Prospect } from '../../../api/generatedTypes';
+import {
+  ApprovedCuratedCorpusItem,
+  Prospect,
+} from '../../../api/generatedTypes';
 import { AddProspectFormConnector } from '..';
 import { Modal } from '../../../_shared/components';
 
@@ -21,11 +24,23 @@ interface AddProspectModalProps {
   toggleApprovedItemModal: VoidFunction;
 
   /**
+   * Toggle the modal that contains the optional scheduling form as necessary.
+   */
+  toggleScheduleItemModal: VoidFunction;
+
+  /**
    * A setter for the current prospect to be worked on. This is passed
    * through straight to the AddProspectFormConnector component where you will
    * find a detailed explanation why it's needed there.
    */
-  setCurrentProspect: (currentProspect: Prospect) => void;
+  setCurrentProspect: (prospect: Prospect) => void;
+
+  /**
+   * A setter for the current approved item to be worked on.
+   *
+   * @param item
+   */
+  setApprovedItem: (item: ApprovedCuratedCorpusItem) => void;
 
   /**
    * Passing in the setter for the state variable isRecommendation in this component's parent:
@@ -44,9 +59,11 @@ export const AddProspectModal: React.FC<AddProspectModalProps> = (
   const {
     isOpen,
     toggleModal,
-    setCurrentProspect,
-    setIsRecommendation,
     toggleApprovedItemModal,
+    toggleScheduleItemModal,
+    setCurrentProspect,
+    setApprovedItem,
+    setIsRecommendation,
   } = props;
 
   return (
@@ -59,7 +76,9 @@ export const AddProspectModal: React.FC<AddProspectModalProps> = (
           <AddProspectFormConnector
             toggleModal={toggleModal}
             toggleApprovedItemModal={toggleApprovedItemModal}
+            toggleScheduleItemModal={toggleScheduleItemModal}
             setCurrentProspect={setCurrentProspect}
+            setApprovedItem={setApprovedItem}
             setIsRecommendation={setIsRecommendation}
           />
         </Grid>

--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -17,11 +17,11 @@ import {
 } from '../../components';
 import {
   ApprovedCuratedCorpusItem,
+  CreateApprovedCuratedCorpusItemMutation,
   CuratedStatus,
   Prospect,
   RejectProspectMutationVariables,
   ScheduledCuratedCorpusItemsResult,
-  CreateApprovedCuratedCorpusItemMutation,
   useCreateApprovedCuratedCorpusItemMutation,
   useCreateScheduledCuratedCorpusItemMutation,
   useGetProspectsQuery,
@@ -525,7 +525,9 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
         isOpen={addProspectModalOpen}
         toggleModal={toggleAddProspectModal}
         toggleApprovedItemModal={toggleApprovedItemModal}
+        toggleScheduleItemModal={toggleScheduleModal}
         setCurrentProspect={setCurrentProspect}
+        setApprovedItem={setApprovedItem}
         setIsRecommendation={setIsRecommendation}
       />
 


### PR DESCRIPTION
## Goal

Instead of showing an error if a prospect has already been curated, jump straight to scheduling if the "Recommend" button is used.

- [x] This initial commit implements this workflow for manually adding an item.
- [x] The main prospecting workflow also needs to be updated.
- [x] Additionally, when you try to add an item to the corpus that is in the rejected corpus, you get an INTERNAL_SERVER_ERROR. we should display a helpful error message instead - this is a backend issue and needs its own PR in `curated-corpus-api` (https://github.com/Pocket/curated-corpus-api/pull/600)

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1338
