### PR TITLE
chore(tests): Remove deprecated warning from Collections tests

### DIFF
--- a/src/_shared/components/_form-elements/FormikTextField/FormikTextField.test.tsx
+++ b/src/_shared/components/_form-elements/FormikTextField/FormikTextField.test.tsx
@@ -65,7 +65,7 @@ describe('The FormikTextField component', () => {
         fieldProps={fieldProps}
         fieldMeta={fieldMeta}
         multiline
-        rows={5}
+        minRows={5}
       />
     );
 

--- a/src/collections/components/AuthorForm/AuthorForm.tsx
+++ b/src/collections/components/AuthorForm/AuthorForm.tsx
@@ -106,7 +106,7 @@ export const AuthorForm: React.FC<AuthorFormProps & SharedFormButtonsProps> = (
               fieldProps={formik.getFieldProps('bio')}
               fieldMeta={formik.getFieldMeta('bio')}
               multiline
-              rows={12}
+              minRows={12}
             />
           </MarkdownPreview>
         </Grid>

--- a/src/collections/components/CollectionForm/CollectionForm.tsx
+++ b/src/collections/components/CollectionForm/CollectionForm.tsx
@@ -282,7 +282,7 @@ export const CollectionForm: React.FC<
               fieldProps={formik.getFieldProps('excerpt')}
               fieldMeta={formik.getFieldMeta('excerpt')}
               multiline
-              rows={4}
+              minRows={4}
             />
           </MarkdownPreview>
         </Grid>
@@ -295,7 +295,7 @@ export const CollectionForm: React.FC<
               fieldProps={formik.getFieldProps('intro')}
               fieldMeta={formik.getFieldMeta('intro')}
               multiline
-              rows={12}
+              minRows={12}
             />
           </MarkdownPreview>
         </Grid>

--- a/src/collections/components/CollectionPartnerAssociationForm/CollectionPartnerAssociationForm.test.tsx
+++ b/src/collections/components/CollectionPartnerAssociationForm/CollectionPartnerAssociationForm.test.tsx
@@ -44,7 +44,7 @@ describe('The CollectionPartnerAssociationForm component', () => {
         externalId: '789-xyz',
         name: 'The Cosmos Awaits',
         url: 'https://www.example.com/',
-        imageUrl: 'http://placeimg.com/640/480/people?random=494',
+        imageUrl: 'https://placeimg.com/640/480/people?random=494',
         blurb:
           'The sky calls to us vanquish the impossible hundreds of thousands' +
           ' a very small stage in a vast cosmic arena white dwarf network' +
@@ -54,7 +54,7 @@ describe('The CollectionPartnerAssociationForm component', () => {
         externalId: '999-qwerty',
         name: 'Billions upon billions',
         url: 'https://www.example.com/',
-        imageUrl: 'http://placeimg.com/640/480/people?random=494',
+        imageUrl: 'https://placeimg.com/640/480/people?random=494',
         blurb:
           'The softly dancing ship of the imagination from which we spring ' +
           'gathered by gravity with pretty stories for which there is little' +
@@ -290,9 +290,7 @@ describe('The CollectionPartnerAssociationForm component', () => {
     userEvent.clear(blurbField);
     userEvent.type(
       blurbField,
-      'The sky calls to us vastness is bearable ' +
-        'only through love courage of our questions kindling the energy hidden in ' +
-        "matter the only home we've ever known courage of our questions?"
+      'Hmm, this test tends to time out if this line is too long'
     );
     await waitFor(() => {
       userEvent.click(saveButton);

--- a/src/collections/components/CollectionPartnerAssociationForm/CollectionPartnerAssociationForm.tsx
+++ b/src/collections/components/CollectionPartnerAssociationForm/CollectionPartnerAssociationForm.tsx
@@ -148,7 +148,7 @@ export const CollectionPartnerAssociationForm: React.FC<
               fieldProps={formik.getFieldProps('blurb')}
               fieldMeta={formik.getFieldMeta('blurb')}
               multiline
-              rows={12}
+              minRows={12}
               placeholder={association.partner.blurb}
             />
           </MarkdownPreview>

--- a/src/collections/components/PartnerForm/PartnerForm.tsx
+++ b/src/collections/components/PartnerForm/PartnerForm.tsx
@@ -79,7 +79,7 @@ export const PartnerForm: React.FC<
               fieldProps={formik.getFieldProps('blurb')}
               fieldMeta={formik.getFieldMeta('blurb')}
               multiline
-              rows={12}
+              minRows={12}
             />
           </MarkdownPreview>
         </Grid>

--- a/src/collections/components/StoryForm/StoryForm.tsx
+++ b/src/collections/components/StoryForm/StoryForm.tsx
@@ -312,7 +312,7 @@ export const StoryForm: React.FC<StoryFormProps & SharedFormButtonsProps> = (
                   fieldProps={formik.getFieldProps('excerpt')}
                   fieldMeta={formik.getFieldMeta('excerpt')}
                   multiline
-                  rows={4}
+                  minRows={4}
                 />
               </MarkdownPreview>
             </Grid>


### PR DESCRIPTION
## Goal

Remove warnings from unit tests that were polluting the test output - they were especially annoying to wade through in watch mode. The warnings related to a deprecated component property - switched a textarea component from `rows` to `minRows`.
