### PR TITLE
feat(scheduling): [BACK-1403] Implement "Move to bottom" button on Schedule page

### DIFF
--- a/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.test.tsx
+++ b/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.test.tsx
@@ -43,7 +43,12 @@ describe('The ScheduledItemCardWrapper component', () => {
   it('should render an approved item card from a scheduled item', () => {
     render(
       <MemoryRouter>
-        <ScheduledItemCardWrapper item={item} />
+        <ScheduledItemCardWrapper
+          item={item}
+          onMoveToBottom={jest.fn()}
+          onReschedule={jest.fn()}
+          onRemove={jest.fn()}
+        />
       </MemoryRouter>
     );
 
@@ -56,7 +61,12 @@ describe('The ScheduledItemCardWrapper component', () => {
   it('should render remove button', () => {
     render(
       <MemoryRouter>
-        <ScheduledItemCardWrapper item={item} />
+        <ScheduledItemCardWrapper
+          item={item}
+          onMoveToBottom={jest.fn()}
+          onReschedule={jest.fn()}
+          onRemove={jest.fn()}
+        />
       </MemoryRouter>
     );
 
@@ -70,7 +80,12 @@ describe('The ScheduledItemCardWrapper component', () => {
   it('should render reschedule button', () => {
     render(
       <MemoryRouter>
-        <ScheduledItemCardWrapper item={item} />
+        <ScheduledItemCardWrapper
+          item={item}
+          onMoveToBottom={jest.fn()}
+          onReschedule={jest.fn()}
+          onRemove={jest.fn()}
+        />
       </MemoryRouter>
     );
 
@@ -79,5 +94,24 @@ describe('The ScheduledItemCardWrapper component', () => {
     });
 
     expect(rescheduleButton).toBeInTheDocument();
+  });
+
+  it('should render "move to bottom" button', () => {
+    render(
+      <MemoryRouter>
+        <ScheduledItemCardWrapper
+          item={item}
+          onMoveToBottom={jest.fn()}
+          onReschedule={jest.fn()}
+          onRemove={jest.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    const button = screen.getByRole('button', {
+      name: /move to bottom/i,
+    });
+
+    expect(button).toBeInTheDocument();
   });
 });

--- a/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.tsx
+++ b/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.tsx
@@ -10,15 +10,21 @@ interface ScheduledItemCardWrapperProps {
    * An object with everything scheduled curated item-related in it.
    */
   item: ScheduledCorpusItem;
+
+  /**
+   * Callback for the "Move to bottom" button
+   */
+  onMoveToBottom: VoidFunction;
+
   /**
    * What to do when the "Remove" button is clicked.
    */
-  onRemove?: VoidFunction;
+  onRemove: VoidFunction;
 
   /**
    * Callback for the "Reschedule" button
    */
-  onReschedule?: VoidFunction;
+  onReschedule: VoidFunction;
 
   /**
    * Optional boolean prop to show/hide the language icon on the ApprovedItemListCard component
@@ -37,6 +43,7 @@ export const ScheduledItemCardWrapper: React.FC<
   const classes = useStyles();
   const {
     item,
+    onMoveToBottom,
     onRemove,
     onReschedule,
     showLanguageIcon,
@@ -55,6 +62,9 @@ export const ScheduledItemCardWrapper: React.FC<
         <CardActions className={classes.actions}>
           <Button buttonType="positive" variant="text" onClick={onReschedule}>
             Reschedule
+          </Button>
+          <Button buttonType="positive" variant="text" onClick={onMoveToBottom}>
+            Move to bottom
           </Button>
           <Button buttonType="negative" variant="text" onClick={onRemove}>
             Remove

--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -4,8 +4,8 @@ import { DateTime } from 'luxon';
 import { FormikHelpers, FormikValues } from 'formik';
 import {
   Button,
-  HandleApiResponse,
   FloatingActionButton,
+  HandleApiResponse,
 } from '../../../_shared/components';
 import {
   RemoveItemFromScheduledSurfaceModal,
@@ -218,6 +218,35 @@ export const SchedulePage: React.FC = (): JSX.Element => {
   };
 
   /**
+   * Pocket Hits items need to be returned in a pre-defined order. When the graph
+   * is queried, scheduled items are returned sorted by the `updatedAt` value
+   * in ascending order (most recently updated goes last).
+   *
+   * To enable the curators to rearrange stories in a certain order for a Pocket Hits
+   * email, a "Move to bottom" button has been added that updates the scheduled entry
+   * to bump up the timestamp recorded in the `updatedAt` field.
+   * @param item
+   */
+  const moveItemToBottom = (item: ScheduledCorpusItem): void => {
+    // Run the "reschedule" mutation with the same variables
+    // it already has. All we want from it is to update `updatedAt` timestamp.
+    const variables = {
+      externalId: item.externalId,
+      scheduledDate: item.scheduledDate,
+    };
+
+    // Run the mutation
+    runMutation(
+      rescheduleItem,
+      { variables },
+      `Success! Item moved to the bottom of the list.`,
+      undefined,
+      undefined,
+      refetch
+    );
+  };
+
+  /**
    * Remove item from Scheduled Surface.
    *
    * @param values
@@ -424,6 +453,9 @@ export const SchedulePage: React.FC = (): JSX.Element => {
                             onRemove={() => {
                               setCurrentItem(item);
                               toggleRemoveModal();
+                            }}
+                            onMoveToBottom={() => {
+                              moveItemToBottom(item);
                             }}
                             onReschedule={() => {
                               setCurrentItem(item);


### PR DESCRIPTION
## Goal

- Added a "Move to bottom" button to each scheduled item - this button
allows curators to move the item to the bottom of the list of scheduled
items consumed by client applications. This will enable predictable
story order on Pocket Hits surfaces.

- Updated tests.

## I'd love feedback on...

- The copy on the button. Is there something more succinct? The long copy gets the layout out of whack. Could we get away with just "Reorder"?

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1403

## Video walkthrough


https://user-images.githubusercontent.com/22447785/163322032-aa08dafc-ee04-4919-8eac-257a9f4a4523.mov



