### PR TITLE
chore(tests): [BACK-1535] Add unit tests for ScheduleItemModal component

### DIFF
--- a/src/_shared/components/Header/Header.test.tsx
+++ b/src/_shared/components/Header/Header.test.tsx
@@ -29,6 +29,7 @@ describe('The Header component', () => {
         <Header
           hasUser={false}
           menuLinks={menuLinks}
+          onLogout={jest.fn()}
           parsedIdToken={null}
           productLink="/something"
           productName="Collections"
@@ -54,6 +55,7 @@ describe('The Header component', () => {
         <Header
           hasUser={false}
           menuLinks={menuLinks}
+          onLogout={jest.fn()}
           parsedIdToken={null}
           productLink="/something"
           productName="Collections"

--- a/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.test.tsx
+++ b/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.test.tsx
@@ -44,6 +44,7 @@ describe('The ApprovedItemForm component', () => {
       createdAt: 1635014926,
       createdBy: 'Amy',
       updatedAt: 1635114926,
+      scheduledSurfaceHistory: [],
     };
   });
 

--- a/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.test.tsx
+++ b/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.test.tsx
@@ -48,6 +48,7 @@ describe('The ExistingProspectCard component', () => {
         isTimeSensitive: false,
         source: CorpusItemSource.Prospect,
         status: CuratedStatus.Recommendation,
+        authors: [{ name: 'Marie Curie', sortOrder: 1 }],
         scheduledSurfaceHistory: [],
       },
     };

--- a/src/curated-corpus/components/ImageUpload/ImageUpload.test.tsx
+++ b/src/curated-corpus/components/ImageUpload/ImageUpload.test.tsx
@@ -38,6 +38,7 @@ describe('The ImageUpload component', () => {
       updatedAt: 1635114926,
       scheduledSurfaceHistory: [],
       source: CorpusItemSource.Prospect,
+      authors: [{ name: 'Charles Dickens', sortOrder: 1 }],
     };
   });
 

--- a/src/curated-corpus/components/MiniScheduleCard/MiniScheduleCard.test.tsx
+++ b/src/curated-corpus/components/MiniScheduleCard/MiniScheduleCard.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import {
-  CorpusLanguage,
   CorpusItemSource,
+  CorpusLanguage,
   CuratedStatus,
   ScheduledCorpusItem,
   Topics,
@@ -43,6 +43,7 @@ describe('The MiniScheduleCard component', () => {
         createdBy: 'Amy',
         updatedAt: 1635114926,
         scheduledSurfaceHistory: [],
+        authors: [{ name: 'John Doe', sortOrder: 1 }],
         source: CorpusItemSource.Prospect,
       },
     };

--- a/src/curated-corpus/components/RejectedItemListCard/RejectedItemListCard.test.tsx
+++ b/src/curated-corpus/components/RejectedItemListCard/RejectedItemListCard.test.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { RejectedCorpusItem } from '../../../api/generatedTypes';
+import {
+  CorpusLanguage,
+  RejectedCorpusItem,
+} from '../../../api/generatedTypes';
 import { RejectedItemListCard } from './RejectedItemListCard';
 
 describe('The RejectedItemListCard component', () => {
@@ -13,7 +16,7 @@ describe('The RejectedItemListCard component', () => {
       prospectId: '123-xyz',
       title: 'How To Win Friends And Influence People with React',
       url: 'http://www.test.com/how-to',
-      language: 'DE',
+      language: CorpusLanguage.De,
       publisher: 'Amazing Inventions',
       topic: 'Technology',
       createdAt: 1635014926,

--- a/src/curated-corpus/components/ScheduleItemModal/ScheduleItemModal.test.tsx
+++ b/src/curated-corpus/components/ScheduleItemModal/ScheduleItemModal.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { mock_AllScheduledSurfaces } from '../../integration-test-mocks/getScheduledSurfacesForUser';
+import { render, screen } from '@testing-library/react';
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
+import { SnackbarProvider } from 'notistack';
+import { MuiPickersUtilsProvider } from '@material-ui/pickers';
+import LuxonUtils from '@date-io/luxon';
+import {
+  ApprovedCorpusItem,
+  CorpusItemSource,
+  CorpusLanguage,
+  CuratedStatus,
+  Topics,
+} from '../../../api/generatedTypes';
+import { ScheduleItemModal } from './ScheduleItemModal';
+import userEvent from '@testing-library/user-event';
+import { mock_ScheduledItemCountsZero } from '../../integration-test-mocks/getScheduledItemCounts';
+
+describe('ScheduleItemModal', () => {
+  const mocks: MockedResponse[] = [
+    mock_AllScheduledSurfaces,
+    mock_ScheduledItemCountsZero,
+  ];
+
+  const approvedItem: ApprovedCorpusItem = {
+    externalId: '123-abc',
+    prospectId: '123-xyz',
+    title: 'How To Win Friends And Influence People with React',
+    url: 'https://www.test.com/how-to',
+    imageUrl: 'https://placeimg.com/640/480/people?random=494',
+    excerpt: 'Everything You Wanted to Know About React and Were Afraid To Ask',
+    language: CorpusLanguage.De,
+    authors: [
+      { name: 'One Author', sortOrder: 1 },
+      { name: 'Two Authors', sortOrder: 2 },
+    ],
+    publisher: 'Amazing Inventions',
+    topic: Topics.HealthFitness,
+    source: CorpusItemSource.Prospect,
+    status: CuratedStatus.Recommendation,
+    isCollection: false,
+    isSyndicated: false,
+    isTimeSensitive: false,
+    createdAt: 1635014926,
+    createdBy: 'Amy',
+    updatedAt: 1635114926,
+    scheduledSurfaceHistory: [],
+  };
+
+  const renderComponent = (
+    mocks: MockedResponse[],
+    props: {
+      headingCopy?: string;
+      isOpen?: boolean;
+      toggleModal?: VoidFunction;
+    }
+  ) => {
+    render(
+      <MockedProvider mocks={mocks}>
+        <SnackbarProvider>
+          <MuiPickersUtilsProvider utils={LuxonUtils}>
+            <ScheduleItemModal
+              approvedItem={approvedItem}
+              disableScheduledSurface={false}
+              isOpen={props.isOpen ?? true}
+              scheduledSurfaceGuid={'dummyId'}
+              onSave={jest.fn()}
+              toggleModal={props.toggleModal ?? jest.fn()}
+              headingCopy={props.headingCopy ?? undefined}
+            />
+          </MuiPickersUtilsProvider>
+        </SnackbarProvider>
+      </MockedProvider>
+    );
+  };
+
+  it('is not visible on the screen unless open', async () => {
+    renderComponent(mocks, { isOpen: false, headingCopy: 'Find me' });
+
+    // Let's make sure the heading is not there
+    expect(screen.queryByText('Find me')).not.toBeInTheDocument();
+
+    // Wait for the form to load, then test whether we can see it
+    const form = await screen.queryByRole('form');
+    expect(form).not.toBeInTheDocument();
+  });
+
+  it('shows up on the screen when open', async () => {
+    renderComponent(mocks, { isOpen: true, headingCopy: 'Find me' });
+
+    // Let's make sure the heading is present
+    expect(screen.queryByText('Find me')).toBeInTheDocument();
+
+    // Wait for the form to load, then test whether we can see it
+    const form = await screen.findByRole('form');
+    expect(form).toBeInTheDocument();
+  });
+
+  it('reacts to pressing the "Cancel" button', async () => {
+    const toggleModal = jest.fn();
+
+    renderComponent(mocks, { toggleModal });
+
+    await screen.findByRole('form');
+
+    userEvent.click(screen.getByText('Cancel'));
+    expect(toggleModal).toBeCalled();
+  });
+
+  it('renders the default heading copy', () => {
+    renderComponent(mocks, { isOpen: true });
+
+    // Let's make sure the heading with the default copy is present
+    expect(screen.queryByText('Schedule this item')).toBeInTheDocument();
+  });
+
+  it('renders the heading copy provided', () => {
+    // In a way this is already tested in the "shows up on the screen" test,
+    // but let's set up a separate unit test for completion
+    const headingCopy = 'My custom header';
+
+    renderComponent(mocks, { headingCopy });
+
+    expect(screen.queryByText(headingCopy)).toBeInTheDocument();
+  });
+});

--- a/src/curated-corpus/components/ScheduleItemModal/ScheduleItemModal.tsx
+++ b/src/curated-corpus/components/ScheduleItemModal/ScheduleItemModal.tsx
@@ -7,9 +7,25 @@ import { Modal } from '../../../_shared/components';
 import { ScheduleItemFormConnector } from '../';
 
 interface ScheduleItemModalProps {
+  /**
+   * The approved corpus item the impending scheduling action is meant for.
+   */
   approvedItem: ApprovedCorpusItem;
+
+  /**
+   * The copy that shows up at the top of the schedule item modal. This is different
+   * depending on which screen the modal is initiated from.
+   */
   headingCopy?: string;
+
+  /**
+   * Whether the modal is visible or not.
+   */
   isOpen: boolean;
+
+  /**
+   * The scheduled surface GUID that should be selected, if provided
+   */
   scheduledSurfaceGuid?: string;
 
   /**
@@ -18,13 +34,29 @@ interface ScheduleItemModalProps {
    */
   disableScheduledSurface?: boolean;
 
+  /**
+   * The action to run when the user hits the "Save" button at the bottom of the modal.
+   * @param values
+   * @param formikHelpers
+   */
   onSave: (
     values: FormikValues,
     formikHelpers: FormikHelpers<any>
   ) => void | Promise<any>;
-  toggleModal: () => void;
+
+  /**
+   * A helper function that toggles the visibility of the modal on and off.
+   */
+  toggleModal: VoidFunction;
 }
 
+/**
+ * This modal opens a form that allows the curators to schedule corpus items
+ * onto Firefox New Tab and other surfaces.
+ *
+ * @param props
+ * @constructor
+ */
 export const ScheduleItemModal: React.FC<ScheduleItemModalProps> = (
   props
 ): JSX.Element => {

--- a/src/curated-corpus/components/ScheduledSurfaceGroupedList/ScheduledSurfaceGroupedList.test.tsx
+++ b/src/curated-corpus/components/ScheduledSurfaceGroupedList/ScheduledSurfaceGroupedList.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import {
+  CorpusItemSource,
+  CorpusLanguage,
   CuratedStatus,
   ScheduledCorpusItemsResult,
 } from '../../../api/generatedTypes';
@@ -15,6 +17,7 @@ describe('The ScheduledSurfaceGroupedList component', () => {
     const item = {
       externalId: '456-dfg',
       scheduledDate: '2030-01-01',
+      scheduledSurfaceGuid: 'NEW_TAB_EN_US',
       createdAt: 1635014926,
       createdBy: 'Amy',
       updatedAt: 1635014927,
@@ -23,11 +26,11 @@ describe('The ScheduledSurfaceGroupedList component', () => {
         externalId: '123-abc',
         prospectId: '123-xyz',
         title: 'First story',
-        url: 'http://www.test.com/how-to',
+        url: 'https://www.test.com/how-to',
         imageUrl: 'https://placeimg.com/640/480/people?random=494',
         excerpt:
           'Everything You Wanted to Know About React and Were Afraid To Ask',
-        language: 'de',
+        language: CorpusLanguage.De,
         publisher: 'Amazing Inventions',
         topic: 'Technology',
         status: CuratedStatus.Recommendation,
@@ -37,6 +40,9 @@ describe('The ScheduledSurfaceGroupedList component', () => {
         createdAt: 1635014926,
         createdBy: 'Amy',
         updatedAt: 1635114926,
+        authors: [{ name: 'Marie Curie', sortOrder: 1 }],
+        scheduledSurfaceHistory: [],
+        source: CorpusItemSource.Prospect,
       },
     };
 

--- a/src/curated-corpus/helpers/helperFunctions.test.ts
+++ b/src/curated-corpus/helpers/helperFunctions.test.ts
@@ -19,7 +19,7 @@ describe('helperFunctions ', () => {
         id: 'test-id',
         prospectId: 'test-prospect-id',
         scheduledSurfaceGuid: 'en-us',
-        prospectType: ProspectType.Syndicated,
+        prospectType: ProspectType.SyndicatedNew,
         url: 'test-prospect-url',
         createdAt: 20220110,
         domain: 'test-prospect-domain',

--- a/src/curated-corpus/integration-test-mocks/getScheduledItemCounts.ts
+++ b/src/curated-corpus/integration-test-mocks/getScheduledItemCounts.ts
@@ -7,11 +7,20 @@ const scheduledItemCounts = {
   totalCount: 0,
 };
 
+const variables = {
+  filters: {
+    scheduledSurfaceGuid: 'dummyId',
+    startDate: '2022-07-19',
+    endDate: '2022-07-19',
+  },
+};
+
 /**
  * Return mocked scheduled item counts
  */
 export const mock_ScheduledItemCountsZero = constructMock(
-  'getScheduledItems',
+  'getScheduledCorpusItems',
   getScheduledItemCounts,
+  variables,
   scheduledItemCounts
 );

--- a/src/curated-corpus/integration-test-mocks/getScheduledItems.ts
+++ b/src/curated-corpus/integration-test-mocks/getScheduledItems.ts
@@ -52,5 +52,6 @@ const scheduledItems: ScheduledCorpusItem[] = [
 export const mock_scheduledItems = constructMock(
   'getScheduledItems',
   getScheduledItems,
+  undefined,
   scheduledItems
 );

--- a/src/curated-corpus/integration-test-mocks/getScheduledSurfacesForUser.ts
+++ b/src/curated-corpus/integration-test-mocks/getScheduledSurfacesForUser.ts
@@ -88,6 +88,7 @@ const allScheduledSurfaces: ScheduledSurface[] = [
 export const mock_AllScheduledSurfaces = constructMock(
   'getScheduledSurfacesForUser',
   getScheduledSurfacesForUser,
+  undefined,
   allScheduledSurfaces
 );
 
@@ -98,6 +99,7 @@ export const mock_AllScheduledSurfaces = constructMock(
 export const mock_TwoScheduledSurfaces = constructMock(
   'getScheduledSurfacesForUser',
   getScheduledSurfacesForUser,
+  undefined,
   allScheduledSurfaces.slice(0, 2)
 );
 
@@ -107,5 +109,6 @@ export const mock_TwoScheduledSurfaces = constructMock(
 export const mock_OneScheduledSurface = constructMock(
   'getScheduledSurfacesForUser',
   getScheduledSurfacesForUser,
+  undefined,
   allScheduledSurfaces.slice(4, 5)
 );

--- a/src/curated-corpus/integration-test-mocks/utils.ts
+++ b/src/curated-corpus/integration-test-mocks/utils.ts
@@ -6,11 +6,13 @@ import { DocumentNode } from '@apollo/client';
 export const constructMock = (
   queryName: string,
   query: DocumentNode,
+  variables: any,
   data: any
 ) => {
   return {
     request: {
       query,
+      variables,
     },
     result: {
       data: {


### PR DESCRIPTION
## Goal

Improve test coverage of our frontend code. Note: no change to functionality, tests added/amended only.

- Added the missing unit tests.

- Added comments to component props.

- Fixed up test mocks elsewhere whenever the IDE highlighted missing props.

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1535

