### PR TITLE
refactor: [BACK-1377] Remove `Curated` from query/mutation names

### DIFF
--- a/src/api/fragments/curatedItemData.ts
+++ b/src/api/fragments/curatedItemData.ts
@@ -4,7 +4,7 @@ import { gql } from '@apollo/client';
  * Everything we need to fetch for a Curated Item
  */
 export const CuratedItemData = gql`
-  fragment CuratedItemData on ApprovedCuratedCorpusItem {
+  fragment CuratedItemData on ApprovedCorpusItem {
     externalId
     prospectId
     title

--- a/src/api/fragments/rejectedItemData.ts
+++ b/src/api/fragments/rejectedItemData.ts
@@ -1,10 +1,10 @@
 import { gql } from '@apollo/client';
 
 /**
- * All the fields for a Rejected Curated Corpus Item
+ * All the fields for a Rejected Corpus Item
  */
 export const RejectedItemData = gql`
-  fragment RejectedItemData on RejectedCuratedCorpusItem {
+  fragment RejectedItemData on RejectedCorpusItem {
     externalId
     prospectId
     url

--- a/src/api/fragments/scheduledItemData.ts
+++ b/src/api/fragments/scheduledItemData.ts
@@ -2,10 +2,10 @@ import { gql } from '@apollo/client';
 import { CuratedItemData } from './curatedItemData';
 
 /**
- * All the fields for a Scheduled Curated Corpus Item
+ * All the fields for a Scheduled Corpus Item
  */
 export const ScheduledItemData = gql`
-  fragment ScheduledItemData on ScheduledCuratedCorpusItem {
+  fragment ScheduledItemData on ScheduledCorpusItem {
     approvedItem {
       ...CuratedItemData
     }

--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -20,24 +20,32 @@ export type Scalars = {
   Int: number;
   Float: number;
   _FieldSet: any;
-  /** A date in the YYYY-MM-DD format. */
+  /** A date string, such as 2007-12-03, compliant with the `full-date` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar. */
   Date: any;
+  /** A String representing a date in the format of `yyyy-MM-dd HH:mm:ss` */
   DateString: any;
+  /**
+   * A string formatted with CommonMark markdown,
+   * plus the strikethrough extension from GFM.
+   * This Scalar is for documentation purposes; otherwise
+   * not treated differently from String in the API.
+   */
   Markdown: any;
+  /** The `Upload` scalar type represents a file upload. */
   Upload: any;
-  /** These are all just renamed strings right now */
+  /** A URL - usually, for an interesting story on the internet that's worth saving to Pocket. */
   Url: any;
 };
 
-export type ApprovedCuratedCorpusImageUrl = {
-  __typename?: 'ApprovedCuratedCorpusImageUrl';
+export type ApprovedCorpusImageUrl = {
+  __typename?: 'ApprovedCorpusImageUrl';
   /** The url of the image stored in the s3 bucket */
   url: Scalars['String'];
 };
 
-/** A prospective story that has been reviewed by the curators and saved to the curated corpus. */
-export type ApprovedCuratedCorpusItem = {
-  __typename?: 'ApprovedCuratedCorpusItem';
+/** A prospective story that has been reviewed by the curators and saved to the corpus. */
+export type ApprovedCorpusItem = {
+  __typename?: 'ApprovedCorpusItem';
   /** A Unix timestamp of when the entity was created. */
   createdAt: Scalars['Int'];
   /** A single sign-on user identifier of the user who created this entity. */
@@ -86,10 +94,10 @@ export type ApprovedCuratedCorpusItem = {
 };
 
 /** The connection type for Approved Item. */
-export type ApprovedCuratedCorpusItemConnection = {
-  __typename?: 'ApprovedCuratedCorpusItemConnection';
+export type ApprovedCorpusItemConnection = {
+  __typename?: 'ApprovedCorpusItemConnection';
   /** A list of edges. */
-  edges: Array<ApprovedCuratedCorpusItemEdge>;
+  edges: Array<ApprovedCorpusItemEdge>;
   /** Information to aid in pagination. */
   pageInfo: PageInfo;
   /** Identifies the total count of Approved Items in the connection. */
@@ -97,16 +105,16 @@ export type ApprovedCuratedCorpusItemConnection = {
 };
 
 /** An edge in a connection. */
-export type ApprovedCuratedCorpusItemEdge = {
-  __typename?: 'ApprovedCuratedCorpusItemEdge';
+export type ApprovedCorpusItemEdge = {
+  __typename?: 'ApprovedCorpusItemEdge';
   /** A cursor for use in pagination. */
   cursor: Scalars['String'];
   /** The Approved Item at the end of the edge. */
-  node: ApprovedCuratedCorpusItem;
+  node: ApprovedCorpusItem;
 };
 
-/** Available fields for filtering ApprovedCuratedCorpusItems. */
-export type ApprovedCuratedCorpusItemFilter = {
+/** Available fields for filtering Approved Items. */
+export type ApprovedCorpusItemFilter = {
   /**
    * Optional filter on the language Approved Items have been classified as.
    * This is a two-letter string, e.g. 'EN' for English or 'DE' for 'German'.
@@ -326,7 +334,6 @@ export enum CorpusItemSource {
   Prospect = 'PROSPECT',
 }
 
-/** Valid language codes for curated corpus items. */
 export enum CorpusLanguage {
   /** German */
   De = 'DE',
@@ -335,7 +342,7 @@ export enum CorpusLanguage {
 }
 
 /** Input data for creating an Approved Item and optionally scheduling this item to appear on a Scheduled Surface. */
-export type CreateApprovedCuratedCorpusItemInput = {
+export type CreateApprovedCorpusItemInput = {
   /** The excerpt of the Approved Item. */
   excerpt: Scalars['String'];
   /** The image URL for this item's accompanying picture. */
@@ -426,7 +433,7 @@ export type CreateCollectionStoryInput = {
 };
 
 /** Input data for creating a Rejected Item. */
-export type CreateRejectedCuratedCorpusItemInput = {
+export type CreateRejectedCorpusItemInput = {
   /** What language this item is in. This is a two-letter code, for example, 'EN' for English. */
   language?: InputMaybe<CorpusLanguage>;
   /** The GUID of the corresponding Prospect ID. Will be empty for manually added item. */
@@ -447,7 +454,7 @@ export type CreateRejectedCuratedCorpusItemInput = {
 };
 
 /** Input data for creating a scheduled entry for an Approved Item on a Scheduled Surface. */
-export type CreateScheduledCuratedCorpusItemInput = {
+export type CreateScheduledCorpusItemInput = {
   /** The ID of the Approved Item that needs to be scheduled. */
   approvedItemExternalId: Scalars['ID'];
   /** The date the associated Approved Item is scheduled to appear on a Scheduled Surface. Format: YYYY-MM-DD. */
@@ -476,7 +483,7 @@ export type DeleteCollectionPartnerAssociationInput = {
 };
 
 /** Input data for deleting a scheduled item for a Scheduled Surface. */
-export type DeleteScheduledCuratedCorpusItemInput = {
+export type DeleteScheduledCorpusItemInput = {
   /** ID of the scheduled item. A string in UUID format. */
   externalId: Scalars['ID'];
 };
@@ -547,7 +554,7 @@ export enum Imageness {
  * Input data for loading an Approved Item via an automated process and optionally scheduling
  * this item to appear on a Scheduled Surface.
  */
-export type ImportApprovedCuratedCorpusItemInput = {
+export type ImportApprovedCorpusItemInput = {
   /** A Unix timestamp of when the entity was created. */
   createdAt: Scalars['Int'];
   /** A single sign-on user identifier of the user who created this entity. */
@@ -585,12 +592,12 @@ export type ImportApprovedCuratedCorpusItemInput = {
 };
 
 /** The data that the loadApprovedCuratedCorpusItem mutation returns on success. */
-export type ImportApprovedCuratedCorpusItemPayload = {
-  __typename?: 'ImportApprovedCuratedCorpusItemPayload';
+export type ImportApprovedCorpusItemPayload = {
+  __typename?: 'ImportApprovedCorpusItemPayload';
   /** The approved item, as created by an automated process. */
-  approvedItem: ApprovedCuratedCorpusItem;
+  approvedItem: ApprovedCorpusItem;
   /** The scheduled entry that is created by an automated process at the same time. */
-  scheduledItem: ScheduledCuratedCorpusItem;
+  scheduledItem: ScheduledCorpusItem;
 };
 
 /**
@@ -815,7 +822,7 @@ export type Mutation = {
    */
   collectionImageUpload: CollectionImageUrl;
   /** Creates an Approved Item and optionally schedules it to appear on a Scheduled Surface. */
-  createApprovedCuratedCorpusItem: ApprovedCuratedCorpusItem;
+  createApprovedCorpusItem: ApprovedCorpusItem;
   /** Creates a Collection. */
   createCollection: Collection;
   /** Creates a CollectionAuthor. */
@@ -827,28 +834,28 @@ export type Mutation = {
   /** Creates a CollectionStory. */
   createCollectionStory: CollectionStory;
   /** Creates a Rejected Item. */
-  createRejectedCuratedCorpusItem: RejectedCuratedCorpusItem;
+  createRejectedCorpusItem: RejectedCorpusItem;
   /** Creates a Scheduled Surface Scheduled Item. */
-  createScheduledCuratedCorpusItem: ScheduledCuratedCorpusItem;
+  createScheduledCorpusItem: ScheduledCorpusItem;
   /** Deletes a CollectionPartnerAssociation. */
   deleteCollectionPartnerAssociation: CollectionPartnerAssociation;
   /** Deletes a CollectionStory. Also deletes all the related CollectionStoryAuthor records. */
   deleteCollectionStory: CollectionStory;
   /** Deletes an item from a Scheduled Surface. */
-  deleteScheduledCuratedCorpusItem: ScheduledCuratedCorpusItem;
+  deleteScheduledCorpusItem: ScheduledCorpusItem;
   /**
    * Lets an automated process create an Approved Item and optionally schedule it to appear
    * on a Scheduled Surface.
    */
-  importApprovedCuratedCorpusItem: ImportApprovedCuratedCorpusItemPayload;
+  importApprovedCorpusItem: ImportApprovedCorpusItemPayload;
   /** Refresh an {Item}'s article content. */
   refreshItemArticle: Item;
   /** Rejects an Approved Item: deletes it from the corpus and creates a Rejected Item instead. */
-  rejectApprovedCuratedCorpusItem: ApprovedCuratedCorpusItem;
+  rejectApprovedCorpusItem: ApprovedCorpusItem;
   /** Updates the scheduled date of a Scheduled Surface Scheduled Item. */
-  rescheduleScheduledCuratedCorpusItem: ScheduledCuratedCorpusItem;
+  rescheduleScheduledCorpusItem: ScheduledCorpusItem;
   /** Updates an Approved Item. */
-  updateApprovedCuratedCorpusItem: ApprovedCuratedCorpusItem;
+  updateApprovedCorpusItem: ApprovedCorpusItem;
   /** Updates a Collection. */
   updateCollection: Collection;
   /** Updates a CollectionAuthor. */
@@ -894,16 +901,16 @@ export type Mutation = {
    * returns true if the operation succeeds, false if not (almost surely due to an incorrect prospectId).
    */
   updateProspectAsCurated?: Maybe<Prospect>;
-  /** Uploads an image to S3 for an Approved Curated Corpus Item */
-  uploadApprovedCuratedCorpusItemImage: ApprovedCuratedCorpusImageUrl;
+  /** Uploads an image to S3 for an Approved Item */
+  uploadApprovedCorpusItemImage: ApprovedCorpusImageUrl;
 };
 
 export type MutationCollectionImageUploadArgs = {
   data: CollectionImageUploadInput;
 };
 
-export type MutationCreateApprovedCuratedCorpusItemArgs = {
-  data: CreateApprovedCuratedCorpusItemInput;
+export type MutationCreateApprovedCorpusItemArgs = {
+  data: CreateApprovedCorpusItemInput;
 };
 
 export type MutationCreateCollectionArgs = {
@@ -926,12 +933,12 @@ export type MutationCreateCollectionStoryArgs = {
   data: CreateCollectionStoryInput;
 };
 
-export type MutationCreateRejectedCuratedCorpusItemArgs = {
-  data: CreateRejectedCuratedCorpusItemInput;
+export type MutationCreateRejectedCorpusItemArgs = {
+  data: CreateRejectedCorpusItemInput;
 };
 
-export type MutationCreateScheduledCuratedCorpusItemArgs = {
-  data: CreateScheduledCuratedCorpusItemInput;
+export type MutationCreateScheduledCorpusItemArgs = {
+  data: CreateScheduledCorpusItemInput;
 };
 
 export type MutationDeleteCollectionPartnerAssociationArgs = {
@@ -942,28 +949,28 @@ export type MutationDeleteCollectionStoryArgs = {
   externalId: Scalars['String'];
 };
 
-export type MutationDeleteScheduledCuratedCorpusItemArgs = {
-  data: DeleteScheduledCuratedCorpusItemInput;
+export type MutationDeleteScheduledCorpusItemArgs = {
+  data: DeleteScheduledCorpusItemInput;
 };
 
-export type MutationImportApprovedCuratedCorpusItemArgs = {
-  data: ImportApprovedCuratedCorpusItemInput;
+export type MutationImportApprovedCorpusItemArgs = {
+  data: ImportApprovedCorpusItemInput;
 };
 
 export type MutationRefreshItemArticleArgs = {
   url: Scalars['String'];
 };
 
-export type MutationRejectApprovedCuratedCorpusItemArgs = {
-  data: RejectApprovedCuratedCorpusItemInput;
+export type MutationRejectApprovedCorpusItemArgs = {
+  data: RejectApprovedCorpusItemInput;
 };
 
-export type MutationRescheduleScheduledCuratedCorpusItemArgs = {
-  data: RescheduleScheduledCuratedCorpusItemInput;
+export type MutationRescheduleScheduledCorpusItemArgs = {
+  data: RescheduleScheduledCorpusItemInput;
 };
 
-export type MutationUpdateApprovedCuratedCorpusItemArgs = {
-  data: UpdateApprovedCuratedCorpusItemInput;
+export type MutationUpdateApprovedCorpusItemArgs = {
+  data: UpdateApprovedCorpusItemInput;
 };
 
 export type MutationUpdateCollectionArgs = {
@@ -1014,7 +1021,7 @@ export type MutationUpdateProspectAsCuratedArgs = {
   prospectId: Scalars['ID'];
 };
 
-export type MutationUploadApprovedCuratedCorpusItemImageArgs = {
+export type MutationUploadApprovedCorpusItemImageArgs = {
   data: Scalars['Upload'];
 };
 
@@ -1089,7 +1096,7 @@ export type PaginationInput = {
 
 export type Prospect = {
   __typename?: 'Prospect';
-  approvedCorpusItem?: Maybe<ApprovedCuratedCorpusItem>;
+  approvedCorpusItem?: Maybe<ApprovedCorpusItem>;
   createdAt?: Maybe<Scalars['Int']>;
   domain?: Maybe<Scalars['String']>;
   excerpt?: Maybe<Scalars['String']>;
@@ -1123,10 +1130,10 @@ export enum ProspectType {
 
 export type Query = {
   __typename?: 'Query';
-  /** Retrieves an approved curated item with the given URL. */
-  getApprovedCuratedCorpusItemByUrl?: Maybe<ApprovedCuratedCorpusItem>;
-  /** Retrieves a paginated, filterable list of ApprovedCuratedCorpusItems. */
-  getApprovedCuratedCorpusItems: ApprovedCuratedCorpusItemConnection;
+  /** Retrieves an approved item with the given URL. */
+  getApprovedCorpusItemByUrl?: Maybe<ApprovedCorpusItem>;
+  /** Retrieves a paginated, filterable list of Approved Items. */
+  getApprovedCorpusItems: ApprovedCorpusItemConnection;
   /** Retrieves a Collection by externalId. */
   getCollection?: Maybe<Collection>;
   /** Retrieves a CollectionAuthor by externalId. */
@@ -1158,10 +1165,10 @@ export type Query = {
   getLanguages: Array<CollectionLanguage>;
   /** returns a set of at most 20 prospects (number may be smaller depending on available data) */
   getProspects: Array<Prospect>;
-  /** Retrieves a paginated, filterable list of RejectedCuratedCorpusItems. */
-  getRejectedCuratedCorpusItems: RejectedCuratedCorpusItemConnection;
+  /** Retrieves a paginated, filterable list of Rejected Items. */
+  getRejectedCorpusItems: RejectedCorpusItemConnection;
   /** Retrieves a list of Approved Items that are scheduled to appear on a Scheduled Surface. */
-  getScheduledCuratedCorpusItems: Array<ScheduledCuratedCorpusItemsResult>;
+  getScheduledCorpusItems: Array<ScheduledCorpusItemsResult>;
   /** Retrieves all ScheduledSurfaces available to the given SSO user. Requires an Authorization header. */
   getScheduledSurfacesForUser: Array<ScheduledSurface>;
   /** returns parser meta data for a given url */
@@ -1169,12 +1176,12 @@ export type Query = {
   searchCollections: CollectionsResult;
 };
 
-export type QueryGetApprovedCuratedCorpusItemByUrlArgs = {
+export type QueryGetApprovedCorpusItemByUrlArgs = {
   url: Scalars['String'];
 };
 
-export type QueryGetApprovedCuratedCorpusItemsArgs = {
-  filters?: InputMaybe<ApprovedCuratedCorpusItemFilter>;
+export type QueryGetApprovedCorpusItemsArgs = {
+  filters?: InputMaybe<ApprovedCorpusItemFilter>;
   pagination?: InputMaybe<PaginationInput>;
 };
 
@@ -1224,13 +1231,13 @@ export type QueryGetProspectsArgs = {
   filters: GetProspectsFilters;
 };
 
-export type QueryGetRejectedCuratedCorpusItemsArgs = {
-  filters?: InputMaybe<RejectedCuratedCorpusItemFilter>;
+export type QueryGetRejectedCorpusItemsArgs = {
+  filters?: InputMaybe<RejectedCorpusItemFilter>;
   pagination?: InputMaybe<PaginationInput>;
 };
 
-export type QueryGetScheduledCuratedCorpusItemsArgs = {
-  filters: ScheduledCuratedCorpusItemsFilterInput;
+export type QueryGetScheduledCorpusItemsArgs = {
+  filters: ScheduledCorpusItemsFilterInput;
 };
 
 export type QueryGetUrlMetadataArgs = {
@@ -1244,7 +1251,7 @@ export type QuerySearchCollectionsArgs = {
 };
 
 /** Input data for rejecting an Approved Item. */
-export type RejectApprovedCuratedCorpusItemInput = {
+export type RejectApprovedCorpusItemInput = {
   /** Approved Item ID. */
   externalId: Scalars['ID'];
   /** A comma-separated list of rejection reasons. */
@@ -1252,8 +1259,8 @@ export type RejectApprovedCuratedCorpusItemInput = {
 };
 
 /** A prospective story that has been rejected by the curators. */
-export type RejectedCuratedCorpusItem = {
-  __typename?: 'RejectedCuratedCorpusItem';
+export type RejectedCorpusItem = {
+  __typename?: 'RejectedCorpusItem';
   /** A Unix timestamp of when the entity was created. */
   createdAt: Scalars['Int'];
   /** A single sign-on user identifier of the user who created this entity. */
@@ -1279,28 +1286,28 @@ export type RejectedCuratedCorpusItem = {
   url: Scalars['Url'];
 };
 
-/** The connection type for Rejected Curated Item. */
-export type RejectedCuratedCorpusItemConnection = {
-  __typename?: 'RejectedCuratedCorpusItemConnection';
+/** The connection type for Rejected Item. */
+export type RejectedCorpusItemConnection = {
+  __typename?: 'RejectedCorpusItemConnection';
   /** A list of edges. */
-  edges: Array<RejectedCuratedCorpusItemEdge>;
+  edges: Array<RejectedCorpusItemEdge>;
   /** Information to aid in pagination. */
   pageInfo: PageInfo;
   /** Identifies the total count of Rejected Curated Items in the connection. */
   totalCount: Scalars['Int'];
 };
 
-/** An edge in a connection for RejectedCuratedCorpusItem type. */
-export type RejectedCuratedCorpusItemEdge = {
-  __typename?: 'RejectedCuratedCorpusItemEdge';
+/** An edge in a connection for RejectedCorpusItem type. */
+export type RejectedCorpusItemEdge = {
+  __typename?: 'RejectedCorpusItemEdge';
   /** A cursor for use in pagination. */
   cursor: Scalars['String'];
-  /** The Rejected Curated Item at the end of the edge. */
-  node: RejectedCuratedCorpusItem;
+  /** The Rejected Item at the end of the edge. */
+  node: RejectedCorpusItem;
 };
 
-/** Available fields for filtering RejectedCuratedCorpusItems. */
-export type RejectedCuratedCorpusItemFilter = {
+/** Available fields for filtering Rejected Items. */
+export type RejectedCorpusItemFilter = {
   /**
    * Optional filter on the language Rejected Curated Items have been classified as.
    * This is a two-letter string, e.g. 'EN' for English or 'DE' for 'German'.
@@ -1328,7 +1335,7 @@ export enum RejectionReason {
 }
 
 /** Input data for rescheduling a scheduled item for a Scheduled Surface. */
-export type RescheduleScheduledCuratedCorpusItemInput = {
+export type RescheduleScheduledCorpusItemInput = {
   /** ID of the scheduled item. A string in UUID format. */
   externalId: Scalars['ID'];
   /** The new scheduled date for the scheduled item to appear on a Scheduled Surface. Format: YYYY-MM-DD. */
@@ -1339,10 +1346,10 @@ export type RescheduleScheduledCuratedCorpusItemInput = {
  * A scheduled entry for an Approved Item to appear on a Scheduled Surface.
  * For example, a story that is scheduled to appear on December 31st, 2021 on the New Tab in Firefox for the US audience.
  */
-export type ScheduledCuratedCorpusItem = {
-  __typename?: 'ScheduledCuratedCorpusItem';
+export type ScheduledCorpusItem = {
+  __typename?: 'ScheduledCorpusItem';
   /** The associated Approved Item. */
-  approvedItem: ApprovedCuratedCorpusItem;
+  approvedItem: ApprovedCorpusItem;
   /** A Unix timestamp of when the entity was created. */
   createdAt: Scalars['Int'];
   /** A single sign-on user identifier of the user who created this entity. */
@@ -1354,7 +1361,7 @@ export type ScheduledCuratedCorpusItem = {
    * This date is relative to the time zone of the Scheduled Surface. Format: YYYY-MM-DD.
    */
   scheduledDate: Scalars['Date'];
-  /** The GUID of this schedudedSurface to which this item is scheduled. Example: 'NEW_TAB_EN_US'. */
+  /** The GUID of this scheduledSurface to which this item is scheduled. Example: 'NEW_TAB_EN_US'. */
   scheduledSurfaceGuid: Scalars['ID'];
   /** A Unix timestamp of when the entity was last updated. */
   updatedAt: Scalars['Int'];
@@ -1363,7 +1370,7 @@ export type ScheduledCuratedCorpusItem = {
 };
 
 /** Available fields for filtering scheduled items for a given Scheduled Surface. */
-export type ScheduledCuratedCorpusItemsFilterInput = {
+export type ScheduledCorpusItemsFilterInput = {
   /** To what day to show scheduled items to, inclusive. Expects a date in YYYY-MM-DD format. */
   endDate: Scalars['Date'];
   /** The GUID of the Scheduled Surface. Example: 'NEW_TAB_EN_US'. */
@@ -1372,13 +1379,13 @@ export type ScheduledCuratedCorpusItemsFilterInput = {
   startDate: Scalars['Date'];
 };
 
-/** The shape of the result returned by the getScheduledCuratedCorpusItems query. */
-export type ScheduledCuratedCorpusItemsResult = {
-  __typename?: 'ScheduledCuratedCorpusItemsResult';
+/** The shape of the result returned by the getScheduledCorpusItems query. */
+export type ScheduledCorpusItemsResult = {
+  __typename?: 'ScheduledCorpusItemsResult';
   /** The number of curated items that are collections for the scheduled date. */
   collectionCount: Scalars['Int'];
   /** An array of items for a given Scheduled Surface */
-  items: Array<ScheduledCuratedCorpusItem>;
+  items: Array<ScheduledCorpusItem>;
   /** The date items are scheduled for, in YYYY-MM-DD format. */
   scheduledDate: Scalars['Date'];
   /** The number of syndicated articles for the scheduled date. */
@@ -1438,7 +1445,7 @@ export type UnMarseable = {
 };
 
 /** Input data for updating an Approved Item. */
-export type UpdateApprovedCuratedCorpusItemInput = {
+export type UpdateApprovedCorpusItemInput = {
   /** The excerpt of the Approved Item. */
   excerpt: Scalars['String'];
   /** Approved Item ID. */
@@ -1712,7 +1719,7 @@ export type CollectionStoryDataFragment = {
 };
 
 export type CuratedItemDataFragment = {
-  __typename?: 'ApprovedCuratedCorpusItem';
+  __typename?: 'ApprovedCorpusItem';
   externalId: string;
   prospectId?: string | null;
   title: string;
@@ -1753,7 +1760,7 @@ export type ProspectDataFragment = {
 };
 
 export type RejectedItemDataFragment = {
-  __typename?: 'RejectedCuratedCorpusItem';
+  __typename?: 'RejectedCorpusItem';
   externalId: string;
   prospectId?: string | null;
   url: any;
@@ -1767,7 +1774,7 @@ export type RejectedItemDataFragment = {
 };
 
 export type ScheduledItemDataFragment = {
-  __typename?: 'ScheduledCuratedCorpusItem';
+  __typename?: 'ScheduledCorpusItem';
   scheduledSurfaceGuid: string;
   createdAt: number;
   createdBy: string;
@@ -1776,7 +1783,7 @@ export type ScheduledItemDataFragment = {
   updatedAt: number;
   updatedBy?: string | null;
   approvedItem: {
-    __typename?: 'ApprovedCuratedCorpusItem';
+    __typename?: 'ApprovedCorpusItem';
     externalId: string;
     prospectId?: string | null;
     title: string;
@@ -1811,14 +1818,14 @@ export type UrlMetadataFragment = {
   isCollection?: boolean | null;
 };
 
-export type CreateApprovedCuratedCorpusItemMutationVariables = Exact<{
-  data: CreateApprovedCuratedCorpusItemInput;
+export type CreateApprovedCorpusItemMutationVariables = Exact<{
+  data: CreateApprovedCorpusItemInput;
 }>;
 
-export type CreateApprovedCuratedCorpusItemMutation = {
+export type CreateApprovedCorpusItemMutation = {
   __typename?: 'Mutation';
-  createApprovedCuratedCorpusItem: {
-    __typename?: 'ApprovedCuratedCorpusItem';
+  createApprovedCorpusItem: {
+    __typename?: 'ApprovedCorpusItem';
     externalId: string;
     prospectId?: string | null;
     title: string;
@@ -2007,16 +2014,16 @@ export type CreateCollectionStoryMutation = {
   };
 };
 
-export type CreateScheduledCuratedCorpusItemMutationVariables = Exact<{
+export type CreateScheduledCorpusItemMutationVariables = Exact<{
   approvedItemExternalId: Scalars['ID'];
   scheduledSurfaceGuid: Scalars['ID'];
   scheduledDate: Scalars['Date'];
 }>;
 
-export type CreateScheduledCuratedCorpusItemMutation = {
+export type CreateScheduledCorpusItemMutation = {
   __typename?: 'Mutation';
-  createScheduledCuratedCorpusItem: {
-    __typename?: 'ScheduledCuratedCorpusItem';
+  createScheduledCorpusItem: {
+    __typename?: 'ScheduledCorpusItem';
     externalId: string;
     createdAt: number;
     createdBy: string;
@@ -2024,7 +2031,7 @@ export type CreateScheduledCuratedCorpusItemMutation = {
     updatedBy?: string | null;
     scheduledDate: any;
     approvedItem: {
-      __typename?: 'ApprovedCuratedCorpusItem';
+      __typename?: 'ApprovedCorpusItem';
       externalId: string;
       prospectId?: string | null;
       title: string;
@@ -2102,8 +2109,8 @@ export type DeleteScheduledItemMutationVariables = Exact<{
 
 export type DeleteScheduledItemMutation = {
   __typename?: 'Mutation';
-  deleteScheduledCuratedCorpusItem: {
-    __typename?: 'ScheduledCuratedCorpusItem';
+  deleteScheduledCorpusItem: {
+    __typename?: 'ScheduledCorpusItem';
     externalId: string;
     createdAt: number;
     createdBy: string;
@@ -2111,7 +2118,7 @@ export type DeleteScheduledItemMutation = {
     updatedBy?: string | null;
     scheduledDate: any;
     approvedItem: {
-      __typename?: 'ApprovedCuratedCorpusItem';
+      __typename?: 'ApprovedCorpusItem';
       externalId: string;
       prospectId?: string | null;
       title: string;
@@ -2147,13 +2154,13 @@ export type ImageUploadMutation = {
 };
 
 export type RejectApprovedItemMutationVariables = Exact<{
-  data: RejectApprovedCuratedCorpusItemInput;
+  data: RejectApprovedCorpusItemInput;
 }>;
 
 export type RejectApprovedItemMutation = {
   __typename?: 'Mutation';
-  rejectApprovedCuratedCorpusItem: {
-    __typename?: 'ApprovedCuratedCorpusItem';
+  rejectApprovedCorpusItem: {
+    __typename?: 'ApprovedCorpusItem';
     externalId: string;
     prospectId?: string | null;
     title: string;
@@ -2176,13 +2183,13 @@ export type RejectApprovedItemMutation = {
 };
 
 export type RejectProspectMutationVariables = Exact<{
-  data: CreateRejectedCuratedCorpusItemInput;
+  data: CreateRejectedCorpusItemInput;
 }>;
 
 export type RejectProspectMutation = {
   __typename?: 'Mutation';
-  createRejectedCuratedCorpusItem: {
-    __typename?: 'RejectedCuratedCorpusItem';
+  createRejectedCorpusItem: {
+    __typename?: 'RejectedCorpusItem';
     externalId: string;
     prospectId?: string | null;
     url: any;
@@ -2196,15 +2203,15 @@ export type RejectProspectMutation = {
   };
 };
 
-export type RescheduleScheduledCuratedCorpusItemMutationVariables = Exact<{
+export type RescheduleScheduledCorpusItemMutationVariables = Exact<{
   externalId: Scalars['ID'];
   scheduledDate: Scalars['Date'];
 }>;
 
-export type RescheduleScheduledCuratedCorpusItemMutation = {
+export type RescheduleScheduledCorpusItemMutation = {
   __typename?: 'Mutation';
-  rescheduleScheduledCuratedCorpusItem: {
-    __typename?: 'ScheduledCuratedCorpusItem';
+  rescheduleScheduledCorpusItem: {
+    __typename?: 'ScheduledCorpusItem';
     scheduledSurfaceGuid: string;
     createdAt: number;
     createdBy: string;
@@ -2213,7 +2220,7 @@ export type RescheduleScheduledCuratedCorpusItemMutation = {
     updatedAt: number;
     updatedBy?: string | null;
     approvedItem: {
-      __typename?: 'ApprovedCuratedCorpusItem';
+      __typename?: 'ApprovedCorpusItem';
       externalId: string;
       prospectId?: string | null;
       title: string;
@@ -2236,14 +2243,14 @@ export type RescheduleScheduledCuratedCorpusItemMutation = {
   };
 };
 
-export type UpdateApprovedCuratedCorpusItemMutationVariables = Exact<{
-  data: UpdateApprovedCuratedCorpusItemInput;
+export type UpdateApprovedCorpusItemMutationVariables = Exact<{
+  data: UpdateApprovedCorpusItemInput;
 }>;
 
-export type UpdateApprovedCuratedCorpusItemMutation = {
+export type UpdateApprovedCorpusItemMutation = {
   __typename?: 'Mutation';
-  updateApprovedCuratedCorpusItem: {
-    __typename?: 'ApprovedCuratedCorpusItem';
+  updateApprovedCorpusItem: {
+    __typename?: 'ApprovedCorpusItem';
     externalId: string;
     prospectId?: string | null;
     title: string;
@@ -2630,14 +2637,14 @@ export type UpdateProspectAsCuratedMutation = {
   } | null;
 };
 
-export type UploadApprovedCuratedCorpusItemImageMutationVariables = Exact<{
+export type UploadApprovedCorpusItemImageMutationVariables = Exact<{
   image: Scalars['Upload'];
 }>;
 
-export type UploadApprovedCuratedCorpusItemImageMutation = {
+export type UploadApprovedCorpusItemImageMutation = {
   __typename?: 'Mutation';
-  uploadApprovedCuratedCorpusItemImage: {
-    __typename?: 'ApprovedCuratedCorpusImageUrl';
+  uploadApprovedCorpusItemImage: {
+    __typename?: 'ApprovedCorpusImageUrl';
     url: string;
   };
 };
@@ -2648,8 +2655,8 @@ export type GetApprovedItemByUrlQueryVariables = Exact<{
 
 export type GetApprovedItemByUrlQuery = {
   __typename?: 'Query';
-  getApprovedCuratedCorpusItemByUrl?: {
-    __typename?: 'ApprovedCuratedCorpusItem';
+  getApprovedCorpusItemByUrl?: {
+    __typename?: 'ApprovedCorpusItem';
     externalId: string;
     prospectId?: string | null;
     title: string;
@@ -2672,14 +2679,14 @@ export type GetApprovedItemByUrlQuery = {
 };
 
 export type GetApprovedItemsQueryVariables = Exact<{
-  filters?: InputMaybe<ApprovedCuratedCorpusItemFilter>;
+  filters?: InputMaybe<ApprovedCorpusItemFilter>;
   pagination?: InputMaybe<PaginationInput>;
 }>;
 
 export type GetApprovedItemsQuery = {
   __typename?: 'Query';
-  getApprovedCuratedCorpusItems: {
-    __typename?: 'ApprovedCuratedCorpusItemConnection';
+  getApprovedCorpusItems: {
+    __typename?: 'ApprovedCorpusItemConnection';
     totalCount: number;
     pageInfo: {
       __typename?: 'PageInfo';
@@ -2689,10 +2696,10 @@ export type GetApprovedItemsQuery = {
       endCursor?: string | null;
     };
     edges: Array<{
-      __typename?: 'ApprovedCuratedCorpusItemEdge';
+      __typename?: 'ApprovedCorpusItemEdge';
       cursor: string;
       node: {
-        __typename?: 'ApprovedCuratedCorpusItem';
+        __typename?: 'ApprovedCorpusItem';
         externalId: string;
         prospectId?: string | null;
         title: string;
@@ -3044,14 +3051,14 @@ export type GetProspectsQuery = {
 };
 
 export type GetRejectedItemsQueryVariables = Exact<{
-  filters?: InputMaybe<RejectedCuratedCorpusItemFilter>;
+  filters?: InputMaybe<RejectedCorpusItemFilter>;
   pagination?: InputMaybe<PaginationInput>;
 }>;
 
 export type GetRejectedItemsQuery = {
   __typename?: 'Query';
-  getRejectedCuratedCorpusItems: {
-    __typename?: 'RejectedCuratedCorpusItemConnection';
+  getRejectedCorpusItems: {
+    __typename?: 'RejectedCorpusItemConnection';
     totalCount: number;
     pageInfo: {
       __typename?: 'PageInfo';
@@ -3061,10 +3068,10 @@ export type GetRejectedItemsQuery = {
       endCursor?: string | null;
     };
     edges: Array<{
-      __typename?: 'RejectedCuratedCorpusItemEdge';
+      __typename?: 'RejectedCorpusItemEdge';
       cursor: string;
       node: {
-        __typename?: 'RejectedCuratedCorpusItem';
+        __typename?: 'RejectedCorpusItem';
         externalId: string;
         prospectId?: string | null;
         url: any;
@@ -3081,13 +3088,13 @@ export type GetRejectedItemsQuery = {
 };
 
 export type GetScheduledItemCountsQueryVariables = Exact<{
-  filters: ScheduledCuratedCorpusItemsFilterInput;
+  filters: ScheduledCorpusItemsFilterInput;
 }>;
 
 export type GetScheduledItemCountsQuery = {
   __typename?: 'Query';
-  getScheduledCuratedCorpusItems: Array<{
-    __typename?: 'ScheduledCuratedCorpusItemsResult';
+  getScheduledCorpusItems: Array<{
+    __typename?: 'ScheduledCorpusItemsResult';
     collectionCount: number;
     syndicatedCount: number;
     totalCount: number;
@@ -3095,19 +3102,19 @@ export type GetScheduledItemCountsQuery = {
 };
 
 export type GetScheduledItemsQueryVariables = Exact<{
-  filters: ScheduledCuratedCorpusItemsFilterInput;
+  filters: ScheduledCorpusItemsFilterInput;
 }>;
 
 export type GetScheduledItemsQuery = {
   __typename?: 'Query';
-  getScheduledCuratedCorpusItems: Array<{
-    __typename?: 'ScheduledCuratedCorpusItemsResult';
+  getScheduledCorpusItems: Array<{
+    __typename?: 'ScheduledCorpusItemsResult';
     collectionCount: number;
     syndicatedCount: number;
     totalCount: number;
     scheduledDate: any;
     items: Array<{
-      __typename?: 'ScheduledCuratedCorpusItem';
+      __typename?: 'ScheduledCorpusItem';
       externalId: string;
       createdAt: number;
       createdBy: string;
@@ -3116,7 +3123,7 @@ export type GetScheduledItemsQuery = {
       scheduledDate: any;
       scheduledSurfaceGuid: string;
       approvedItem: {
-        __typename?: 'ApprovedCuratedCorpusItem';
+        __typename?: 'ApprovedCorpusItem';
         externalId: string;
         prospectId?: string | null;
         title: string;
@@ -3375,7 +3382,7 @@ export const ProspectDataFragmentDoc = gql`
   }
 `;
 export const RejectedItemDataFragmentDoc = gql`
-  fragment RejectedItemData on RejectedCuratedCorpusItem {
+  fragment RejectedItemData on RejectedCorpusItem {
     externalId
     prospectId
     url
@@ -3389,7 +3396,7 @@ export const RejectedItemDataFragmentDoc = gql`
   }
 `;
 export const CuratedItemDataFragmentDoc = gql`
-  fragment CuratedItemData on ApprovedCuratedCorpusItem {
+  fragment CuratedItemData on ApprovedCorpusItem {
     externalId
     prospectId
     title
@@ -3411,7 +3418,7 @@ export const CuratedItemDataFragmentDoc = gql`
   }
 `;
 export const ScheduledItemDataFragmentDoc = gql`
-  fragment ScheduledItemData on ScheduledCuratedCorpusItem {
+  fragment ScheduledItemData on ScheduledCorpusItem {
     approvedItem {
       ...CuratedItemData
     }
@@ -3438,59 +3445,57 @@ export const UrlMetadataFragmentDoc = gql`
     isCollection
   }
 `;
-export const CreateApprovedCuratedCorpusItemDocument = gql`
-  mutation createApprovedCuratedCorpusItem(
-    $data: CreateApprovedCuratedCorpusItemInput!
-  ) {
-    createApprovedCuratedCorpusItem(data: $data) {
+export const CreateApprovedCorpusItemDocument = gql`
+  mutation createApprovedCorpusItem($data: CreateApprovedCorpusItemInput!) {
+    createApprovedCorpusItem(data: $data) {
       ...CuratedItemData
     }
   }
   ${CuratedItemDataFragmentDoc}
 `;
-export type CreateApprovedCuratedCorpusItemMutationFn = Apollo.MutationFunction<
-  CreateApprovedCuratedCorpusItemMutation,
-  CreateApprovedCuratedCorpusItemMutationVariables
+export type CreateApprovedCorpusItemMutationFn = Apollo.MutationFunction<
+  CreateApprovedCorpusItemMutation,
+  CreateApprovedCorpusItemMutationVariables
 >;
 
 /**
- * __useCreateApprovedCuratedCorpusItemMutation__
+ * __useCreateApprovedCorpusItemMutation__
  *
- * To run a mutation, you first call `useCreateApprovedCuratedCorpusItemMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useCreateApprovedCuratedCorpusItemMutation` returns a tuple that includes:
+ * To run a mutation, you first call `useCreateApprovedCorpusItemMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateApprovedCorpusItemMutation` returns a tuple that includes:
  * - A mutate function that you can call at any time to execute the mutation
  * - An object with fields that represent the current status of the mutation's execution
  *
  * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
  *
  * @example
- * const [createApprovedCuratedCorpusItemMutation, { data, loading, error }] = useCreateApprovedCuratedCorpusItemMutation({
+ * const [createApprovedCorpusItemMutation, { data, loading, error }] = useCreateApprovedCorpusItemMutation({
  *   variables: {
  *      data: // value for 'data'
  *   },
  * });
  */
-export function useCreateApprovedCuratedCorpusItemMutation(
+export function useCreateApprovedCorpusItemMutation(
   baseOptions?: Apollo.MutationHookOptions<
-    CreateApprovedCuratedCorpusItemMutation,
-    CreateApprovedCuratedCorpusItemMutationVariables
+    CreateApprovedCorpusItemMutation,
+    CreateApprovedCorpusItemMutationVariables
   >
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
-    CreateApprovedCuratedCorpusItemMutation,
-    CreateApprovedCuratedCorpusItemMutationVariables
-  >(CreateApprovedCuratedCorpusItemDocument, options);
+    CreateApprovedCorpusItemMutation,
+    CreateApprovedCorpusItemMutationVariables
+  >(CreateApprovedCorpusItemDocument, options);
 }
-export type CreateApprovedCuratedCorpusItemMutationHookResult = ReturnType<
-  typeof useCreateApprovedCuratedCorpusItemMutation
+export type CreateApprovedCorpusItemMutationHookResult = ReturnType<
+  typeof useCreateApprovedCorpusItemMutation
 >;
-export type CreateApprovedCuratedCorpusItemMutationResult =
-  Apollo.MutationResult<CreateApprovedCuratedCorpusItemMutation>;
-export type CreateApprovedCuratedCorpusItemMutationOptions =
+export type CreateApprovedCorpusItemMutationResult =
+  Apollo.MutationResult<CreateApprovedCorpusItemMutation>;
+export type CreateApprovedCorpusItemMutationOptions =
   Apollo.BaseMutationOptions<
-    CreateApprovedCuratedCorpusItemMutation,
-    CreateApprovedCuratedCorpusItemMutationVariables
+    CreateApprovedCorpusItemMutation,
+    CreateApprovedCorpusItemMutationVariables
   >;
 export const CreateCollectionDocument = gql`
   mutation createCollection(
@@ -3864,13 +3869,13 @@ export type CreateCollectionStoryMutationOptions = Apollo.BaseMutationOptions<
   CreateCollectionStoryMutation,
   CreateCollectionStoryMutationVariables
 >;
-export const CreateScheduledCuratedCorpusItemDocument = gql`
-  mutation createScheduledCuratedCorpusItem(
+export const CreateScheduledCorpusItemDocument = gql`
+  mutation createScheduledCorpusItem(
     $approvedItemExternalId: ID!
     $scheduledSurfaceGuid: ID!
     $scheduledDate: Date!
   ) {
-    createScheduledCuratedCorpusItem(
+    createScheduledCorpusItem(
       data: {
         approvedItemExternalId: $approvedItemExternalId
         scheduledSurfaceGuid: $scheduledSurfaceGuid
@@ -3890,24 +3895,23 @@ export const CreateScheduledCuratedCorpusItemDocument = gql`
   }
   ${CuratedItemDataFragmentDoc}
 `;
-export type CreateScheduledCuratedCorpusItemMutationFn =
-  Apollo.MutationFunction<
-    CreateScheduledCuratedCorpusItemMutation,
-    CreateScheduledCuratedCorpusItemMutationVariables
-  >;
+export type CreateScheduledCorpusItemMutationFn = Apollo.MutationFunction<
+  CreateScheduledCorpusItemMutation,
+  CreateScheduledCorpusItemMutationVariables
+>;
 
 /**
- * __useCreateScheduledCuratedCorpusItemMutation__
+ * __useCreateScheduledCorpusItemMutation__
  *
- * To run a mutation, you first call `useCreateScheduledCuratedCorpusItemMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useCreateScheduledCuratedCorpusItemMutation` returns a tuple that includes:
+ * To run a mutation, you first call `useCreateScheduledCorpusItemMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateScheduledCorpusItemMutation` returns a tuple that includes:
  * - A mutate function that you can call at any time to execute the mutation
  * - An object with fields that represent the current status of the mutation's execution
  *
  * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
  *
  * @example
- * const [createScheduledCuratedCorpusItemMutation, { data, loading, error }] = useCreateScheduledCuratedCorpusItemMutation({
+ * const [createScheduledCorpusItemMutation, { data, loading, error }] = useCreateScheduledCorpusItemMutation({
  *   variables: {
  *      approvedItemExternalId: // value for 'approvedItemExternalId'
  *      scheduledSurfaceGuid: // value for 'scheduledSurfaceGuid'
@@ -3915,27 +3919,27 @@ export type CreateScheduledCuratedCorpusItemMutationFn =
  *   },
  * });
  */
-export function useCreateScheduledCuratedCorpusItemMutation(
+export function useCreateScheduledCorpusItemMutation(
   baseOptions?: Apollo.MutationHookOptions<
-    CreateScheduledCuratedCorpusItemMutation,
-    CreateScheduledCuratedCorpusItemMutationVariables
+    CreateScheduledCorpusItemMutation,
+    CreateScheduledCorpusItemMutationVariables
   >
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
-    CreateScheduledCuratedCorpusItemMutation,
-    CreateScheduledCuratedCorpusItemMutationVariables
-  >(CreateScheduledCuratedCorpusItemDocument, options);
+    CreateScheduledCorpusItemMutation,
+    CreateScheduledCorpusItemMutationVariables
+  >(CreateScheduledCorpusItemDocument, options);
 }
-export type CreateScheduledCuratedCorpusItemMutationHookResult = ReturnType<
-  typeof useCreateScheduledCuratedCorpusItemMutation
+export type CreateScheduledCorpusItemMutationHookResult = ReturnType<
+  typeof useCreateScheduledCorpusItemMutation
 >;
-export type CreateScheduledCuratedCorpusItemMutationResult =
-  Apollo.MutationResult<CreateScheduledCuratedCorpusItemMutation>;
-export type CreateScheduledCuratedCorpusItemMutationOptions =
+export type CreateScheduledCorpusItemMutationResult =
+  Apollo.MutationResult<CreateScheduledCorpusItemMutation>;
+export type CreateScheduledCorpusItemMutationOptions =
   Apollo.BaseMutationOptions<
-    CreateScheduledCuratedCorpusItemMutation,
-    CreateScheduledCuratedCorpusItemMutationVariables
+    CreateScheduledCorpusItemMutation,
+    CreateScheduledCorpusItemMutationVariables
   >;
 export const DeleteCollectionPartnerAssociationDocument = gql`
   mutation deleteCollectionPartnerAssociation($externalId: String!) {
@@ -4043,7 +4047,7 @@ export type DeleteCollectionStoryMutationOptions = Apollo.BaseMutationOptions<
 >;
 export const DeleteScheduledItemDocument = gql`
   mutation deleteScheduledItem($externalId: ID!) {
-    deleteScheduledCuratedCorpusItem(data: { externalId: $externalId }) {
+    deleteScheduledCorpusItem(data: { externalId: $externalId }) {
       externalId
       createdAt
       createdBy
@@ -4166,8 +4170,8 @@ export type ImageUploadMutationOptions = Apollo.BaseMutationOptions<
   ImageUploadMutationVariables
 >;
 export const RejectApprovedItemDocument = gql`
-  mutation rejectApprovedItem($data: RejectApprovedCuratedCorpusItemInput!) {
-    rejectApprovedCuratedCorpusItem(data: $data) {
+  mutation rejectApprovedItem($data: RejectApprovedCorpusItemInput!) {
+    rejectApprovedCorpusItem(data: $data) {
       ...CuratedItemData
     }
   }
@@ -4217,8 +4221,8 @@ export type RejectApprovedItemMutationOptions = Apollo.BaseMutationOptions<
   RejectApprovedItemMutationVariables
 >;
 export const RejectProspectDocument = gql`
-  mutation rejectProspect($data: CreateRejectedCuratedCorpusItemInput!) {
-    createRejectedCuratedCorpusItem(data: $data) {
+  mutation rejectProspect($data: CreateRejectedCorpusItemInput!) {
+    createRejectedCorpusItem(data: $data) {
       ...RejectedItemData
     }
   }
@@ -4267,12 +4271,12 @@ export type RejectProspectMutationOptions = Apollo.BaseMutationOptions<
   RejectProspectMutation,
   RejectProspectMutationVariables
 >;
-export const RescheduleScheduledCuratedCorpusItemDocument = gql`
-  mutation rescheduleScheduledCuratedCorpusItem(
+export const RescheduleScheduledCorpusItemDocument = gql`
+  mutation rescheduleScheduledCorpusItem(
     $externalId: ID!
     $scheduledDate: Date!
   ) {
-    rescheduleScheduledCuratedCorpusItem(
+    rescheduleScheduledCorpusItem(
       data: { externalId: $externalId, scheduledDate: $scheduledDate }
     ) {
       ...ScheduledItemData
@@ -4280,105 +4284,102 @@ export const RescheduleScheduledCuratedCorpusItemDocument = gql`
   }
   ${ScheduledItemDataFragmentDoc}
 `;
-export type RescheduleScheduledCuratedCorpusItemMutationFn =
-  Apollo.MutationFunction<
-    RescheduleScheduledCuratedCorpusItemMutation,
-    RescheduleScheduledCuratedCorpusItemMutationVariables
-  >;
+export type RescheduleScheduledCorpusItemMutationFn = Apollo.MutationFunction<
+  RescheduleScheduledCorpusItemMutation,
+  RescheduleScheduledCorpusItemMutationVariables
+>;
 
 /**
- * __useRescheduleScheduledCuratedCorpusItemMutation__
+ * __useRescheduleScheduledCorpusItemMutation__
  *
- * To run a mutation, you first call `useRescheduleScheduledCuratedCorpusItemMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useRescheduleScheduledCuratedCorpusItemMutation` returns a tuple that includes:
+ * To run a mutation, you first call `useRescheduleScheduledCorpusItemMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useRescheduleScheduledCorpusItemMutation` returns a tuple that includes:
  * - A mutate function that you can call at any time to execute the mutation
  * - An object with fields that represent the current status of the mutation's execution
  *
  * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
  *
  * @example
- * const [rescheduleScheduledCuratedCorpusItemMutation, { data, loading, error }] = useRescheduleScheduledCuratedCorpusItemMutation({
+ * const [rescheduleScheduledCorpusItemMutation, { data, loading, error }] = useRescheduleScheduledCorpusItemMutation({
  *   variables: {
  *      externalId: // value for 'externalId'
  *      scheduledDate: // value for 'scheduledDate'
  *   },
  * });
  */
-export function useRescheduleScheduledCuratedCorpusItemMutation(
+export function useRescheduleScheduledCorpusItemMutation(
   baseOptions?: Apollo.MutationHookOptions<
-    RescheduleScheduledCuratedCorpusItemMutation,
-    RescheduleScheduledCuratedCorpusItemMutationVariables
+    RescheduleScheduledCorpusItemMutation,
+    RescheduleScheduledCorpusItemMutationVariables
   >
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
-    RescheduleScheduledCuratedCorpusItemMutation,
-    RescheduleScheduledCuratedCorpusItemMutationVariables
-  >(RescheduleScheduledCuratedCorpusItemDocument, options);
+    RescheduleScheduledCorpusItemMutation,
+    RescheduleScheduledCorpusItemMutationVariables
+  >(RescheduleScheduledCorpusItemDocument, options);
 }
-export type RescheduleScheduledCuratedCorpusItemMutationHookResult = ReturnType<
-  typeof useRescheduleScheduledCuratedCorpusItemMutation
+export type RescheduleScheduledCorpusItemMutationHookResult = ReturnType<
+  typeof useRescheduleScheduledCorpusItemMutation
 >;
-export type RescheduleScheduledCuratedCorpusItemMutationResult =
-  Apollo.MutationResult<RescheduleScheduledCuratedCorpusItemMutation>;
-export type RescheduleScheduledCuratedCorpusItemMutationOptions =
+export type RescheduleScheduledCorpusItemMutationResult =
+  Apollo.MutationResult<RescheduleScheduledCorpusItemMutation>;
+export type RescheduleScheduledCorpusItemMutationOptions =
   Apollo.BaseMutationOptions<
-    RescheduleScheduledCuratedCorpusItemMutation,
-    RescheduleScheduledCuratedCorpusItemMutationVariables
+    RescheduleScheduledCorpusItemMutation,
+    RescheduleScheduledCorpusItemMutationVariables
   >;
-export const UpdateApprovedCuratedCorpusItemDocument = gql`
-  mutation updateApprovedCuratedCorpusItem(
-    $data: UpdateApprovedCuratedCorpusItemInput!
-  ) {
-    updateApprovedCuratedCorpusItem(data: $data) {
+export const UpdateApprovedCorpusItemDocument = gql`
+  mutation updateApprovedCorpusItem($data: UpdateApprovedCorpusItemInput!) {
+    updateApprovedCorpusItem(data: $data) {
       ...CuratedItemData
     }
   }
   ${CuratedItemDataFragmentDoc}
 `;
-export type UpdateApprovedCuratedCorpusItemMutationFn = Apollo.MutationFunction<
-  UpdateApprovedCuratedCorpusItemMutation,
-  UpdateApprovedCuratedCorpusItemMutationVariables
+export type UpdateApprovedCorpusItemMutationFn = Apollo.MutationFunction<
+  UpdateApprovedCorpusItemMutation,
+  UpdateApprovedCorpusItemMutationVariables
 >;
 
 /**
- * __useUpdateApprovedCuratedCorpusItemMutation__
+ * __useUpdateApprovedCorpusItemMutation__
  *
- * To run a mutation, you first call `useUpdateApprovedCuratedCorpusItemMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useUpdateApprovedCuratedCorpusItemMutation` returns a tuple that includes:
+ * To run a mutation, you first call `useUpdateApprovedCorpusItemMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateApprovedCorpusItemMutation` returns a tuple that includes:
  * - A mutate function that you can call at any time to execute the mutation
  * - An object with fields that represent the current status of the mutation's execution
  *
  * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
  *
  * @example
- * const [updateApprovedCuratedCorpusItemMutation, { data, loading, error }] = useUpdateApprovedCuratedCorpusItemMutation({
+ * const [updateApprovedCorpusItemMutation, { data, loading, error }] = useUpdateApprovedCorpusItemMutation({
  *   variables: {
  *      data: // value for 'data'
  *   },
  * });
  */
-export function useUpdateApprovedCuratedCorpusItemMutation(
+export function useUpdateApprovedCorpusItemMutation(
   baseOptions?: Apollo.MutationHookOptions<
-    UpdateApprovedCuratedCorpusItemMutation,
-    UpdateApprovedCuratedCorpusItemMutationVariables
+    UpdateApprovedCorpusItemMutation,
+    UpdateApprovedCorpusItemMutationVariables
   >
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
-    UpdateApprovedCuratedCorpusItemMutation,
-    UpdateApprovedCuratedCorpusItemMutationVariables
-  >(UpdateApprovedCuratedCorpusItemDocument, options);
+    UpdateApprovedCorpusItemMutation,
+    UpdateApprovedCorpusItemMutationVariables
+  >(UpdateApprovedCorpusItemDocument, options);
 }
-export type UpdateApprovedCuratedCorpusItemMutationHookResult = ReturnType<
-  typeof useUpdateApprovedCuratedCorpusItemMutation
+export type UpdateApprovedCorpusItemMutationHookResult = ReturnType<
+  typeof useUpdateApprovedCorpusItemMutation
 >;
-export type UpdateApprovedCuratedCorpusItemMutationResult =
-  Apollo.MutationResult<UpdateApprovedCuratedCorpusItemMutation>;
-export type UpdateApprovedCuratedCorpusItemMutationOptions =
+export type UpdateApprovedCorpusItemMutationResult =
+  Apollo.MutationResult<UpdateApprovedCorpusItemMutation>;
+export type UpdateApprovedCorpusItemMutationOptions =
   Apollo.BaseMutationOptions<
-    UpdateApprovedCuratedCorpusItemMutation,
-    UpdateApprovedCuratedCorpusItemMutationVariables
+    UpdateApprovedCorpusItemMutation,
+    UpdateApprovedCorpusItemMutationVariables
   >;
 export const UpdateCollectionDocument = gql`
   mutation updateCollection(
@@ -5165,61 +5166,60 @@ export type UpdateProspectAsCuratedMutationOptions = Apollo.BaseMutationOptions<
   UpdateProspectAsCuratedMutation,
   UpdateProspectAsCuratedMutationVariables
 >;
-export const UploadApprovedCuratedCorpusItemImageDocument = gql`
-  mutation uploadApprovedCuratedCorpusItemImage($image: Upload!) {
-    uploadApprovedCuratedCorpusItemImage(data: $image) {
+export const UploadApprovedCorpusItemImageDocument = gql`
+  mutation uploadApprovedCorpusItemImage($image: Upload!) {
+    uploadApprovedCorpusItemImage(data: $image) {
       url
     }
   }
 `;
-export type UploadApprovedCuratedCorpusItemImageMutationFn =
-  Apollo.MutationFunction<
-    UploadApprovedCuratedCorpusItemImageMutation,
-    UploadApprovedCuratedCorpusItemImageMutationVariables
-  >;
+export type UploadApprovedCorpusItemImageMutationFn = Apollo.MutationFunction<
+  UploadApprovedCorpusItemImageMutation,
+  UploadApprovedCorpusItemImageMutationVariables
+>;
 
 /**
- * __useUploadApprovedCuratedCorpusItemImageMutation__
+ * __useUploadApprovedCorpusItemImageMutation__
  *
- * To run a mutation, you first call `useUploadApprovedCuratedCorpusItemImageMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useUploadApprovedCuratedCorpusItemImageMutation` returns a tuple that includes:
+ * To run a mutation, you first call `useUploadApprovedCorpusItemImageMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUploadApprovedCorpusItemImageMutation` returns a tuple that includes:
  * - A mutate function that you can call at any time to execute the mutation
  * - An object with fields that represent the current status of the mutation's execution
  *
  * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
  *
  * @example
- * const [uploadApprovedCuratedCorpusItemImageMutation, { data, loading, error }] = useUploadApprovedCuratedCorpusItemImageMutation({
+ * const [uploadApprovedCorpusItemImageMutation, { data, loading, error }] = useUploadApprovedCorpusItemImageMutation({
  *   variables: {
  *      image: // value for 'image'
  *   },
  * });
  */
-export function useUploadApprovedCuratedCorpusItemImageMutation(
+export function useUploadApprovedCorpusItemImageMutation(
   baseOptions?: Apollo.MutationHookOptions<
-    UploadApprovedCuratedCorpusItemImageMutation,
-    UploadApprovedCuratedCorpusItemImageMutationVariables
+    UploadApprovedCorpusItemImageMutation,
+    UploadApprovedCorpusItemImageMutationVariables
   >
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
-    UploadApprovedCuratedCorpusItemImageMutation,
-    UploadApprovedCuratedCorpusItemImageMutationVariables
-  >(UploadApprovedCuratedCorpusItemImageDocument, options);
+    UploadApprovedCorpusItemImageMutation,
+    UploadApprovedCorpusItemImageMutationVariables
+  >(UploadApprovedCorpusItemImageDocument, options);
 }
-export type UploadApprovedCuratedCorpusItemImageMutationHookResult = ReturnType<
-  typeof useUploadApprovedCuratedCorpusItemImageMutation
+export type UploadApprovedCorpusItemImageMutationHookResult = ReturnType<
+  typeof useUploadApprovedCorpusItemImageMutation
 >;
-export type UploadApprovedCuratedCorpusItemImageMutationResult =
-  Apollo.MutationResult<UploadApprovedCuratedCorpusItemImageMutation>;
-export type UploadApprovedCuratedCorpusItemImageMutationOptions =
+export type UploadApprovedCorpusItemImageMutationResult =
+  Apollo.MutationResult<UploadApprovedCorpusItemImageMutation>;
+export type UploadApprovedCorpusItemImageMutationOptions =
   Apollo.BaseMutationOptions<
-    UploadApprovedCuratedCorpusItemImageMutation,
-    UploadApprovedCuratedCorpusItemImageMutationVariables
+    UploadApprovedCorpusItemImageMutation,
+    UploadApprovedCorpusItemImageMutationVariables
   >;
 export const GetApprovedItemByUrlDocument = gql`
   query getApprovedItemByUrl($url: String!) {
-    getApprovedCuratedCorpusItemByUrl(url: $url) {
+    getApprovedCorpusItemByUrl(url: $url) {
       ...CuratedItemData
     }
   }
@@ -5278,10 +5278,10 @@ export type GetApprovedItemByUrlQueryResult = Apollo.QueryResult<
 >;
 export const GetApprovedItemsDocument = gql`
   query getApprovedItems(
-    $filters: ApprovedCuratedCorpusItemFilter
+    $filters: ApprovedCorpusItemFilter
     $pagination: PaginationInput
   ) {
-    getApprovedCuratedCorpusItems(filters: $filters, pagination: $pagination) {
+    getApprovedCorpusItems(filters: $filters, pagination: $pagination) {
       totalCount
       pageInfo {
         hasNextPage
@@ -6002,10 +6002,10 @@ export type GetProspectsQueryResult = Apollo.QueryResult<
 >;
 export const GetRejectedItemsDocument = gql`
   query getRejectedItems(
-    $filters: RejectedCuratedCorpusItemFilter
+    $filters: RejectedCorpusItemFilter
     $pagination: PaginationInput
   ) {
-    getRejectedCuratedCorpusItems(filters: $filters, pagination: $pagination) {
+    getRejectedCorpusItems(filters: $filters, pagination: $pagination) {
       totalCount
       pageInfo {
         hasNextPage
@@ -6076,10 +6076,8 @@ export type GetRejectedItemsQueryResult = Apollo.QueryResult<
   GetRejectedItemsQueryVariables
 >;
 export const GetScheduledItemCountsDocument = gql`
-  query getScheduledItemCounts(
-    $filters: ScheduledCuratedCorpusItemsFilterInput!
-  ) {
-    getScheduledCuratedCorpusItems(filters: $filters) {
+  query getScheduledItemCounts($filters: ScheduledCorpusItemsFilterInput!) {
+    getScheduledCorpusItems(filters: $filters) {
       collectionCount
       syndicatedCount
       totalCount
@@ -6138,8 +6136,8 @@ export type GetScheduledItemCountsQueryResult = Apollo.QueryResult<
   GetScheduledItemCountsQueryVariables
 >;
 export const GetScheduledItemsDocument = gql`
-  query getScheduledItems($filters: ScheduledCuratedCorpusItemsFilterInput!) {
-    getScheduledCuratedCorpusItems(filters: $filters) {
+  query getScheduledItems($filters: ScheduledCorpusItemsFilterInput!) {
+    getScheduledCorpusItems(filters: $filters) {
       collectionCount
       syndicatedCount
       totalCount

--- a/src/api/mutations/createApprovedItem.ts
+++ b/src/api/mutations/createApprovedItem.ts
@@ -2,10 +2,8 @@ import { gql } from '@apollo/client';
 import { CuratedItemData } from '../fragments/curatedItemData';
 
 export const createApprovedItem = gql`
-  mutation createApprovedCuratedCorpusItem(
-    $data: CreateApprovedCuratedCorpusItemInput!
-  ) {
-    createApprovedCuratedCorpusItem(data: $data) {
+  mutation createApprovedCorpusItem($data: CreateApprovedCorpusItemInput!) {
+    createApprovedCorpusItem(data: $data) {
       ...CuratedItemData
     }
   }

--- a/src/api/mutations/createScheduledCuratedCorpusItem.ts
+++ b/src/api/mutations/createScheduledCuratedCorpusItem.ts
@@ -1,13 +1,13 @@
 import { gql } from '@apollo/client';
 import { CuratedItemData } from '../fragments/curatedItemData';
 
-export const createScheduledCuratedCorpusItem = gql`
-  mutation createScheduledCuratedCorpusItem(
+export const createScheduledCorpusItem = gql`
+  mutation createScheduledCorpusItem(
     $approvedItemExternalId: ID!
     $scheduledSurfaceGuid: ID!
     $scheduledDate: Date!
   ) {
-    createScheduledCuratedCorpusItem(
+    createScheduledCorpusItem(
       data: {
         approvedItemExternalId: $approvedItemExternalId
         scheduledSurfaceGuid: $scheduledSurfaceGuid

--- a/src/api/mutations/deleteScheduledItem.ts
+++ b/src/api/mutations/deleteScheduledItem.ts
@@ -3,7 +3,7 @@ import { CuratedItemData } from '../fragments/curatedItemData';
 
 export const deleteScheduledItem = gql`
   mutation deleteScheduledItem($externalId: ID!) {
-    deleteScheduledCuratedCorpusItem(data: { externalId: $externalId }) {
+    deleteScheduledCorpusItem(data: { externalId: $externalId }) {
       externalId
       createdAt
       createdBy

--- a/src/api/mutations/rejectApprovedItem.ts
+++ b/src/api/mutations/rejectApprovedItem.ts
@@ -2,8 +2,8 @@ import { gql } from '@apollo/client';
 import { CuratedItemData } from '../fragments/curatedItemData';
 
 export const rejectApprovedItem = gql`
-  mutation rejectApprovedItem($data: RejectApprovedCuratedCorpusItemInput!) {
-    rejectApprovedCuratedCorpusItem(data: $data) {
+  mutation rejectApprovedItem($data: RejectApprovedCorpusItemInput!) {
+    rejectApprovedCorpusItem(data: $data) {
       ...CuratedItemData
     }
   }

--- a/src/api/mutations/rejectProspect.ts
+++ b/src/api/mutations/rejectProspect.ts
@@ -2,8 +2,8 @@ import { gql } from '@apollo/client';
 import { RejectedItemData } from '../fragments/rejectedItemData';
 
 export const rejectProspect = gql`
-  mutation rejectProspect($data: CreateRejectedCuratedCorpusItemInput!) {
-    createRejectedCuratedCorpusItem(data: $data) {
+  mutation rejectProspect($data: CreateRejectedCorpusItemInput!) {
+    createRejectedCorpusItem(data: $data) {
       ...RejectedItemData
     }
   }

--- a/src/api/mutations/rescheduledScheduledItem.ts
+++ b/src/api/mutations/rescheduledScheduledItem.ts
@@ -2,11 +2,11 @@ import { gql } from '@apollo/client';
 import { ScheduledItemData } from '../fragments/scheduledItemData';
 
 export const rescheduleScheduledItem = gql`
-  mutation rescheduleScheduledCuratedCorpusItem(
+  mutation rescheduleScheduledCorpusItem(
     $externalId: ID!
     $scheduledDate: Date!
   ) {
-    rescheduleScheduledCuratedCorpusItem(
+    rescheduleScheduledCorpusItem(
       data: { externalId: $externalId, scheduledDate: $scheduledDate }
     ) {
       ...ScheduledItemData

--- a/src/api/mutations/updateApprovedItem.ts
+++ b/src/api/mutations/updateApprovedItem.ts
@@ -2,10 +2,8 @@ import { gql } from '@apollo/client';
 import { CuratedItemData } from '../fragments/curatedItemData';
 
 export const updateApprovedItem = gql`
-  mutation updateApprovedCuratedCorpusItem(
-    $data: UpdateApprovedCuratedCorpusItemInput!
-  ) {
-    updateApprovedCuratedCorpusItem(data: $data) {
+  mutation updateApprovedCorpusItem($data: UpdateApprovedCorpusItemInput!) {
+    updateApprovedCorpusItem(data: $data) {
       ...CuratedItemData
     }
   }

--- a/src/api/mutations/uploadApprovedItemImage.ts
+++ b/src/api/mutations/uploadApprovedItemImage.ts
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client';
 
 export const uploadApprovedItemImage = gql`
-  mutation uploadApprovedCuratedCorpusItemImage($image: Upload!) {
-    uploadApprovedCuratedCorpusItemImage(data: $image) {
+  mutation uploadApprovedCorpusItemImage($image: Upload!) {
+    uploadApprovedCorpusItemImage(data: $image) {
       url
     }
   }

--- a/src/api/queries/getApprovedItemByUrl.ts
+++ b/src/api/queries/getApprovedItemByUrl.ts
@@ -6,7 +6,7 @@ import { CuratedItemData } from '../fragments/curatedItemData';
  */
 export const getApprovedItemByUrl = gql`
   query getApprovedItemByUrl($url: String!) {
-    getApprovedCuratedCorpusItemByUrl(url: $url) {
+    getApprovedCorpusItemByUrl(url: $url) {
       ...CuratedItemData
     }
   }

--- a/src/api/queries/getApprovedItems.ts
+++ b/src/api/queries/getApprovedItems.ts
@@ -6,10 +6,10 @@ import { CuratedItemData } from '../fragments/curatedItemData';
  */
 export const getApprovedItems = gql`
   query getApprovedItems(
-    $filters: ApprovedCuratedCorpusItemFilter
+    $filters: ApprovedCorpusItemFilter
     $pagination: PaginationInput
   ) {
-    getApprovedCuratedCorpusItems(filters: $filters, pagination: $pagination) {
+    getApprovedCorpusItems(filters: $filters, pagination: $pagination) {
       totalCount
       pageInfo {
         hasNextPage

--- a/src/api/queries/getRejectedItems.ts
+++ b/src/api/queries/getRejectedItems.ts
@@ -6,10 +6,10 @@ import { RejectedItemData } from '../fragments/rejectedItemData';
  */
 export const getRejectedItems = gql`
   query getRejectedItems(
-    $filters: RejectedCuratedCorpusItemFilter
+    $filters: RejectedCorpusItemFilter
     $pagination: PaginationInput
   ) {
-    getRejectedCuratedCorpusItems(filters: $filters, pagination: $pagination) {
+    getRejectedCorpusItems(filters: $filters, pagination: $pagination) {
       totalCount
       pageInfo {
         hasNextPage

--- a/src/api/queries/getScheduledItemCounts.ts
+++ b/src/api/queries/getScheduledItemCounts.ts
@@ -1,10 +1,8 @@
 import { gql } from '@apollo/client';
 
 export const getScheduledItemCounts = gql`
-  query getScheduledItemCounts(
-    $filters: ScheduledCuratedCorpusItemsFilterInput!
-  ) {
-    getScheduledCuratedCorpusItems(filters: $filters) {
+  query getScheduledItemCounts($filters: ScheduledCorpusItemsFilterInput!) {
+    getScheduledCorpusItems(filters: $filters) {
       collectionCount
       syndicatedCount
       totalCount

--- a/src/api/queries/getScheduledItems.ts
+++ b/src/api/queries/getScheduledItems.ts
@@ -2,8 +2,8 @@ import { gql } from '@apollo/client';
 import { CuratedItemData } from '../fragments/curatedItemData';
 
 export const getScheduledItems = gql`
-  query getScheduledItems($filters: ScheduledCuratedCorpusItemsFilterInput!) {
-    getScheduledCuratedCorpusItems(filters: $filters) {
+  query getScheduledItems($filters: ScheduledCorpusItemsFilterInput!) {
+    getScheduledCorpusItems(filters: $filters) {
       collectionCount
       syndicatedCount
       totalCount

--- a/src/curated-corpus/components/AddProspectFormConnector/AddProspectFormConnector.tsx
+++ b/src/curated-corpus/components/AddProspectFormConnector/AddProspectFormConnector.tsx
@@ -91,7 +91,7 @@ export const AddProspectFormConnector: React.FC<
     notifyOnNetworkStatusChange: true,
     fetchPolicy: 'no-cache',
     onCompleted: (data) => {
-      const approvedItem = data?.getApprovedCuratedCorpusItemByUrl;
+      const approvedItem = data?.getApprovedCorpusItemByUrl;
 
       // show error toast if the url exists already
       if (approvedItem) {

--- a/src/curated-corpus/components/ApprovedItemCardWrapper/ApprovedItemCardWrapper.test.tsx
+++ b/src/curated-corpus/components/ApprovedItemCardWrapper/ApprovedItemCardWrapper.test.tsx
@@ -1,14 +1,11 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import {
-  ApprovedCuratedCorpusItem,
-  CuratedStatus,
-} from '../../../api/generatedTypes';
+import { ApprovedCorpusItem, CuratedStatus } from '../../../api/generatedTypes';
 import { ApprovedItemCardWrapper } from './ApprovedItemCardWrapper';
 
 describe('The ApprovedItemCardWrapper component', () => {
-  let item: ApprovedCuratedCorpusItem;
+  let item: ApprovedCorpusItem;
 
   beforeEach(() => {
     item = {

--- a/src/curated-corpus/components/ApprovedItemCardWrapper/ApprovedItemCardWrapper.tsx
+++ b/src/curated-corpus/components/ApprovedItemCardWrapper/ApprovedItemCardWrapper.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Card, CardActions } from '@material-ui/core';
 import { useStyles } from './ApprovedItemCardWrapper.styles';
-import { ApprovedCuratedCorpusItem } from '../../../api/generatedTypes';
+import { ApprovedCorpusItem } from '../../../api/generatedTypes';
 import { Button } from '../../../_shared/components';
 import { ApprovedItemListCard } from '../ApprovedItemListCard/ApprovedItemListCard';
 
@@ -9,7 +9,7 @@ interface ApprovedItemCardWrapperProps {
   /**
    * An object with everything approved curated item-related in it.
    */
-  item: ApprovedCuratedCorpusItem;
+  item: ApprovedCorpusItem;
 
   onReject: VoidFunction;
 

--- a/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.test.tsx
+++ b/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { MockedProvider } from '@apollo/client/testing';
 import { SnackbarProvider } from 'notistack';
 import {
-  ApprovedCuratedCorpusItem,
+  ApprovedCorpusItem,
   CuratedStatus,
   Topics,
 } from '../../../api/generatedTypes';
@@ -12,7 +12,7 @@ import { ApprovedItemForm } from './ApprovedItemForm';
 import { uploadApprovedItemImage } from '../../../api/mutations/uploadApprovedItemImage';
 
 describe('The ApprovedItemForm component', () => {
-  let item: ApprovedCuratedCorpusItem;
+  let item: ApprovedCorpusItem;
   const onSubmit = jest.fn();
   const onCancel = jest.fn();
   const onImageSave = jest.fn();
@@ -220,7 +220,7 @@ describe('The ApprovedItemForm component', () => {
           },
           result: {
             data: {
-              uploadApprovedCuratedCorpusItemImage: {
+              uploadApprovedCorpusItemImage: {
                 url: file.name,
               },
             },

--- a/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.tsx
+++ b/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { FormikHelpers, FormikValues, useFormik } from 'formik';
 import { validationSchema } from './ApprovedItemForm.validation';
-import {
-  ApprovedCuratedCorpusItem,
-  CuratedStatus,
-} from '../../../api/generatedTypes';
+import { ApprovedCorpusItem, CuratedStatus } from '../../../api/generatedTypes';
 import {
   ApprovedItemFromProspect,
   curationStatusOptions,
@@ -33,7 +30,7 @@ interface ApprovedItemFormProps {
   /**
    * The approved item that needs to be edited.
    */
-  approvedItem: ApprovedCuratedCorpusItem | ApprovedItemFromProspect;
+  approvedItem: ApprovedCorpusItem | ApprovedItemFromProspect;
 
   /**
    * On submit handle function called on the 'Save' button click

--- a/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.test.tsx
+++ b/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.test.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import {
-  ApprovedCuratedCorpusItem,
+  ApprovedCorpusItem,
   CuratedStatus,
   Topics,
 } from '../../../api/generatedTypes';
 import { ApprovedItemListCard } from './ApprovedItemListCard';
 
 describe('The ApprovedItemListCard component', () => {
-  let item: ApprovedCuratedCorpusItem;
+  let item: ApprovedCorpusItem;
 
   beforeEach(() => {
     item = {

--- a/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.tsx
+++ b/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.tsx
@@ -15,17 +15,14 @@ import CheckCircleOutlineIcon from '@material-ui/icons/CheckCircleOutline';
 import LabelOutlinedIcon from '@material-ui/icons/LabelOutlined';
 import LanguageIcon from '@material-ui/icons/Language';
 import { useStyles } from './ApprovedItemListCard.styles';
-import {
-  ApprovedCuratedCorpusItem,
-  CuratedStatus,
-} from '../../../api/generatedTypes';
+import { ApprovedCorpusItem, CuratedStatus } from '../../../api/generatedTypes';
 import { getDisplayTopic } from '../../helpers/helperFunctions';
 
 interface ApprovedItemListCardProps {
   /**
    * An object with everything approved curated item-related in it.
    */
-  item: ApprovedCuratedCorpusItem;
+  item: ApprovedCorpusItem;
 }
 
 export const ApprovedItemListCard: React.FC<ApprovedItemListCardProps> = (

--- a/src/curated-corpus/components/ApprovedItemModal/ApprovedItemModal.tsx
+++ b/src/curated-corpus/components/ApprovedItemModal/ApprovedItemModal.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { Modal } from '../../../_shared/components';
 import { Box, Grid, Typography } from '@material-ui/core';
-import { ApprovedCuratedCorpusItem } from '../../../api/generatedTypes';
+import { ApprovedCorpusItem } from '../../../api/generatedTypes';
 import { FormikValues } from 'formik';
 import { FormikHelpers } from 'formik/dist/types';
 import { ApprovedItemForm } from '../ApprovedItemForm/ApprovedItemForm';
 import { ApprovedItemFromProspect } from '../../helpers/definitions';
 
 interface ApprovedItemModalProps {
-  approvedItem: ApprovedCuratedCorpusItem | ApprovedItemFromProspect;
+  approvedItem: ApprovedCorpusItem | ApprovedItemFromProspect;
   isOpen: boolean;
   heading?: string;
   showItemTitle?: boolean;

--- a/src/curated-corpus/components/ImageUpload/ImageUpload.test.tsx
+++ b/src/curated-corpus/components/ImageUpload/ImageUpload.test.tsx
@@ -2,16 +2,13 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ImageUpload } from './ImageUpload';
-import {
-  ApprovedCuratedCorpusItem,
-  CuratedStatus,
-} from '../../../api/generatedTypes';
+import { ApprovedCorpusItem, CuratedStatus } from '../../../api/generatedTypes';
 import { SnackbarProvider } from 'notistack';
 import { MockedProvider } from '@apollo/client/testing';
 import { formatFileSize } from '../../../_shared/utils/formatFileSize';
 
 describe('The ImageUpload component', () => {
-  let entity: ApprovedCuratedCorpusItem;
+  let entity: ApprovedCorpusItem;
   const placeholder = 'test-placeholder';
   const onImageSave = jest.fn();
 

--- a/src/curated-corpus/components/ImageUpload/ImageUpload.tsx
+++ b/src/curated-corpus/components/ImageUpload/ImageUpload.tsx
@@ -17,9 +17,9 @@ import { FileUploadInfo } from '../../../_shared/components/FileUploadInfo/FileU
 import { useStyles } from './ImageUpload.styles';
 import { useNotifications } from '../../../_shared/hooks';
 import {
-  ApprovedCuratedCorpusItem,
-  useUploadApprovedCuratedCorpusItemImageMutation,
-  MutationUploadApprovedCuratedCorpusItemImageArgs,
+  ApprovedCorpusItem,
+  MutationUploadApprovedCorpusItemImageArgs,
+  useUploadApprovedCorpusItemImageMutation,
 } from '../../../api/generatedTypes';
 import { readImageFileFromDisk } from '../../helpers/helperFunctions';
 import { ApprovedItemFromProspect } from '../../helpers/definitions';
@@ -28,7 +28,7 @@ interface ImageUploadProps {
   /**
    * Approved item entity
    */
-  entity: ApprovedCuratedCorpusItem | ApprovedItemFromProspect;
+  entity: ApprovedCorpusItem | ApprovedItemFromProspect;
 
   /**
    * A path to a placeholder image to show if no image is available
@@ -67,7 +67,7 @@ export const ImageUpload: React.FC<ImageUploadProps> = (props): JSX.Element => {
 
   // This state variable stores the image/file data read from the disk
   const [imageData, setImageData] = useState<
-    MutationUploadApprovedCuratedCorpusItemImageArgs | undefined
+    MutationUploadApprovedCorpusItemImageArgs | undefined
   >(undefined);
 
   // This state variable stores the image url. Default/initial value is
@@ -81,8 +81,7 @@ export const ImageUpload: React.FC<ImageUploadProps> = (props): JSX.Element => {
   };
 
   // prepare the upload to S3 mutation
-  const [uploadApprovedItemImage] =
-    useUploadApprovedCuratedCorpusItemImageMutation();
+  const [uploadApprovedItemImage] = useUploadApprovedCorpusItemImageMutation();
 
   // Process the file the user chose from their PC/mobile device,
   // show file info to the user and set data to use in upload mutation
@@ -112,7 +111,7 @@ export const ImageUpload: React.FC<ImageUploadProps> = (props): JSX.Element => {
         setUploadInProgress(false);
 
         // pull the returned s3 image url into a variable
-        const s3ImageUrl = data.data?.uploadApprovedCuratedCorpusItemImage.url;
+        const s3ImageUrl = data.data?.uploadApprovedCorpusItemImage.url;
 
         // if the image upload to s3 was successful
         if (s3ImageUrl) {

--- a/src/curated-corpus/components/MiniScheduleCard/MiniScheduleCard.test.tsx
+++ b/src/curated-corpus/components/MiniScheduleCard/MiniScheduleCard.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import {
   CuratedStatus,
-  ScheduledCuratedCorpusItem,
+  ScheduledCorpusItem,
   Topics,
 } from '../../../api/generatedTypes';
 
@@ -11,7 +11,7 @@ import { MiniScheduleCard } from './MiniScheduleCard';
 import { getDisplayTopic } from '../../helpers/helperFunctions';
 
 describe('The MiniScheduleCard component', () => {
-  let item: ScheduledCuratedCorpusItem;
+  let item: ScheduledCorpusItem;
 
   beforeEach(() => {
     item = {

--- a/src/curated-corpus/components/MiniScheduleCard/MiniScheduleCard.tsx
+++ b/src/curated-corpus/components/MiniScheduleCard/MiniScheduleCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ScheduledCuratedCorpusItem } from '../../../api/generatedTypes';
+import { ScheduledCorpusItem } from '../../../api/generatedTypes';
 import {
   Card,
   CardContent,
@@ -17,7 +17,7 @@ import { useStyles } from './MiniScheduleCard.styles';
 import { getDisplayTopic } from '../../helpers/helperFunctions';
 
 interface MiniScheduleCardProps {
-  item: ScheduledCuratedCorpusItem;
+  item: ScheduledCorpusItem;
 }
 
 /**

--- a/src/curated-corpus/components/RejectItemModal/RejectItemModal.tsx
+++ b/src/curated-corpus/components/RejectItemModal/RejectItemModal.tsx
@@ -3,12 +3,11 @@ import { Modal } from '../../../_shared/components';
 import { Box, Grid, Typography } from '@material-ui/core';
 import { FormikValues } from 'formik';
 import { FormikHelpers } from 'formik/dist/types';
-import { Prospect } from '../../../api/generatedTypes';
+import { ApprovedCorpusItem, Prospect } from '../../../api/generatedTypes';
 import { RejectItemForm } from '../RejectItemForm/RejectItemForm';
-import { ApprovedCuratedCorpusItem } from '../../../api/generatedTypes';
 
 interface RejectProspectModalProps {
-  prospect: Prospect | ApprovedCuratedCorpusItem;
+  prospect: Prospect | ApprovedCorpusItem;
   isOpen: boolean;
   onSave: (
     values: FormikValues,

--- a/src/curated-corpus/components/RejectedItemListCard/RejectedItemListCard.test.tsx
+++ b/src/curated-corpus/components/RejectedItemListCard/RejectedItemListCard.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { RejectedCuratedCorpusItem } from '../../../api/generatedTypes';
+import { RejectedCorpusItem } from '../../../api/generatedTypes';
 import { RejectedItemListCard } from './RejectedItemListCard';
 
 describe('The RejectedItemListCard component', () => {
-  let rejectedItem: RejectedCuratedCorpusItem;
+  let rejectedItem: RejectedCorpusItem;
 
   beforeEach(() => {
     rejectedItem = {

--- a/src/curated-corpus/components/RejectedItemListCard/RejectedItemListCard.tsx
+++ b/src/curated-corpus/components/RejectedItemListCard/RejectedItemListCard.tsx
@@ -15,13 +15,13 @@ import FaceIcon from '@material-ui/icons/Face';
 import LabelOutlinedIcon from '@material-ui/icons/LabelOutlined';
 
 import { useStyles } from './RejectedItemListCard.styles';
-import { RejectedCuratedCorpusItem } from '../../../api/generatedTypes';
+import { RejectedCorpusItem } from '../../../api/generatedTypes';
 
 interface RejectedItemListCardProps {
   /**
    * An object with everything rejected curated item-related in it.
    */
-  item: RejectedCuratedCorpusItem;
+  item: RejectedCorpusItem;
 }
 
 export const RejectedItemListCard: React.FC<RejectedItemListCardProps> = (

--- a/src/curated-corpus/components/RemoveItemFromScheduledSurfaceModal/RemoveItemFromScheduledSurfaceModal.tsx
+++ b/src/curated-corpus/components/RemoveItemFromScheduledSurfaceModal/RemoveItemFromScheduledSurfaceModal.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { Modal } from '../../../_shared/components';
 import { Grid } from '@material-ui/core';
-import { ScheduledCuratedCorpusItem } from '../../../api/generatedTypes';
+import { ScheduledCorpusItem } from '../../../api/generatedTypes';
 import { FormikValues } from 'formik';
 import { FormikHelpers } from 'formik/dist/types';
 import { RemoveItemFromScheduledSurfaceForm } from '../';
 
 interface RemoveItemFromScheduledSurfaceModalProps {
-  item: ScheduledCuratedCorpusItem;
+  item: ScheduledCorpusItem;
   isOpen: boolean;
   onSave: (
     values: FormikValues,

--- a/src/curated-corpus/components/ScheduleItemFormConnector/ScheduleItemFormConnector.tsx
+++ b/src/curated-corpus/components/ScheduleItemFormConnector/ScheduleItemFormConnector.tsx
@@ -6,7 +6,7 @@ import {
   SharedFormButtonsProps,
 } from '../../../_shared/components';
 import {
-  ScheduledCuratedCorpusItemsFilterInput,
+  ScheduledCorpusItemsFilterInput,
   useGetScheduledItemCountsLazyQuery,
   useGetScheduledSurfacesForUserQuery,
 } from '../../../api/generatedTypes';
@@ -71,15 +71,14 @@ export const ScheduleItemFormConnector: React.FC<
       onCompleted: (data) => {
         // If there's something already scheduled for the chosen date,
         // let the user know.
-        if (data.getScheduledCuratedCorpusItems.length > 0) {
-          const totalCount = data.getScheduledCuratedCorpusItems[0].totalCount;
+        if (data.getScheduledCorpusItems.length > 0) {
+          const totalCount = data.getScheduledCorpusItems[0].totalCount;
 
           setLookupCopy(
             <>
               Already scheduled: {totalCount}{' '}
               {totalCount === 1 ? 'story' : 'stories'} (
-              {data.getScheduledCuratedCorpusItems[0].syndicatedCount}{' '}
-              syndicated).
+              {data.getScheduledCorpusItems[0].syndicatedCount} syndicated).
             </>
           );
         } else {
@@ -106,7 +105,7 @@ export const ScheduleItemFormConnector: React.FC<
       // Look up any other scheduled items for this date + scheduled surface combination.
       // Start with the filters. Note `startDate` and `endDate` is the same as we're
       // interested in single day data only.
-      const filters: ScheduledCuratedCorpusItemsFilterInput = {
+      const filters: ScheduledCorpusItemsFilterInput = {
         scheduledSurfaceGuid,
         startDate: date?.toFormat('yyyy-MM-dd'),
         endDate: date?.toFormat('yyyy-MM-dd'),

--- a/src/curated-corpus/components/ScheduleItemModal/ScheduleItemModal.tsx
+++ b/src/curated-corpus/components/ScheduleItemModal/ScheduleItemModal.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { FormikValues } from 'formik';
 import { FormikHelpers } from 'formik/dist/types';
 import { Box, Grid, Typography } from '@material-ui/core';
-import { ApprovedCuratedCorpusItem } from '../../../api/generatedTypes';
+import { ApprovedCorpusItem } from '../../../api/generatedTypes';
 import { Modal } from '../../../_shared/components';
 import { ScheduleItemFormConnector } from '../';
 
 interface ScheduleItemModalProps {
-  approvedItem: ApprovedCuratedCorpusItem;
+  approvedItem: ApprovedCorpusItem;
   headingCopy?: string;
   isOpen: boolean;
   scheduledSurfaceGuid?: string;

--- a/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.test.tsx
+++ b/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.test.tsx
@@ -3,12 +3,12 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import {
   CuratedStatus,
-  ScheduledCuratedCorpusItem,
+  ScheduledCorpusItem,
 } from '../../../api/generatedTypes';
 import { ScheduledItemCardWrapper } from './ScheduledItemCardWrapper';
 
 describe('The ScheduledItemCardWrapper component', () => {
-  let item: ScheduledCuratedCorpusItem;
+  let item: ScheduledCorpusItem;
 
   beforeEach(() => {
     item = {

--- a/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.tsx
+++ b/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Card, CardActions, Grid } from '@material-ui/core';
 import { useStyles } from './ScheduledItemCardWrapper.styles';
-import { ScheduledCuratedCorpusItem } from '../../../api/generatedTypes';
+import { ScheduledCorpusItem } from '../../../api/generatedTypes';
 import { Button } from '../../../_shared/components';
 import { ApprovedItemListCard } from '../ApprovedItemListCard/ApprovedItemListCard';
 
@@ -9,7 +9,7 @@ interface ScheduledItemCardWrapperProps {
   /**
    * An object with everything scheduled curated item-related in it.
    */
-  item: ScheduledCuratedCorpusItem;
+  item: ScheduledCorpusItem;
   /**
    * What to do when the "Remove" button is clicked.
    */

--- a/src/curated-corpus/components/ScheduledSurfaceGroupedList/ScheduledSurfaceGroupedList.test.tsx
+++ b/src/curated-corpus/components/ScheduledSurfaceGroupedList/ScheduledSurfaceGroupedList.test.tsx
@@ -3,13 +3,13 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import {
   CuratedStatus,
-  ScheduledCuratedCorpusItemsResult,
+  ScheduledCorpusItemsResult,
 } from '../../../api/generatedTypes';
 
 import { ScheduledSurfaceGroupedList } from './ScheduledSurfaceGroupedList';
 
 describe('The ScheduledSurfaceGroupedList component', () => {
-  let data: ScheduledCuratedCorpusItemsResult;
+  let data: ScheduledCorpusItemsResult;
 
   beforeEach(() => {
     const item = {

--- a/src/curated-corpus/components/ScheduledSurfaceGroupedList/ScheduledSurfaceGroupedList.tsx
+++ b/src/curated-corpus/components/ScheduledSurfaceGroupedList/ScheduledSurfaceGroupedList.tsx
@@ -3,8 +3,8 @@ import { DateTime } from 'luxon';
 import { Grid, Typography } from '@material-ui/core';
 import { MiniScheduleCard } from '../';
 import {
-  ScheduledCuratedCorpusItem,
-  ScheduledCuratedCorpusItemsResult,
+  ScheduledCorpusItem,
+  ScheduledCorpusItemsResult,
 } from '../../../api/generatedTypes';
 import { useStyles } from './ScheduledSurfaceGroupedList.styles';
 
@@ -13,7 +13,7 @@ interface ScheduledSurfaceGroupedListProps {
    * A list of Scheduled items to display with accompanying data
    * such as the scheduled date.
    */
-  data: ScheduledCuratedCorpusItemsResult;
+  data: ScheduledCorpusItemsResult;
 }
 
 /**
@@ -40,7 +40,7 @@ export const ScheduledSurfaceGroupedList: React.FC<
           {displayDate} ({data.syndicatedCount}/{data.totalCount} syndicated)
         </Typography>
       </Grid>
-      {data.items.map((item: ScheduledCuratedCorpusItem) => {
+      {data.items.map((item: ScheduledCorpusItem) => {
         return <MiniScheduleCard key={item.externalId} item={item} />;
       })}
     </>

--- a/src/curated-corpus/helpers/definitions.ts
+++ b/src/curated-corpus/helpers/definitions.ts
@@ -1,6 +1,6 @@
 // Here we keep sets of options for curating items
 import {
-  ApprovedCuratedCorpusItem,
+  ApprovedCorpusItem,
   CorpusLanguage,
   CuratedStatus,
   ProspectType,
@@ -59,14 +59,11 @@ export const curationStatusOptions: DropdownOption[] = [
 
 /**
  *  This type is only being used as the return type for the helper function transformProspectToApprovedItem().
-  It is meant to be a bridge between the Prospect and ApprovedCuratedCorpus graphql types.
-  ApprovedCuratedCorpusItem has language as a required field and Prospect has it as a possible undefined.
-  When mapping a Prospect to an ApprovedCuratedCorpusItem type, we need to able to set the language to undefined
+  It is meant to be a bridge between the Prospect and ApprovedCorpusItem graphql types.
+  ApprovedCorpusItem has language as a required field and Prospect has it as a possible undefined.
+  When mapping a Prospect to an ApprovedCorpusItem type, we need to able to set the language to undefined
   for when it is undefined on the Prospect, which later will be set in the form before creating an Approved item
  */
-export type ApprovedItemFromProspect = Omit<
-  ApprovedCuratedCorpusItem,
-  'language'
-> & {
+export type ApprovedItemFromProspect = Omit<ApprovedCorpusItem, 'language'> & {
   language: CorpusLanguage | undefined;
 };

--- a/src/curated-corpus/helpers/helperFunctions.test.ts
+++ b/src/curated-corpus/helpers/helperFunctions.test.ts
@@ -14,7 +14,7 @@ import {
 
 describe('helperFunctions ', () => {
   describe('transformProspectToApprovedItem function', () => {
-    it('should create an ApprovedCuratedCorpusItem with all the provided fields', () => {
+    it('should create an ApprovedCorpusItem with all the provided fields', () => {
       const prospect: Prospect = {
         id: 'test-prospect-id',
         scheduledSurfaceGuid: 'en-us',
@@ -60,7 +60,7 @@ describe('helperFunctions ', () => {
       });
     });
 
-    it('should create an ApprovedCuratedCorpusItem with the default fields when only required fields are provided', () => {
+    it('should create an ApprovedCorpusItem with the default fields when only required fields are provided', () => {
       const prospect: Prospect = {
         id: 'test-prospect-id',
         url: 'test-prospect-url',

--- a/src/curated-corpus/helpers/helperFunctions.ts
+++ b/src/curated-corpus/helpers/helperFunctions.ts
@@ -7,7 +7,7 @@ import {
   Prospect,
   UrlMetadata,
 } from '../../api/generatedTypes';
-import { topics, ApprovedItemFromProspect } from './definitions';
+import { ApprovedItemFromProspect, topics } from './definitions';
 
 /**
  *
@@ -126,7 +126,7 @@ export const downloadAndUploadApprovedItemImageToS3 = async (
     throw new Error('Failed to upload image, please try again');
   }
 
-  return data?.uploadApprovedCuratedCorpusItemImage.url;
+  return data?.uploadApprovedCorpusItemImage.url;
 };
 
 /**

--- a/src/curated-corpus/pages/ApprovedItemsPage/ApprovedItemsPage.tsx
+++ b/src/curated-corpus/pages/ApprovedItemsPage/ApprovedItemsPage.tsx
@@ -3,14 +3,14 @@ import { Grid, Typography } from '@material-ui/core';
 import { FormikHelpers, FormikValues } from 'formik';
 import { config } from '../../../config';
 import {
-  ApprovedCuratedCorpusItem,
-  ApprovedCuratedCorpusItemEdge,
-  ApprovedCuratedCorpusItemFilter,
-  CreateScheduledCuratedCorpusItemInput,
-  useCreateScheduledCuratedCorpusItemMutation,
+  ApprovedCorpusItem,
+  ApprovedCorpusItemEdge,
+  ApprovedCorpusItemFilter,
+  CreateScheduledCorpusItemInput,
+  useCreateScheduledCorpusItemMutation,
   useGetApprovedItemsLazyQuery,
   useRejectApprovedItemMutation,
-  useUpdateApprovedCuratedCorpusItemMutation,
+  useUpdateApprovedCorpusItemMutation,
 } from '../../../api/generatedTypes';
 import { HandleApiResponse } from '../../../_shared/components';
 import {
@@ -27,7 +27,7 @@ import { DateTime } from 'luxon';
 export const ApprovedItemsPage: React.FC = (): JSX.Element => {
   // Get the usual API response vars and a helper method to retrieve data
   // that can be used inside hooks.
-  const [getApprovedCuratedCorpusItems, { loading, error, data, refetch }] =
+  const [getApprovedCorpusItems, { loading, error, data, refetch }] =
     useGetApprovedItemsLazyQuery(
       // We need to make sure search results are never served from the cache.
       { fetchPolicy: 'no-cache', notifyOnNetworkStatusChange: true }
@@ -39,7 +39,7 @@ export const ApprovedItemsPage: React.FC = (): JSX.Element => {
 
   // Save the filters in a state variable to be able to use them when paginating
   // through results.
-  const [filters, setFilters] = useState<ApprovedCuratedCorpusItemFilter>({});
+  const [filters, setFilters] = useState<ApprovedCorpusItemFilter>({});
 
   // Save the cursors returned with every request to be able to use them when
   // paginating through results.
@@ -49,7 +49,7 @@ export const ApprovedItemsPage: React.FC = (): JSX.Element => {
   // On the initial page load, load most recently added Curated Items -
   // the first page of results, no filters applied.
   useEffect(() => {
-    getApprovedCuratedCorpusItems({
+    getApprovedCorpusItems({
       variables: {
         pagination: { first: config.pagination.curatedItemsPerPage },
       },
@@ -59,8 +59,8 @@ export const ApprovedItemsPage: React.FC = (): JSX.Element => {
   // Set the cursors once data is returned by the API.
   useEffect(() => {
     if (data) {
-      setAfter(data.getApprovedCuratedCorpusItems.pageInfo.endCursor);
-      setBefore(data.getApprovedCuratedCorpusItems.pageInfo.startCursor);
+      setAfter(data.getApprovedCorpusItems.pageInfo.endCursor);
+      setBefore(data.getApprovedCorpusItems.pageInfo.startCursor);
     }
   }, [data]);
 
@@ -84,7 +84,7 @@ export const ApprovedItemsPage: React.FC = (): JSX.Element => {
     }
 
     // Execute the search.
-    getApprovedCuratedCorpusItems({
+    getApprovedCorpusItems({
       variables: {
         pagination: { first: config.pagination.curatedItemsPerPage },
         filters,
@@ -101,7 +101,7 @@ export const ApprovedItemsPage: React.FC = (): JSX.Element => {
    * Results are always retrieved from the API.
    */
   const loadNext = () => {
-    getApprovedCuratedCorpusItems({
+    getApprovedCorpusItems({
       variables: {
         pagination: { first: config.pagination.curatedItemsPerPage, after },
         filters,
@@ -116,7 +116,7 @@ export const ApprovedItemsPage: React.FC = (): JSX.Element => {
    * Results are always retrieved from the API.
    */
   const loadPrevious = () => {
-    getApprovedCuratedCorpusItems({
+    getApprovedCorpusItems({
       variables: {
         pagination: { last: config.pagination.curatedItemsPerPage, before },
         filters,
@@ -142,7 +142,7 @@ export const ApprovedItemsPage: React.FC = (): JSX.Element => {
    * Set the current Approved Item to be worked on (e.g., edited or scheduled).
    */
   const [currentItem, setCurrentItem] = useState<
-    Omit<ApprovedCuratedCorpusItem, '__typename'> | undefined
+    Omit<ApprovedCorpusItem, '__typename'> | undefined
   >(undefined);
 
   // 1. Prepare the "reject curated item" mutation
@@ -178,14 +178,14 @@ export const ApprovedItemsPage: React.FC = (): JSX.Element => {
   };
 
   // 1. Prepare the "schedule curated item" mutation
-  const [scheduleCuratedItem] = useCreateScheduledCuratedCorpusItemMutation();
+  const [scheduleCuratedItem] = useCreateScheduledCorpusItemMutation();
   // 2. Schedule the curated item when the user saves a scheduling request
   const onScheduleSave = (
     values: FormikValues,
     formikHelpers: FormikHelpers<any>
   ): void => {
     // Set out all the variables we need to pass to the mutation
-    const variables: CreateScheduledCuratedCorpusItemInput = {
+    const variables: CreateScheduledCorpusItemInput = {
       approvedItemExternalId: currentItem?.externalId!,
       scheduledSurfaceGuid: values.scheduledSurfaceGuid,
       scheduledDate: values.scheduledDate.toISODate(),
@@ -209,7 +209,7 @@ export const ApprovedItemsPage: React.FC = (): JSX.Element => {
   };
 
   // Mutation for updating an approved item
-  const [updateApprovedItem] = useUpdateApprovedCuratedCorpusItemMutation();
+  const [updateApprovedItem] = useUpdateApprovedCorpusItemMutation();
 
   /**
    * Executed on form submission
@@ -298,13 +298,13 @@ export const ApprovedItemsPage: React.FC = (): JSX.Element => {
         {data && (
           <Grid item xs={12}>
             <Typography>
-              Found {data.getApprovedCuratedCorpusItems.totalCount} result(s).
+              Found {data.getApprovedCorpusItems.totalCount} result(s).
             </Typography>
           </Grid>
         )}
         {data &&
-          data.getApprovedCuratedCorpusItems.edges.map(
-            (edge: ApprovedCuratedCorpusItemEdge) => {
+          data.getApprovedCorpusItems.edges.map(
+            (edge: ApprovedCorpusItemEdge) => {
               return (
                 <Grid
                   item
@@ -337,11 +337,9 @@ export const ApprovedItemsPage: React.FC = (): JSX.Element => {
 
       {data && (
         <NextPrevPagination
-          hasNextPage={data.getApprovedCuratedCorpusItems.pageInfo.hasNextPage}
+          hasNextPage={data.getApprovedCorpusItems.pageInfo.hasNextPage}
           loadNext={loadNext}
-          hasPreviousPage={
-            data.getApprovedCuratedCorpusItems.pageInfo.hasPreviousPage
-          }
+          hasPreviousPage={data.getApprovedCorpusItems.pageInfo.hasPreviousPage}
           loadPrevious={loadPrevious}
         />
       )}

--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -16,20 +16,20 @@ import {
   SplitButton,
 } from '../../components';
 import {
-  ApprovedCuratedCorpusItem,
+  ApprovedCorpusItem,
+  CreateApprovedCorpusItemMutation,
   CuratedStatus,
   Prospect,
   RejectProspectMutationVariables,
-  ScheduledCuratedCorpusItemsResult,
-  CreateApprovedCuratedCorpusItemMutation,
-  useCreateApprovedCuratedCorpusItemMutation,
-  useCreateScheduledCuratedCorpusItemMutation,
+  ScheduledCorpusItemsResult,
+  useCreateApprovedCorpusItemMutation,
+  useCreateScheduledCorpusItemMutation,
   useGetProspectsQuery,
   useGetScheduledItemsQuery,
   useGetScheduledSurfacesForUserQuery,
   useRejectProspectMutation,
   useUpdateProspectAsCuratedMutation,
-  useUploadApprovedCuratedCorpusItemImageMutation,
+  useUploadApprovedCorpusItemImageMutation,
 } from '../../../api/generatedTypes';
 import {
   useNotifications,
@@ -166,7 +166,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
    * Set the current Curated Item to be worked on (e.g., to add to Scheduled Surface optionally).
    */
   const [approvedItem, setApprovedItem] = useState<
-    ApprovedCuratedCorpusItem | undefined
+    ApprovedCorpusItem | undefined
   >(undefined);
 
   const [isRecommendation, setIsRecommendation] = useState<boolean>(false);
@@ -303,11 +303,10 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
   };
 
   // Prepare the create approved item mutation
-  const [createApprovedItem] = useCreateApprovedCuratedCorpusItemMutation();
+  const [createApprovedItem] = useCreateApprovedCorpusItemMutation();
 
   // Prepare the upload approved item image mutation
-  const [uploadApprovedItemImage] =
-    useUploadApprovedCuratedCorpusItemImageMutation();
+  const [uploadApprovedItemImage] = useUploadApprovedCorpusItemImageMutation();
 
   // The toast notification hook
   const { showNotification } = useNotifications();
@@ -352,7 +351,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
       createApprovedItem,
       { variables: { data: { ...approvedItem } } },
       'Item successfully added to the curated corpus.',
-      (approvedItemData: CreateApprovedCuratedCorpusItemMutation) => {
+      (approvedItemData: CreateApprovedCorpusItemMutation) => {
         // if we have a prospect id, we need to tell prospect api that this
         // prospect has been curated
         if (currentProspect?.id !== '') {
@@ -363,7 +362,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
             undefined,
             () => {
               postCreateApprovedItem(
-                approvedItemData.createApprovedCuratedCorpusItem,
+                approvedItemData.createApprovedCorpusItem,
                 true
               );
 
@@ -377,7 +376,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
           // if we don't have a prospect id, this was a manually added prospect
           // and we don't need to call prospect api at all
           postCreateApprovedItem(
-            approvedItemData.createApprovedCuratedCorpusItem,
+            approvedItemData.createApprovedCorpusItem,
             false
           );
 
@@ -390,12 +389,11 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
   /**
    * common stuff we (may) need to do after creating an approved item
    *
-   * @param approvedItemStatus (CuratedStatus): the status of the approved item
-   * @param approvedItemData (any): the data we get back from the createApprovedItem mutation
+   * @param approvedItem
    * @param filterProspects (boolean): whether or not we need to filter the list of prospects on the screen
    */
   const postCreateApprovedItem = (
-    approvedItem: ApprovedCuratedCorpusItem,
+    approvedItem: ApprovedCorpusItem,
     filterProspects: boolean
   ): void => {
     toggleApprovedItemModal();
@@ -452,7 +450,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
   };
 
   // 1. Prepare the "schedule curated item" mutation
-  const [scheduleCuratedItem] = useCreateScheduledCuratedCorpusItemMutation();
+  const [scheduleCuratedItem] = useCreateScheduledCorpusItemMutation();
   // 2. Schedule the curated item when the user saves a scheduling request
   const onScheduleSave = (
     values: FormikValues,
@@ -647,8 +645,8 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
               />
             )}
             {dataScheduled &&
-              dataScheduled.getScheduledCuratedCorpusItems.map(
-                (data: ScheduledCuratedCorpusItemsResult) => (
+              dataScheduled.getScheduledCorpusItems.map(
+                (data: ScheduledCorpusItemsResult) => (
                   <ScheduledSurfaceGroupedList
                     key={data.scheduledDate}
                     data={data}

--- a/src/curated-corpus/pages/RejectedItemsPage/RejectedItemsPage.tsx
+++ b/src/curated-corpus/pages/RejectedItemsPage/RejectedItemsPage.tsx
@@ -3,8 +3,8 @@ import { Grid, Typography } from '@material-ui/core';
 import { FormikValues } from 'formik';
 import { config } from '../../../config';
 import {
-  RejectedCuratedCorpusItemEdge,
-  RejectedCuratedCorpusItemFilter,
+  RejectedCorpusItemEdge,
+  RejectedCorpusItemFilter,
   useGetRejectedItemsLazyQuery,
 } from '../../../api/generatedTypes';
 
@@ -19,7 +19,7 @@ import {
 export const RejectedItemsPage: React.FC = (): JSX.Element => {
   // Get the usual API response vars and a helper method to retrieve data
   // that can be used inside hooks.
-  const [getRejectedCuratedCorpusItems, { loading, error, data }] =
+  const [getRejectedCorpusItems, { loading, error, data }] =
     useGetRejectedItemsLazyQuery(
       // We need to make sure search results are never served from the cache.
       { fetchPolicy: 'no-cache', notifyOnNetworkStatusChange: true }
@@ -27,7 +27,7 @@ export const RejectedItemsPage: React.FC = (): JSX.Element => {
 
   // Save the filters in a state variable to be able to use them when paginating
   // through results.
-  const [filters, setFilters] = useState<RejectedCuratedCorpusItemFilter>({});
+  const [filters, setFilters] = useState<RejectedCorpusItemFilter>({});
 
   // Save the cursors returned with every request to be able to use them when
   // paginating through results.
@@ -37,7 +37,7 @@ export const RejectedItemsPage: React.FC = (): JSX.Element => {
   // On the initial page load, load most recently added Rejected Items -
   // the first page of results, no filters applied.
   useEffect(() => {
-    getRejectedCuratedCorpusItems({
+    getRejectedCorpusItems({
       variables: {
         pagination: { first: config.pagination.rejectedItemsPerPage },
       },
@@ -47,19 +47,22 @@ export const RejectedItemsPage: React.FC = (): JSX.Element => {
   // Set the cursors once data is returned by the API.
   useEffect(() => {
     if (data) {
-      setAfter(data.getRejectedCuratedCorpusItems.pageInfo.endCursor);
-      setBefore(data.getRejectedCuratedCorpusItems.pageInfo.startCursor);
+      setAfter(data.getRejectedCorpusItems.pageInfo.endCursor);
+      setBefore(data.getRejectedCorpusItems.pageInfo.startCursor);
     }
   }, [data]);
 
   /**
-   * Process search form values and convert them into a RejectedCuratedCorpusItemFilter
-   * object that will be accepted as a variable by the getRejectedCuratedCorpusItems query.
+   * Process search form values and convert them into a RejectedCorpusItem
+   *Filter
+   * object that will be accepted as a variable by the getRejectedCorpusItem
+   *s query.
    * @param values
    */
   const handleSubmit = (values: FormikValues): void => {
     // Using `any` here as TS is rather unhappy at the below for() loop
-    // if filters are correctly typed as RejectedCuratedCorpusItemFilter.
+    // if filters are correctly typed as RejectedCorpusItem
+    //Filter.
     // The alternative appears to be setting the type correctly and then
     // manually checking each possible filter form value and setting it
     // in the filter input if it contains something.
@@ -72,7 +75,7 @@ export const RejectedItemsPage: React.FC = (): JSX.Element => {
     }
 
     // Execute the search.
-    getRejectedCuratedCorpusItems({
+    getRejectedCorpusItems({
       variables: {
         pagination: { first: config.pagination.rejectedItemsPerPage },
         filters,
@@ -89,7 +92,7 @@ export const RejectedItemsPage: React.FC = (): JSX.Element => {
    * Results are always retrieved from the API.
    */
   const loadNext = () => {
-    getRejectedCuratedCorpusItems({
+    getRejectedCorpusItems({
       variables: {
         pagination: { first: config.pagination.rejectedItemsPerPage, after },
         filters,
@@ -104,7 +107,7 @@ export const RejectedItemsPage: React.FC = (): JSX.Element => {
    * Results are always retrieved from the API.
    */
   const loadPrevious = () => {
-    getRejectedCuratedCorpusItems({
+    getRejectedCorpusItems({
       variables: {
         pagination: { last: config.pagination.rejectedItemsPerPage, before },
         filters,
@@ -134,13 +137,13 @@ export const RejectedItemsPage: React.FC = (): JSX.Element => {
         {data && (
           <Grid item xs={12}>
             <Typography>
-              Found {data.getRejectedCuratedCorpusItems.totalCount} result(s).
+              Found {data.getRejectedCorpusItems.totalCount} result(s).
             </Typography>
           </Grid>
         )}
         {data &&
-          data.getRejectedCuratedCorpusItems.edges.map(
-            (edge: RejectedCuratedCorpusItemEdge) => {
+          data.getRejectedCorpusItems.edges.map(
+            (edge: RejectedCorpusItemEdge) => {
               return (
                 <Grid
                   item
@@ -161,11 +164,9 @@ export const RejectedItemsPage: React.FC = (): JSX.Element => {
 
       {data && (
         <NextPrevPagination
-          hasNextPage={data.getRejectedCuratedCorpusItems.pageInfo.hasNextPage}
+          hasNextPage={data.getRejectedCorpusItems.pageInfo.hasNextPage}
           loadNext={loadNext}
-          hasPreviousPage={
-            data.getRejectedCuratedCorpusItems.pageInfo.hasPreviousPage
-          }
+          hasPreviousPage={data.getRejectedCorpusItems.pageInfo.hasPreviousPage}
           loadPrevious={loadPrevious}
         />
       )}

--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -8,17 +8,17 @@ import {
   LoadExtraButton,
   RemoveItemFromScheduledSurfaceModal,
   ScheduledItemCardWrapper,
-  SplitButton,
   ScheduleItemModal,
+  SplitButton,
 } from '../../components';
 import {
-  ScheduledCuratedCorpusItem,
-  ScheduledCuratedCorpusItemsFilterInput,
-  ScheduledCuratedCorpusItemsResult,
+  ScheduledCorpusItem,
+  ScheduledCorpusItemsFilterInput,
+  ScheduledCorpusItemsResult,
   useDeleteScheduledItemMutation,
   useGetScheduledItemsQuery,
   useGetScheduledSurfacesForUserQuery,
-  useRescheduleScheduledCuratedCorpusItemMutation,
+  useRescheduleScheduledCorpusItemMutation,
 } from '../../../api/generatedTypes';
 import {
   useNotifications,
@@ -103,7 +103,7 @@ export const SchedulePage: React.FC = (): JSX.Element => {
    * @param direction
    */
   const loadMore = (direction: 'past' | 'future') => {
-    let filters: ScheduledCuratedCorpusItemsFilterInput;
+    let filters: ScheduledCorpusItemsFilterInput;
 
     if (direction === 'future') {
       // shift the dates two days into the future
@@ -154,7 +154,7 @@ export const SchedulePage: React.FC = (): JSX.Element => {
    * Set the current Scheduled Item to be worked on.
    */
   const [currentItem, setCurrentItem] = useState<
-    Omit<ScheduledCuratedCorpusItem, '__typename'> | undefined
+    Omit<ScheduledCorpusItem, '__typename'> | undefined
   >(undefined);
 
   // Get a helper function that will execute each mutation, show standard notifications
@@ -165,7 +165,7 @@ export const SchedulePage: React.FC = (): JSX.Element => {
   const [deleteScheduledItem] = useDeleteScheduledItemMutation();
 
   // Prepare the "reschedule scheduled curated corpus item" mutation
-  const [rescheduleItem] = useRescheduleScheduledCuratedCorpusItemMutation();
+  const [rescheduleItem] = useRescheduleScheduledCorpusItemMutation();
 
   /**
    * Reschedule item
@@ -279,8 +279,8 @@ export const SchedulePage: React.FC = (): JSX.Element => {
           )}
 
           {data &&
-            data.getScheduledCuratedCorpusItems.map(
-              (data: ScheduledCuratedCorpusItemsResult) => (
+            data.getScheduledCorpusItems.map(
+              (data: ScheduledCorpusItemsResult) => (
                 <Grid
                   container
                   direction="row"
@@ -298,7 +298,7 @@ export const SchedulePage: React.FC = (): JSX.Element => {
                         ({data.syndicatedCount}/{data.totalCount} syndicated)
                       </Typography>
                     </Grid>
-                    {data.items.map((item: ScheduledCuratedCorpusItem) => {
+                    {data.items.map((item: ScheduledCorpusItem) => {
                       return (
                         <ScheduledItemCardWrapper
                           key={item.externalId}


### PR DESCRIPTION
## Goal

Update the frontend in tandem with https://github.com/Pocket/curated-corpus-api/pull/650 and https://github.com/Pocket/prospect-api/pull/399. 

- Regenerated types based on the GraphQL schema from Admin API

- Updated mutations and queries to use the new names.

- Updated all components and tests that were referencing the generated types.

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1377


