### PR TITLE
feat(pageNotFound): [BACK-1322] Add 404 page for invalid collections app routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,7 +52,7 @@ function App(): JSX.Element {
                     <CuratedCorpusLandingPage />
                   </Route>
                 )}
-                <Route path="*" component={PageNotFound} />
+                <Route component={PageNotFound} />
               </Switch>
             </>
           </BrowserRouter>

--- a/src/collections/pages/CollectionsLandingPage/CollectionsLandingPage.tsx
+++ b/src/collections/pages/CollectionsLandingPage/CollectionsLandingPage.tsx
@@ -7,6 +7,7 @@ import {
   HeaderConnector,
   MainContentWrapper,
   MenuLink,
+  PageNotFound,
 } from '../../../_shared/components';
 
 import {
@@ -93,6 +94,7 @@ export const CollectionsLandingPage = (): JSX.Element => {
           <Route exact path={`${path}/search/`}>
             <CollectionSearchPage />
           </Route>
+          <Route component={PageNotFound} />
         </Switch>
       </MainContentWrapper>
     </ApolloProvider>

--- a/src/curated-corpus/pages/CuratedCorpusLandingPage/CuratedCorpusLandingPage.tsx
+++ b/src/curated-corpus/pages/CuratedCorpusLandingPage/CuratedCorpusLandingPage.tsx
@@ -8,6 +8,7 @@ import {
   HeaderConnector,
   MainContentWrapper,
   MenuLink,
+  PageNotFound,
 } from '../../../_shared/components';
 import {
   ApprovedItemsPage,
@@ -98,6 +99,7 @@ export const CuratedCorpusLandingPage = (): JSX.Element => {
             <Route exact path={`${path}/rejected/`}>
               <RejectedItemsPage />
             </Route>
+            <Route component={PageNotFound} />
           </Switch>
         </MainContentWrapper>
       </MuiPickersUtilsProvider>


### PR DESCRIPTION
## Goal

**aside**: add 404 page for invalid curation-tools routes

Tickets:

- [BACK-1322]
- [BACK-1323]

[BACK-1322]: https://getpocket.atlassian.net/browse/BACK-1322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BACK-1323]: https://getpocket.atlassian.net/browse/BACK-1323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ