### PR TITLE
chore(refactor): remove unecessary guid to timezone map and fiz z-index on new tab selector

### DIFF
--- a/src/curated-corpus/components/SplitButton/SplitButton.styles.tsx
+++ b/src/curated-corpus/components/SplitButton/SplitButton.styles.tsx
@@ -7,7 +7,8 @@ export const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     popper: {
       // this prevents the dropdown from being covered by schedule item card
-      zIndex: 1,
+      // and the label on the date picker
+      zIndex: 2,
     },
 
     optionNameSmall: {

--- a/src/curated-corpus/helpers/definitions.ts
+++ b/src/curated-corpus/helpers/definitions.ts
@@ -67,31 +67,3 @@ export const curationStatusOptions: DropdownOption[] = [
 export type ApprovedItemFromProspect = Omit<ApprovedCorpusItem, 'language'> & {
   language: CorpusLanguage | undefined;
 };
-
-// scheduled surface guid to timezone map
-export const guidToUtcOffset = [
-  {
-    guid: 'NEW_TAB_EN_US',
-    timeZone: 'America/New_York',
-  },
-  {
-    guid: 'NEW_TAB_DE_DE',
-    timeZone: 'Europe/Berlin',
-  },
-  {
-    guid: 'NEW_TAB_EN_GB',
-    timeZone: 'Europe/London',
-  },
-  {
-    guid: 'NEW_TAB_EN_INTL',
-    timeZone: 'Asia/Kolkata',
-  },
-  {
-    guid: 'POCKET_HITS_EN_US',
-    timeZone: 'America/New_York',
-  },
-  {
-    guid: 'POCKET_HITS_DE_DE',
-    timeZone: 'Europe/Berlin',
-  },
-];

--- a/src/curated-corpus/helpers/helperFunctions.ts
+++ b/src/curated-corpus/helpers/helperFunctions.ts
@@ -4,15 +4,12 @@ import {
   CorpusItemSource,
   CorpusLanguage,
   CuratedStatus,
+  GetScheduledSurfacesForUserQuery,
   Maybe,
   Prospect,
   UrlMetadata,
 } from '../../api/generatedTypes';
-import {
-  topics,
-  ApprovedItemFromProspect,
-  guidToUtcOffset,
-} from './definitions';
+import { topics, ApprovedItemFromProspect } from './definitions';
 
 /**
  *
@@ -180,14 +177,19 @@ export const getDisplayTopic = (
   return displayTopic ? displayTopic : 'N/A';
 };
 
-export const getLocalDateTimeForGuid = (guidCode: string) => {
-  const guid = guidToUtcOffset.find((item) => item.guid === guidCode);
+export const getLocalDateTimeForGuid = (
+  guidCode: string,
+  scheduledSurfacesForUser: GetScheduledSurfacesForUserQuery
+) => {
+  const guid = scheduledSurfacesForUser.getScheduledSurfacesForUser.find(
+    (item) => item.guid === guidCode
+  );
 
   if (!guid) {
     return;
   }
 
-  const localDateTime = DateTime.local().setZone(guid.timeZone);
+  const localDateTime = DateTime.local().setZone(guid.ianaTimezone);
 
   // the Luxon library does not provide us a straightforward way to format the date the way we want
   // i.e August 28, 2022, 11:59 pm. That is why you can see we are concatenating two different formats

--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -144,7 +144,13 @@ export const SchedulePage: React.FC = (): JSX.Element => {
     error && showNotification(error.message, 'error');
 
     // set local time for the scheduled surface on initial page load
-    setGuidLocalDateTime(getLocalDateTimeForGuid(currentScheduledSurfaceGuid));
+    scheduledSurfaceData &&
+      setGuidLocalDateTime(
+        getLocalDateTimeForGuid(
+          currentScheduledSurfaceGuid,
+          scheduledSurfaceData
+        )
+      );
   }, [currentScheduledSurfaceGuid]);
 
   // Setting up the lazy query hook now that we need to execute
@@ -172,8 +178,10 @@ export const SchedulePage: React.FC = (): JSX.Element => {
       });
       setCurrentScheduledSurfaceGuid(option.code);
 
-      getLocalDateTimeForGuid(option.code);
-      setGuidLocalDateTime(getLocalDateTimeForGuid(option.code));
+      scheduledSurfaceData &&
+        setGuidLocalDateTime(
+          getLocalDateTimeForGuid(option.code, scheduledSurfaceData)
+        );
     }
   };
 


### PR DESCRIPTION
## Goal

Remove the `guidToTimezone` map structure in favour of the newly added `ianaTimezone` field on the scheduled item received from the query
