### PR TITLE
feat(prospects): [BACK-1434] Display authors coming from Prospect API

### DIFF
--- a/src/api/fragments/prospect.ts
+++ b/src/api/fragments/prospect.ts
@@ -16,6 +16,7 @@ export const ProspectData = gql`
     url
     createdAt
     imageUrl
+    authors
     publisher
     domain
     title

--- a/src/api/fragments/urlMetadata.ts
+++ b/src/api/fragments/urlMetadata.ts
@@ -14,5 +14,6 @@ export const urlMetadata = gql`
     language
     isSyndicated
     isCollection
+    authors
   }
 `;

--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -1096,6 +1096,7 @@ export type PaginationInput = {
 export type Prospect = {
   __typename?: 'Prospect';
   approvedCorpusItem?: Maybe<ApprovedCorpusItem>;
+  authors?: Maybe<Scalars['String']>;
   createdAt?: Maybe<Scalars['Int']>;
   domain?: Maybe<Scalars['String']>;
   excerpt?: Maybe<Scalars['String']>;
@@ -1560,6 +1561,7 @@ export type UpdateCollectionStorySortOrderInput = {
 
 export type UrlMetadata = {
   __typename?: 'UrlMetadata';
+  authors?: Maybe<Scalars['String']>;
   domain?: Maybe<Scalars['String']>;
   excerpt?: Maybe<Scalars['String']>;
   imageUrl?: Maybe<Scalars['String']>;
@@ -1752,6 +1754,7 @@ export type ProspectDataFragment = {
   url: string;
   createdAt?: number | null;
   imageUrl?: string | null;
+  authors?: string | null;
   publisher?: string | null;
   domain?: string | null;
   title?: string | null;
@@ -1853,6 +1856,7 @@ export type UrlMetadataFragment = {
   language?: string | null;
   isSyndicated?: boolean | null;
   isCollection?: boolean | null;
+  authors?: string | null;
 };
 
 export type CreateApprovedCorpusItemMutationVariables = Exact<{
@@ -2664,6 +2668,7 @@ export type UpdateProspectAsCuratedMutation = {
     url: string;
     createdAt?: number | null;
     imageUrl?: string | null;
+    authors?: string | null;
     publisher?: string | null;
     domain?: string | null;
     title?: string | null;
@@ -3112,6 +3117,7 @@ export type GetProspectsQuery = {
     url: string;
     createdAt?: number | null;
     imageUrl?: string | null;
+    authors?: string | null;
     publisher?: string | null;
     domain?: string | null;
     title?: string | null;
@@ -3378,6 +3384,7 @@ export type GetUrlMetadataQuery = {
     language?: string | null;
     isSyndicated?: boolean | null;
     isCollection?: boolean | null;
+    authors?: string | null;
   };
 };
 
@@ -3515,6 +3522,7 @@ export const ProspectDataFragmentDoc = gql`
     url
     createdAt
     imageUrl
+    authors
     publisher
     domain
     title
@@ -3559,6 +3567,7 @@ export const UrlMetadataFragmentDoc = gql`
     language
     isSyndicated
     isCollection
+    authors
   }
 `;
 export const CreateApprovedCorpusItemDocument = gql`

--- a/src/curated-corpus/components/ProspectListCard/ProspectListCard.test.tsx
+++ b/src/curated-corpus/components/ProspectListCard/ProspectListCard.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { Prospect, Topics } from '../../../api/generatedTypes';
+import { CorpusLanguage, Prospect, Topics } from '../../../api/generatedTypes';
 import { ProspectListCard } from './ProspectListCard';
 
 describe('The ProspectListCard component', () => {
@@ -13,6 +13,7 @@ describe('The ProspectListCard component', () => {
   beforeEach(() => {
     prospect = {
       id: '123-abc',
+      prospectId: '456-dfg',
       title: 'How To Win Friends And Influence People with DynamoDB',
       scheduledSurfaceGuid: 'NEW_TAB_EN_US',
       prospectType: 'organic-timespent',
@@ -20,8 +21,9 @@ describe('The ProspectListCard component', () => {
       imageUrl: 'https://placeimg.com/640/480/people?random=495',
       excerpt:
         'Everything You Wanted to Know About DynamoDB and Were Afraid To Ask',
-      language: 'de',
+      language: CorpusLanguage.De,
       publisher: 'Amazing Inventions',
+      authors: 'Charles Dickens,O. Henry',
       topic: Topics.Technology,
     };
   });
@@ -52,6 +54,14 @@ describe('The ProspectListCard component', () => {
     // The excerpt is also present
     const excerpt = screen.getByText(/wanted to know about dynamo/i);
     expect(excerpt).toBeInTheDocument();
+
+    // And the authors
+    const authors = screen.getByText(prospect.authors!);
+    expect(authors).toBeInTheDocument();
+
+    // And even the publisher
+    const publisher = screen.getByText(prospect.publisher!);
+    expect(publisher).toBeInTheDocument();
   });
 
   it('shows language correctly', () => {

--- a/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
+++ b/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
@@ -81,7 +81,8 @@ export const ProspectListCard: React.FC<ProspectListCardProps> = (
             component="span"
             align="left"
           >
-            <span>{prospect.publisher}</span> &middot;{' '}
+            <span>{prospect.authors ? prospect.authors : 'Authors: N/A'}</span>{' '}
+            &middot; <span>{prospect.publisher}</span> &middot;{' '}
             <span>{prospect.domain}</span>
           </Typography>{' '}
           <Box py={1}>


### PR DESCRIPTION
## Goal

Display the author information, now available for prospects, on the Prospecting page.

- Updated fragments for `UrlMetadata` and `Prospect`.

- Added authors alongside the publisher in ProspectListCard component.

- Updated unit tests.

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1434