### PR TITLE
fix(corpus): [BACK-1380] Cannot edit items in the corpus - language enum error

### DIFF
--- a/src/curated-corpus/helpers/definitions.ts
+++ b/src/curated-corpus/helpers/definitions.ts
@@ -47,8 +47,8 @@ export const prospectFilterOptions: DropdownOption[] = prospectFilters;
 
 // Language codes. Currently only English and German are needed.
 export const languages: DropdownOption[] = [
-  { code: 'EN', name: 'English' },
-  { code: 'DE', name: 'German' },
+  { code: CorpusLanguage.En, name: 'English' },
+  { code: CorpusLanguage.De, name: 'German' },
 ];
 
 // This maps to the status (CuratedStatus type) field in DB for an ApprovedItem

--- a/src/curated-corpus/pages/ApprovedItemsPage/ApprovedItemsPage.tsx
+++ b/src/curated-corpus/pages/ApprovedItemsPage/ApprovedItemsPage.tsx
@@ -218,21 +218,16 @@ export const ApprovedItemsPage: React.FC = (): JSX.Element => {
     values: FormikValues,
     formikHelpers: FormikHelpers<any>
   ): void => {
-    // Mapping these values to match the format that mutation/DB accepts
-    const languageCode: string = values.language === 'English' ? 'en' : 'de';
-    const curationStatus: string = values.curationStatus.toUpperCase();
-    const topic: string = values.topic.toUpperCase();
-
     const variables = {
       data: {
         externalId: currentItem?.externalId,
         title: values.title,
         excerpt: values.excerpt,
-        status: curationStatus,
-        language: languageCode,
+        status: values.curationStatus,
+        language: values.language,
         publisher: values.publisher,
         imageUrl: values.imageUrl,
-        topic: topic,
+        topic: values.topic,
         isTimeSensitive: values.timeSensitive,
       },
     };
@@ -243,7 +238,7 @@ export const ApprovedItemsPage: React.FC = (): JSX.Element => {
       { variables },
       `Curated item "${currentItem?.title.substring(
         0,
-        50
+        40
       )}..." successfully updated`,
       () => {
         toggleEditModal();


### PR DESCRIPTION
## Goal

Allow curators to edit approved items again.

- Removed string transformations that are no longer necessary to conform
to mutation input requirements and that were the cause of the bug.

- Updated shared data to use enums.

## Reference

Tickets:

-https://getpocket.atlassian.net/browse/BACK-1380


