### PR TITLE
fix(image-cache): encode the image cache url

### DIFF
--- a/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.tsx
+++ b/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.tsx
@@ -51,7 +51,7 @@ export const ApprovedItemListCard: React.FC<ApprovedItemListCardProps> = (
   // prefixing the item's imageUrl with the pocket-image-cache url to format it to a size of 600x300
   const formattedImageUrl =
     `https://pocket-image-cache.com/600x300/filters:format(jpg):extract_focal()/`.concat(
-      item.imageUrl
+      encodeURIComponent(item.imageUrl)
     );
 
   return (


### PR DESCRIPTION
## Goal

URL encode images when showing on the approved list card
