### PR TITLE
fix(mozilla): moving to mozilla auth proxy

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -15,15 +15,15 @@ export const config = {
   oauth2: {
     provider: `${
       process.env.REACT_APP_OAUTH2_PROVIDER ??
-      'https://pocket-admin-prod.auth.us-east-1.amazoncognito.com/oauth2'
+      'https://mozilla-auth-proxy.getpocket.com/oauth2'
     }`,
     // So is the client ID.
     clientId: `${
-      process.env.REACT_APP_OAUTH2_CLIENT_ID ?? '6qt94s9d651k24mvul9q2lbrcv'
+      process.env.REACT_APP_OAUTH2_CLIENT_ID ?? '2acvnpoglouk95t2pks7hucu7p'
     }`,
     logoutEndpoint: `${
       process.env.REACT_APP_OAUTH2_LOGOUT_ENDPOINT ??
-      'https://pocket-admin-prod.auth.us-east-1.amazoncognito.com/logout'
+      'https://mozilla-auth-proxy.getpocket.com/logout'
     }`,
     redirectUri: `${
       process.env.REACT_APP_OAUTH2_REDIRECT_URI ??

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -17,9 +17,9 @@ export const config = {
       process.env.REACT_APP_OAUTH2_PROVIDER ??
       'https://mozilla-auth-proxy.getpocket.com/oauth2'
     }`,
-    // So is the client ID.
+    // So is the client ID
     clientId: `${
-      process.env.REACT_APP_OAUTH2_CLIENT_ID ?? '2acvnpoglouk95t2pks7hucu7p'
+      process.env.REACT_APP_OAUTH2_CLIENT_ID ?? '5qgiui93mdakahca0rvvtsi3ar'
     }`,
     logoutEndpoint: `${
       process.env.REACT_APP_OAUTH2_LOGOUT_ENDPOINT ??


### PR DESCRIPTION
## Goal

Move to Mozilla Auth Proxy instead of our older cognito proxy. this should ameliorate the problem we've faced for years when folks are in too many mozilla groups and access breaks (due to the group size breaking the auth payload size restrictions).

- https://getpocket.atlassian.net/browse/BACK-1505

### Note

the client id value in your local `.env` file will need to be updated! ask in slack (or check AWS cognito) for the new value!
