### PR TITLE
fix(manual schedule): [BACK-1456] Fix manual scheduling throwing an error

### DIFF
--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -515,10 +515,10 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
         // Hide the loading indicator
         formikHelpers.setSubmitting(false);
 
-        // In case this prospect already existed in the corpus database,
+        // In case this prospect already existed in the corpus database i.e it has an approvedItem on it,
         // mark it as curated at this point
-        // A manually added item (currentProspect) won't have an id so we skip this check and mutation call
-        if (currentProspect?.id && approvedItem?.url === currentProspect?.url) {
+        // A manually added item/currentProspect won't have an approvedItem on it so this check is never hit
+        if (currentProspect?.approvedCorpusItem) {
           runMutation(updateProspectAsCurated, {
             variables: { id: currentProspect?.id },
           });

--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -517,7 +517,8 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
 
         // In case this prospect already existed in the corpus database,
         // mark it as curated at this point
-        if (approvedItem?.url === currentProspect?.url) {
+        // A manually added item (currentProspect) won't have an id so we skip this check and mutation call
+        if (currentProspect?.id && approvedItem?.url === currentProspect?.url) {
           runMutation(updateProspectAsCurated, {
             variables: { id: currentProspect?.id },
           });


### PR DESCRIPTION
## Goal

After adding a manual prospect/item and then trying to schedule it, users were getting an error toast even though the item was being successfully scheduled. This change fixes that.

Tickets:

- [BACK-1456]

[BACK-1456]: https://getpocket.atlassian.net/browse/BACK-1456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ