### PR TITLE
fix(schedule item card): [BACK-1358] lower z-index to un block scheduled surface selector dropdown

### DIFF
--- a/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.styles.tsx
+++ b/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.styles.tsx
@@ -10,6 +10,7 @@ export const useStyles = makeStyles((theme: Theme) =>
       display: 'flex',
       flexDirection: 'column',
       position: 'relative',
+      zIndex: -1,
     },
     actions: {
       margin: 'auto',

--- a/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.styles.tsx
+++ b/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.styles.tsx
@@ -10,7 +10,6 @@ export const useStyles = makeStyles((theme: Theme) =>
       display: 'flex',
       flexDirection: 'column',
       position: 'relative',
-      zIndex: -1,
     },
     actions: {
       margin: 'auto',

--- a/src/curated-corpus/components/SplitButton/SplitButton.styles.tsx
+++ b/src/curated-corpus/components/SplitButton/SplitButton.styles.tsx
@@ -5,6 +5,11 @@ import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
  */
 export const useStyles = makeStyles((theme: Theme) =>
   createStyles({
+    popper: {
+      // this prevents the dropdown from being covered by schedule item card
+      zIndex: 1,
+    },
+
     optionNameSmall: {
       minWidth: '4rem',
     },

--- a/src/curated-corpus/components/SplitButton/SplitButton.tsx
+++ b/src/curated-corpus/components/SplitButton/SplitButton.tsx
@@ -119,6 +119,7 @@ export const SplitButton: React.FC<SplitButtonProps> = (props) => {
         </Button>
       </ButtonGroup>
       <Popper
+        className={classes.popper}
         open={open}
         anchorEl={anchorRef.current}
         role={undefined}


### PR DESCRIPTION
## Goal

Fix minor cosmetic bug, schedule surface selector drop down was being covered by the scheduled item card 

Tickets:

- [BACK-1358]

[BACK-1358]: https://getpocket.atlassian.net/browse/BACK-1358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

### Screen capture
<img width="408" alt="Screen Shot 2022-03-08 at 12 23 32 PM" src="https://user-images.githubusercontent.com/16694733/157292214-d39838ab-8f19-4e5c-93c0-81dddaba11d0.png">

