### PR TITLE
chore(shared data): update prospect types

### DIFF
--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -1112,8 +1112,10 @@ export type Prospect = {
  * by the Curation Admin Tools frontend to filter prospects.
  */
 export enum ProspectType {
+  CountsLogisticApproval = 'COUNTS_LOGISTIC_APPROVAL',
   DomainAllowlist = 'DOMAIN_ALLOWLIST',
   Global = 'GLOBAL',
+  HybridLogisticApproval = 'HYBRID_LOGISTIC_APPROVAL',
   OrganicTimespent = 'ORGANIC_TIMESPENT',
   Syndicated = 'SYNDICATED',
   TopSaved = 'TOP_SAVED',

--- a/src/curated-corpus/helpers/definitions.ts
+++ b/src/curated-corpus/helpers/definitions.ts
@@ -32,12 +32,18 @@ export const topics: DropdownOption[] = [
 ];
 
 // All the possible Prospect types for filtering
-export const prospectFilterOptions: DropdownOption[] = [
-  { code: '', name: 'All Sources' },
-  { code: ProspectType.Global, name: 'Global' },
-  { code: ProspectType.OrganicTimespent, name: 'Time Spent' },
-  { code: ProspectType.Syndicated, name: 'Syndicated' },
-];
+const prospectFilters: DropdownOption[] = [{ code: '', name: 'All Sources' }];
+
+Object.keys(ProspectType).forEach((key, index) => {
+  prospectFilters.push({
+    // this gives us a value like ORGANIC_TIMESPENT
+    code: Object.values(ProspectType)[index],
+    // this gives us a value like OrganicTimespent
+    name: key,
+  });
+});
+
+export const prospectFilterOptions: DropdownOption[] = prospectFilters;
 
 // Language codes. Currently only English and German are needed.
 export const languages: DropdownOption[] = [

--- a/src/curated-corpus/helpers/getProspectFilterOptions.test.ts
+++ b/src/curated-corpus/helpers/getProspectFilterOptions.test.ts
@@ -14,28 +14,16 @@ describe('getProspectFilterOptions', () => {
   });
 
   it('returns all available options if all are present for given Scheduled Surface', () => {
-    const types: ProspectType[] = [
-      ProspectType.Global,
-      ProspectType.OrganicTimespent,
-      ProspectType.Syndicated,
-    ];
+    const types: ProspectType[] = Object.values(ProspectType);
 
     const options = getProspectFilterOptions(types);
 
-    // 3 prospect types + 1 'All Sources' option
-    expect(options).to.have.lengthOf(4);
+    // all prospect types + 1 'All Sources' option
+    expect(options).to.have.lengthOf(Object.values(ProspectType).length + 1);
 
+    // first option should be 'All Sources'
     expect(options[0].code).to.be.an.empty.string;
     expect(options[0].name).to.equal('All Sources');
-
-    expect(options[1].code).to.equal(ProspectType.Global);
-    expect(options[1].name).to.equal('Global');
-
-    expect(options[2].code).to.equal(ProspectType.OrganicTimespent);
-    expect(options[2].name).to.equal('Time Spent');
-
-    expect(options[3].code).to.equal(ProspectType.Syndicated);
-    expect(options[3].name).to.equal('Syndicated');
   });
 
   it('returns a cut-down list of prospect types if only some are available for given Scheduled Surface', () => {


### PR DESCRIPTION
## Goal

update shared data prospect types.

- also make drop down of prospect types dynamic based off generatedTypes
  (at the expense of a little readability)

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1376

## Implementation Decisions

i chose to sacrifice some readability so our prospect types dropdown will automatically update whenever we add new prospect types.
