### PR TITLE
refactor(prospectId): update prospects to use uuid for prospectId property and other updates

### DIFF
--- a/src/api/fragments/prospect.ts
+++ b/src/api/fragments/prospect.ts
@@ -8,6 +8,7 @@ import { CuratedItemData } from './curatedItemData';
 export const ProspectData = gql`
   fragment ProspectData on Prospect {
     id
+    prospectId
     scheduledSurfaceGuid
     topic
     prospectType

--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -897,7 +897,7 @@ export type Mutation = {
   updateCollectionStorySortOrder: CollectionStory;
   /**
    * marks a prospect as 'curated' in the database, preventing it from being displayed for prospecting.
-   * returns true if the operation succeeds, false if not (almost surely due to an incorrect prospectId).
+   * returns true if the operation succeeds, false if not (almost surely due to an incorrect id).
    */
   updateProspectAsCurated?: Maybe<Prospect>;
   /** Uploads an image to S3 for an Approved Item */
@@ -1017,7 +1017,7 @@ export type MutationUpdateCollectionStorySortOrderArgs = {
 };
 
 export type MutationUpdateProspectAsCuratedArgs = {
-  prospectId: Scalars['ID'];
+  id: Scalars['ID'];
 };
 
 export type MutationUploadApprovedCorpusItemImageArgs = {
@@ -1104,6 +1104,7 @@ export type Prospect = {
   isCollection?: Maybe<Scalars['Boolean']>;
   isSyndicated?: Maybe<Scalars['Boolean']>;
   language?: Maybe<CorpusLanguage>;
+  prospectId: Scalars['ID'];
   prospectType: Scalars['String'];
   publisher?: Maybe<Scalars['String']>;
   saveCount?: Maybe<Scalars['Int']>;
@@ -1743,6 +1744,7 @@ export type CuratedItemDataFragment = {
 export type ProspectDataFragment = {
   __typename?: 'Prospect';
   id: string;
+  prospectId: string;
   scheduledSurfaceGuid: string;
   topic?: string | null;
   prospectType: string;
@@ -2633,7 +2635,7 @@ export type UpdateCollectionStorySortOrderMutation = {
 };
 
 export type UpdateProspectAsCuratedMutationVariables = Exact<{
-  prospectId: Scalars['ID'];
+  id: Scalars['ID'];
 }>;
 
 export type UpdateProspectAsCuratedMutation = {
@@ -2641,6 +2643,7 @@ export type UpdateProspectAsCuratedMutation = {
   updateProspectAsCurated?: {
     __typename?: 'Prospect';
     id: string;
+    prospectId: string;
     scheduledSurfaceGuid: string;
     topic?: string | null;
     prospectType: string;
@@ -3075,6 +3078,7 @@ export type GetProspectsQuery = {
   getProspects: Array<{
     __typename?: 'Prospect';
     id: string;
+    prospectId: string;
     scheduledSurfaceGuid: string;
     topic?: string | null;
     prospectType: string;
@@ -3450,6 +3454,7 @@ export const CuratedItemDataFragmentDoc = gql`
 export const ProspectDataFragmentDoc = gql`
   fragment ProspectData on Prospect {
     id
+    prospectId
     scheduledSurfaceGuid
     topic
     prospectType
@@ -5183,8 +5188,8 @@ export type UpdateCollectionStorySortOrderMutationOptions =
     UpdateCollectionStorySortOrderMutationVariables
   >;
 export const UpdateProspectAsCuratedDocument = gql`
-  mutation updateProspectAsCurated($prospectId: ID!) {
-    updateProspectAsCurated(prospectId: $prospectId) {
+  mutation updateProspectAsCurated($id: ID!) {
+    updateProspectAsCurated(id: $id) {
       ...ProspectData
     }
   }
@@ -5208,7 +5213,7 @@ export type UpdateProspectAsCuratedMutationFn = Apollo.MutationFunction<
  * @example
  * const [updateProspectAsCuratedMutation, { data, loading, error }] = useUpdateProspectAsCuratedMutation({
  *   variables: {
- *      prospectId: // value for 'prospectId'
+ *      id: // value for 'id'
  *   },
  * });
  */

--- a/src/api/mutations/updateProspectAsCurated.ts
+++ b/src/api/mutations/updateProspectAsCurated.ts
@@ -2,8 +2,8 @@ import { gql } from '@apollo/client';
 import { ProspectData } from '../fragments/prospect';
 
 export const updateProspectAsCurated = gql`
-  mutation updateProspectAsCurated($prospectId: ID!) {
-    updateProspectAsCurated(prospectId: $prospectId) {
+  mutation updateProspectAsCurated($id: ID!) {
+    updateProspectAsCurated(id: $id) {
       ...ProspectData
     }
   }

--- a/src/curated-corpus/helpers/helperFunctions.test.ts
+++ b/src/curated-corpus/helpers/helperFunctions.test.ts
@@ -16,7 +16,8 @@ describe('helperFunctions ', () => {
   describe('transformProspectToApprovedItem function', () => {
     it('should create an ApprovedCorpusItem with all the provided fields', () => {
       const prospect: Prospect = {
-        id: 'test-prospect-id',
+        id: 'test-id',
+        prospectId: 'test-prospect-id',
         scheduledSurfaceGuid: 'en-us',
         prospectType: ProspectType.Syndicated,
         url: 'test-prospect-url',
@@ -64,6 +65,7 @@ describe('helperFunctions ', () => {
       const prospect: Prospect = {
         id: 'test-prospect-id',
         url: 'test-prospect-url',
+        prospectId: 'test-prospect-id',
         scheduledSurfaceGuid: 'en-us',
         prospectType: ProspectType.Global,
       };

--- a/src/curated-corpus/helpers/helperFunctions.test.ts
+++ b/src/curated-corpus/helpers/helperFunctions.test.ts
@@ -42,7 +42,7 @@ describe('helperFunctions ', () => {
 
       expect(approvedItemFromProspect).toMatchObject({
         externalId: '',
-        prospectId: prospect.id,
+        prospectId: prospect.prospectId,
         url: prospect.url,
         title: prospect.title,
         imageUrl: prospect.imageUrl,

--- a/src/curated-corpus/helpers/helperFunctions.ts
+++ b/src/curated-corpus/helpers/helperFunctions.ts
@@ -23,9 +23,10 @@ export const transformProspectToApprovedItem = (
   isRecommendation: boolean,
   isManual: boolean
 ): ApprovedItemFromProspect => {
+  //TODO: do stuff here
   return {
     externalId: '',
-    prospectId: prospect.id,
+    prospectId: prospect.prospectId,
     url: prospect.url,
     title: prospect.title ?? '',
     imageUrl: prospect.imageUrl ?? '',
@@ -66,6 +67,7 @@ export const transformUrlMetaDataToProspect = (
   return {
     // manually added items don't have a prospect id!
     id: '',
+    prospectId: '',
     // Set whatever properties the Parser could retrieve for us
     url: metadata.url,
     title: metadata.title ?? '',

--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -344,7 +344,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
     const imageUrl: string = s3ImageUrl;
 
     const approvedItem = {
-      prospectId: currentProspect?.id!,
+      prospectId: currentProspect?.prospectId,
       url: values.url,
       title: values.title,
       excerpt: values.excerpt,
@@ -371,7 +371,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
           // call the mutation to mark prospect as approved
           runMutation(
             updateProspectAsCurated,
-            { variables: { prospectId: currentProspect?.id } },
+            { variables: { id: currentProspect?.id } },
             undefined,
             () => {
               postCreateApprovedItem(


### PR DESCRIPTION
## Goal

-  Update the `updateProspectAsCurated` mutation to use the `id` `(uuid)` and update the mutation input variable.  
- Update the Prospect fragment

Tickets:

- [BACK-1415]

[BACK-1415]: https://getpocket.atlassian.net/browse/BACK-1415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ