### PR TITLE
fix(manual): resetting manual submission when from prospect

### DIFF
--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -682,11 +682,13 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
                   prospect={prospect}
                   onAddToCorpus={() => {
                     setCurrentProspect(prospect);
+                    setIsManualSubmission(false);
                     setIsRecommendation(false);
                     toggleApprovedItemModal();
                   }}
                   onRecommend={() => {
                     setCurrentProspect(prospect);
+                    setIsManualSubmission(false);
                     setIsRecommendation(true);
                     toggleApprovedItemModal();
                   }}


### PR DESCRIPTION
## Goal

Make sure to reset manual submission to false when a user clicks on a prospect card

## Todos

- [x] Reset isManual state

## Implementation Decisions

Long term I think we should update 

```
 approvedItem={transformProspectToApprovedItem(
      currentProspect,
      isRecommendation,
      isManualSubmission
    )}
```

to not use the isManualSubmission state variable and instead rely on there being a prospect id