### PR TITLE
fix(scheduledItem): Prevent scheduling and rescheduling items without topic

### DIFF
--- a/src/curated-corpus/pages/ApprovedItemsPage/ApprovedItemsPage.tsx
+++ b/src/curated-corpus/pages/ApprovedItemsPage/ApprovedItemsPage.tsx
@@ -21,7 +21,11 @@ import {
   RejectItemModal,
   ScheduleItemModal,
 } from '../../components';
-import { useRunMutation, useToggle } from '../../../_shared/hooks';
+import {
+  useRunMutation,
+  useToggle,
+  useNotifications,
+} from '../../../_shared/hooks';
 import { DateTime } from 'luxon';
 
 export const ApprovedItemsPage: React.FC = (): JSX.Element => {
@@ -36,6 +40,9 @@ export const ApprovedItemsPage: React.FC = (): JSX.Element => {
   // Get a helper function that will execute each mutation, show standard notifications
   // and execute any additional actions in a callback
   const { runMutation } = useRunMutation();
+
+  // set up the hook for toast notification
+  const { showNotification } = useNotifications();
 
   // Save the filters in a state variable to be able to use them when paginating
   // through results.
@@ -184,6 +191,13 @@ export const ApprovedItemsPage: React.FC = (): JSX.Element => {
     values: FormikValues,
     formikHelpers: FormikHelpers<any>
   ): void => {
+    // DE items migrated from the old system don't have a topic. This check forces to add a topic before scheduling
+    // Although for this case, if an item is in the corpus already, we shouldn't run into this since you need to add a Topic before you can save it to the corpus
+    if (!currentItem?.topic) {
+      showNotification('Cannot schedule item without topic', 'error');
+      return;
+    }
+
     // Set out all the variables we need to pass to the mutation
     const variables: CreateScheduledCorpusItemInput = {
       approvedItemExternalId: currentItem?.externalId!,

--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -474,6 +474,12 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
     values: FormikValues,
     formikHelpers: FormikHelpers<any>
   ): void => {
+    // DE items migrated from the old system don't have a topic. This check forces to add a topic before scheduling
+    if (!approvedItem?.topic) {
+      showNotification('Cannot schedule item without topic', 'error');
+      return;
+    }
+
     // Set out all the variables we need to pass to the mutation
     const variables = {
       approvedItemExternalId: approvedItem?.externalId,

--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -195,6 +195,12 @@ export const SchedulePage: React.FC = (): JSX.Element => {
     values: FormikValues,
     formikHelpers: FormikHelpers<any>
   ): void => {
+    // DE items migrated from the old system don't have a topic. This check forces to add a topic before scheduling
+    if (!currentItem?.approvedItem.topic) {
+      showNotification('Cannot schedule item without topic', 'error');
+      return;
+    }
+
     // Set out all the variables we need to pass to the mutation
     const variables = {
       externalId: currentItem?.externalId,


### PR DESCRIPTION
## Goal

Prevent items without `topic` property from being scheduled/rescheduled 

Tickets:

- [BACK-1437]

[BACK-1437]: https://getpocket.atlassian.net/browse/BACK-1437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ