### PR TITLE
fix(rejected): hide rejected prospects

### DIFF
--- a/src/api/fragments/prospect.ts
+++ b/src/api/fragments/prospect.ts
@@ -1,9 +1,10 @@
 import { gql } from '@apollo/client';
 import { CuratedItemData } from './curatedItemData';
+import { RejectedItemData } from './rejectedItemData';
 
 /**
- * Everything we need to fetch for a Prospect, including an optional
- * ApprovedCorpusItem object if there's a match by URL.
+ * Everything we need to fetch for a Prospect, including optional
+ * ApprovedCorpusItem and RejectedCorpusItem objects if there's a match by URL.
  */
 export const ProspectData = gql`
   fragment ProspectData on Prospect {
@@ -26,6 +27,10 @@ export const ProspectData = gql`
     approvedCorpusItem {
       ...CuratedItemData
     }
+    rejectedCorpusItem {
+      ...RejectedItemData
+    }
   }
   ${CuratedItemData}
+  ${RejectedItemData}
 `;

--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -1107,6 +1107,7 @@ export type Prospect = {
   prospectId: Scalars['ID'];
   prospectType: Scalars['String'];
   publisher?: Maybe<Scalars['String']>;
+  rejectedCorpusItem?: Maybe<RejectedCorpusItem>;
   saveCount?: Maybe<Scalars['Int']>;
   scheduledSurfaceGuid: Scalars['String'];
   title?: Maybe<Scalars['String']>;
@@ -1779,6 +1780,19 @@ export type ProspectDataFragment = {
     createdAt: number;
     updatedBy?: string | null;
     updatedAt: number;
+  } | null;
+  rejectedCorpusItem?: {
+    __typename?: 'RejectedCorpusItem';
+    externalId: string;
+    prospectId?: string | null;
+    url: any;
+    title: string;
+    topic: string;
+    language: CorpusLanguage;
+    publisher: string;
+    reason: string;
+    createdBy: string;
+    createdAt: number;
   } | null;
 };
 
@@ -2679,6 +2693,19 @@ export type UpdateProspectAsCuratedMutation = {
       updatedBy?: string | null;
       updatedAt: number;
     } | null;
+    rejectedCorpusItem?: {
+      __typename?: 'RejectedCorpusItem';
+      externalId: string;
+      prospectId?: string | null;
+      url: any;
+      title: string;
+      topic: string;
+      language: CorpusLanguage;
+      publisher: string;
+      reason: string;
+      createdBy: string;
+      createdAt: number;
+    } | null;
   } | null;
 };
 
@@ -3114,6 +3141,19 @@ export type GetProspectsQuery = {
       updatedBy?: string | null;
       updatedAt: number;
     } | null;
+    rejectedCorpusItem?: {
+      __typename?: 'RejectedCorpusItem';
+      externalId: string;
+      prospectId?: string | null;
+      url: any;
+      title: string;
+      topic: string;
+      language: CorpusLanguage;
+      publisher: string;
+      reason: string;
+      createdBy: string;
+      createdAt: number;
+    } | null;
   }>;
 };
 
@@ -3451,6 +3491,20 @@ export const CuratedItemDataFragmentDoc = gql`
     updatedAt
   }
 `;
+export const RejectedItemDataFragmentDoc = gql`
+  fragment RejectedItemData on RejectedCorpusItem {
+    externalId
+    prospectId
+    url
+    title
+    topic
+    language
+    publisher
+    reason
+    createdBy
+    createdAt
+  }
+`;
 export const ProspectDataFragmentDoc = gql`
   fragment ProspectData on Prospect {
     id
@@ -3472,22 +3526,12 @@ export const ProspectDataFragmentDoc = gql`
     approvedCorpusItem {
       ...CuratedItemData
     }
+    rejectedCorpusItem {
+      ...RejectedItemData
+    }
   }
   ${CuratedItemDataFragmentDoc}
-`;
-export const RejectedItemDataFragmentDoc = gql`
-  fragment RejectedItemData on RejectedCorpusItem {
-    externalId
-    prospectId
-    url
-    title
-    topic
-    language
-    publisher
-    reason
-    createdBy
-    createdAt
-  }
+  ${RejectedItemDataFragmentDoc}
 `;
 export const ScheduledItemDataFragmentDoc = gql`
   fragment ScheduledItemData on ScheduledCorpusItem {

--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -652,6 +652,11 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
 
           {prospects &&
             prospects.map((prospect) => {
+              if (prospect.rejectedCorpusItem) {
+                // If an item was rejected, lets just not show it
+                return;
+              }
+
               if (prospect.approvedCorpusItem) {
                 return (
                   <ExistingProspectCard


### PR DESCRIPTION
## Goal

If there is a rejected prospect we should hide it.

This depends on https://github.com/Pocket/prospect-api/pull/431 and https://github.com/Pocket/curated-corpus-api/pull/686

## Todos

- [ ] Outstanding todo
- [x] Completed todo

## Modifying Environment Variables

Omit this section if not applicable.

- [ ] Variables added to SSM
- [ ] Variables added to terraform environment config

Have you followed the guidelines in our Contributing document?

## Deployment

Omit this section if not applicable.

Anything we should know about deploying this PR?

## Reference

Documentation here:

- Link to docs

Tickets:

- Link to JIRA tickets

## Implementation Decisions
