### PR TITLE
 feat(loading state): [BACK-1356] show a loading bar when manually adding a prospect

### DIFF
--- a/src/curated-corpus/components/AddProspectForm/AddProspectForm.tsx
+++ b/src/curated-corpus/components/AddProspectForm/AddProspectForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Grid } from '@material-ui/core';
+import { Grid, LinearProgress } from '@material-ui/core';
 
 import { FormikHelpers, FormikValues, useFormik } from 'formik';
 import {
@@ -17,7 +17,8 @@ interface AddProspectFormProps {
     formikHelpers: FormikHelpers<any>
   ) => void | Promise<any>;
 
-  setIsLoaderShowing: (isShowing: boolean) => void;
+  // show/hide the loading bar on submissions
+  isLoaderShowing: boolean;
 }
 
 /**
@@ -30,7 +31,7 @@ export const AddProspectForm: React.FC<
   const classes = useStyles();
 
   // de-structure props
-  const { onCancel, onSubmit, setIsLoaderShowing } = props;
+  const { onCancel, onSubmit, isLoaderShowing } = props;
 
   // set up formik object for this form
   const formik = useFormik({
@@ -43,29 +44,27 @@ export const AddProspectForm: React.FC<
     onSubmit,
   });
 
-  formik.isSubmitting && setIsLoaderShowing(true);
-
   return (
-    <>
-      <form
-        name="add-prospect-form"
-        onSubmit={formik.handleSubmit}
-        className={classes.root}
-      >
-        <Grid container>
-          <Grid item xs={12}>
-            <FormikTextField
-              id="itemUrl"
-              label="Item URL"
-              fieldProps={formik.getFieldProps('itemUrl')}
-              fieldMeta={formik.getFieldMeta('itemUrl')}
-              autoFocus
-            />
-
-            <SharedFormButtons onCancel={onCancel} />
-          </Grid>
+    <form
+      name="add-prospect-form"
+      onSubmit={formik.handleSubmit}
+      className={classes.root}
+    >
+      <Grid container spacing={2}>
+        <Grid item xs={12}>
+          <FormikTextField
+            id="itemUrl"
+            label="Item URL"
+            fieldProps={formik.getFieldProps('itemUrl')}
+            fieldMeta={formik.getFieldMeta('itemUrl')}
+            autoFocus
+          />
         </Grid>
-      </form>
-    </>
+        <Grid item xs={12}>
+          {isLoaderShowing && <LinearProgress />}
+          <SharedFormButtons onCancel={onCancel} />
+        </Grid>
+      </Grid>
+    </form>
   );
 };

--- a/src/curated-corpus/components/AddProspectForm/AddProspectForm.tsx
+++ b/src/curated-corpus/components/AddProspectForm/AddProspectForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Grid, LinearProgress } from '@material-ui/core';
+import { Grid } from '@material-ui/core';
 
 import { FormikHelpers, FormikValues, useFormik } from 'formik';
 import {
@@ -16,6 +16,8 @@ interface AddProspectFormProps {
     values: FormikValues,
     formikHelpers: FormikHelpers<any>
   ) => void | Promise<any>;
+
+  setIsLoaderShowing: (isShowing: boolean) => void;
 }
 
 /**
@@ -28,7 +30,7 @@ export const AddProspectForm: React.FC<
   const classes = useStyles();
 
   // de-structure props
-  const { onCancel, onSubmit } = props;
+  const { onCancel, onSubmit, setIsLoaderShowing } = props;
 
   // set up formik object for this form
   const formik = useFormik({
@@ -40,6 +42,8 @@ export const AddProspectForm: React.FC<
     validationSchema,
     onSubmit,
   });
+
+  formik.isSubmitting && setIsLoaderShowing(true);
 
   return (
     <>
@@ -62,14 +66,6 @@ export const AddProspectForm: React.FC<
           </Grid>
         </Grid>
       </form>
-
-      {formik.isSubmitting && (
-        <Grid item xs={12}>
-          <Box mb={3}>
-            <LinearProgress />
-          </Box>
-        </Grid>
-      )}
     </>
   );
 };

--- a/src/curated-corpus/components/AddProspectFormConnector/AddProspectFormConnector.tsx
+++ b/src/curated-corpus/components/AddProspectFormConnector/AddProspectFormConnector.tsx
@@ -40,6 +40,8 @@ interface AddProspectFormConnectorProps {
    * We need to call this to be able to set the hidden Source field to Manual in the approved item form
    */
   setIsManualSubmission: (isManual: boolean) => void;
+
+  setIsLoaderShowing: (isShowing: boolean) => void;
 }
 
 /**
@@ -57,6 +59,7 @@ export const AddProspectFormConnector: React.FC<
     setCurrentProspect,
     setIsRecommendation,
     setIsManualSubmission,
+    setIsLoaderShowing,
   } = props;
 
   // state variable to store the itemUrl field from the form
@@ -137,6 +140,12 @@ export const AddProspectFormConnector: React.FC<
       toggleApprovedItemModal();
     },
   });
-
-  return <AddProspectForm onCancel={toggleModal} onSubmit={onSubmit} />;
+  console.log('***** CONNECTOR');
+  return (
+    <AddProspectForm
+      onCancel={toggleModal}
+      onSubmit={onSubmit}
+      setIsLoaderShowing={setIsLoaderShowing}
+    />
+  );
 };

--- a/src/curated-corpus/components/AddProspectFormConnector/AddProspectFormConnector.tsx
+++ b/src/curated-corpus/components/AddProspectFormConnector/AddProspectFormConnector.tsx
@@ -40,8 +40,6 @@ interface AddProspectFormConnectorProps {
    * We need to call this to be able to set the hidden Source field to Manual in the approved item form
    */
   setIsManualSubmission: (isManual: boolean) => void;
-
-  setIsLoaderShowing: (isShowing: boolean) => void;
 }
 
 /**
@@ -59,11 +57,13 @@ export const AddProspectFormConnector: React.FC<
     setCurrentProspect,
     setIsRecommendation,
     setIsManualSubmission,
-    setIsLoaderShowing,
   } = props;
 
   // state variable to store the itemUrl field from the form
   const [itemUrl, setItemUrl] = useState<string>('');
+
+  // state variable to show/hide the loading bar in the AddProspectForm component when submitting
+  const [isLoaderShowing, setIsLoaderShowing] = useState<boolean>(false);
 
   // set up some hooks
   const { showNotification } = useNotifications();
@@ -86,6 +86,9 @@ export const AddProspectFormConnector: React.FC<
       },
     });
 
+    // show the loading bar
+    setIsLoaderShowing(true);
+
     formikHelpers.resetForm();
   };
 
@@ -99,6 +102,9 @@ export const AddProspectFormConnector: React.FC<
       // show error toast if the url exists already
       if (approvedItem) {
         showNotification('This URL already exists in the Corpus', 'error');
+
+        // hide the loading bar after this failed submission
+        setIsLoaderShowing(false);
         return;
       }
 
@@ -140,12 +146,12 @@ export const AddProspectFormConnector: React.FC<
       toggleApprovedItemModal();
     },
   });
-  console.log('***** CONNECTOR');
+
   return (
     <AddProspectForm
       onCancel={toggleModal}
       onSubmit={onSubmit}
-      setIsLoaderShowing={setIsLoaderShowing}
+      isLoaderShowing={isLoaderShowing}
     />
   );
 };

--- a/src/curated-corpus/components/AddProspectFormConnector/AddProspectFormConnector.tsx
+++ b/src/curated-corpus/components/AddProspectFormConnector/AddProspectFormConnector.tsx
@@ -63,6 +63,8 @@ export const AddProspectFormConnector: React.FC<
   const [itemUrl, setItemUrl] = useState<string>('');
 
   // state variable to show/hide the loading bar in the AddProspectForm component when submitting
+  // this is against our current pattern of using the formik.isSubmitting in the form component itself
+  // to show a loading indicator. After a lot of debugging, we can't figure out why that way doesn't work hence resorting to this
   const [isLoaderShowing, setIsLoaderShowing] = useState<boolean>(false);
 
   // set up some hooks

--- a/src/curated-corpus/components/AddProspectModal/AddProspectModal.tsx
+++ b/src/curated-corpus/components/AddProspectModal/AddProspectModal.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Grid } from '@material-ui/core';
+import React, { useState } from 'react';
+import { Grid, LinearProgress } from '@material-ui/core';
 import { Prospect } from '../../../api/generatedTypes';
 import { AddProspectFormConnector } from '..';
 import { Modal } from '../../../_shared/components';
@@ -57,6 +57,8 @@ export const AddProspectModal: React.FC<AddProspectModalProps> = (
     toggleApprovedItemModal,
   } = props;
 
+  const [isLoaderShowing, setIsLoaderShowing] = useState<boolean>(false);
+
   return (
     <Modal open={isOpen} handleClose={toggleModal}>
       <Grid container direction="column">
@@ -70,8 +72,10 @@ export const AddProspectModal: React.FC<AddProspectModalProps> = (
             setCurrentProspect={setCurrentProspect}
             setIsRecommendation={setIsRecommendation}
             setIsManualSubmission={setIsManualSubmission}
+            setIsLoaderShowing={setIsLoaderShowing}
           />
         </Grid>
+        {isLoaderShowing && <LinearProgress />}
       </Grid>
     </Modal>
   );

--- a/src/curated-corpus/components/AddProspectModal/AddProspectModal.tsx
+++ b/src/curated-corpus/components/AddProspectModal/AddProspectModal.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Grid, LinearProgress } from '@material-ui/core';
+import React from 'react';
+import { Grid } from '@material-ui/core';
 import { Prospect } from '../../../api/generatedTypes';
 import { AddProspectFormConnector } from '..';
 import { Modal } from '../../../_shared/components';
@@ -57,8 +57,6 @@ export const AddProspectModal: React.FC<AddProspectModalProps> = (
     toggleApprovedItemModal,
   } = props;
 
-  const [isLoaderShowing, setIsLoaderShowing] = useState<boolean>(false);
-
   return (
     <Modal open={isOpen} handleClose={toggleModal}>
       <Grid container direction="column">
@@ -72,10 +70,8 @@ export const AddProspectModal: React.FC<AddProspectModalProps> = (
             setCurrentProspect={setCurrentProspect}
             setIsRecommendation={setIsRecommendation}
             setIsManualSubmission={setIsManualSubmission}
-            setIsLoaderShowing={setIsLoaderShowing}
           />
         </Grid>
-        {isLoaderShowing && <LinearProgress />}
       </Grid>
     </Modal>
   );


### PR DESCRIPTION
## Goal

- Add a loading bar when manually adding a prospect

Tickets:

- [BACK-1356]

## Screen capture

https://user-images.githubusercontent.com/16694733/161850717-7a3b3a9f-7fa0-4b04-bc78-66b9d614c40d.mov




[BACK-1356]: https://getpocket.atlassian.net/browse/BACK-1356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ