### PR TITLE
fix(preflight header): [BACK-1422] Add pre flight header to apollo client instance

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -45,6 +45,9 @@ const apolloOptions = {
 };
 
 export const client = new ApolloClient({
-  link: createUploadLink({ uri: config.adminApiEndpoint }),
+  link: createUploadLink({
+    uri: config.adminApiEndpoint,
+    headers: { 'Apollo-Require-Preflight': true },
+  }),
   ...apolloOptions,
 });


### PR DESCRIPTION
❌  DO NOT MERGE ❌ 

## Goal

After adding the `csrfPrevention:true` property on the Admin-api gateway instance, the image upload requests were being blocked due to the `content-type` header for that request being `multipart/form-data`. This change fixes that and allows for successful image uploads

Tickets:

- [BACK-1422]

[BACK-1422]: https://getpocket.atlassian.net/browse/BACK-1422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ