### PR TITLE
feat(UI): [BACK-1542] Show Syndication in Prospecting

### DIFF
--- a/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.styles.tsx
+++ b/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.styles.tsx
@@ -23,6 +23,9 @@ export const useStyles = makeStyles((theme: Theme) =>
       color: theme.palette.primary.main,
       padding: '1.25 rem 0',
     },
+    listItemIcon: {
+      minWidth: '1.5rem',
+    },
     title: {
       fontSize: '1.25rem',
       fontWeight: 500,

--- a/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.test.tsx
+++ b/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.test.tsx
@@ -54,7 +54,7 @@ describe('The ExistingProspectCard component', () => {
     };
   });
 
-  it('shows basic prospect information', () => {
+  it('should show basic prospect metadata', () => {
     render(
       <MemoryRouter>
         <ExistingProspectCard
@@ -80,7 +80,7 @@ describe('The ExistingProspectCard component', () => {
     expect(excerpt).toBeInTheDocument();
   });
 
-  it('shows language correctly', () => {
+  it('should show language correctly', () => {
     render(
       <MemoryRouter>
         <ExistingProspectCard
@@ -93,7 +93,7 @@ describe('The ExistingProspectCard component', () => {
     expect(screen.getByText(/^de$/i)).toBeInTheDocument();
   });
 
-  it('shows topic correctly', () => {
+  it('should show topic correctly', () => {
     render(
       <MemoryRouter>
         <ExistingProspectCard
@@ -109,7 +109,6 @@ describe('The ExistingProspectCard component', () => {
   it('should render card with excerpt', () => {
     render(
       <MemoryRouter>
-        {' '}
         <ExistingProspectCard
           item={prospect.approvedCorpusItem!}
           onSchedule={onSchedule}
@@ -118,6 +117,35 @@ describe('The ExistingProspectCard component', () => {
     );
 
     expect(screen.getByText(prospect.excerpt!)).toBeInTheDocument();
+  });
+
+  it('should not render "syndicated" tag for non-syndicated articles', () => {
+    render(
+      <MemoryRouter>
+        <ExistingProspectCard
+          item={prospect.approvedCorpusItem!}
+          onSchedule={onSchedule}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText('Syndicated')).not.toBeInTheDocument();
+  });
+
+  it('should render "syndicated" tag for syndicated articles', () => {
+    // Update the mock so that it becomes a syndicated article.
+    prospect.approvedCorpusItem!.isSyndicated = true;
+
+    render(
+      <MemoryRouter>
+        <ExistingProspectCard
+          item={prospect.approvedCorpusItem!}
+          onSchedule={onSchedule}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText('Syndicated')).toBeInTheDocument();
   });
 
   it('should render curated item card with the action button', () => {

--- a/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.tsx
+++ b/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.tsx
@@ -7,11 +7,17 @@ import {
   Chip,
   Grid,
   Link,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
   Typography,
 } from '@material-ui/core';
 import LanguageIcon from '@material-ui/icons/Language';
 import LabelOutlinedIcon from '@material-ui/icons/LabelOutlined';
 import CheckIcon from '@material-ui/icons/Check';
+import CheckCircleOutlineIcon from '@material-ui/icons/CheckCircleOutline';
+
 import { useStyles } from './ExistingProspectCard.styles';
 import { ApprovedCorpusItem } from '../../../api/generatedTypes';
 import { Button } from '../../../_shared/components';
@@ -26,6 +32,13 @@ interface ExistingProspectCardProps {
   onSchedule: VoidFunction;
 }
 
+/**
+ * This component is used on the Prospecting page to display prospects that are
+ * already in the curated corpus.
+ *
+ * @param props
+ * @constructor
+ */
 export const ExistingProspectCard: React.FC<ExistingProspectCardProps> = (
   props
 ): JSX.Element => {
@@ -42,6 +55,15 @@ export const ExistingProspectCard: React.FC<ExistingProspectCardProps> = (
             alt={item.title}
             className={classes.image}
           />
+
+          <List dense disablePadding>
+            <ListItem disableGutters>
+              <ListItemIcon className={classes.listItemIcon}>
+                <LanguageIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText secondary={item.language} />
+            </ListItem>
+          </List>
         </Grid>
         <Grid item xs={12} sm={9}>
           <Link href={item.url} target="_blank" className={classes.link}>
@@ -67,15 +89,17 @@ export const ExistingProspectCard: React.FC<ExistingProspectCardProps> = (
             <Chip
               variant="outlined"
               color="primary"
-              label={item.language}
-              icon={<LanguageIcon />}
-            />{' '}
-            <Chip
-              variant="outlined"
-              color="primary"
               label={getDisplayTopic(item.topic)}
               icon={<LabelOutlinedIcon />}
             />{' '}
+            {item.isSyndicated && (
+              <Chip
+                variant="outlined"
+                color="primary"
+                label="Syndicated"
+                icon={<CheckCircleOutlineIcon />}
+              />
+            )}{' '}
             <Chip
               variant="default"
               color="secondary"

--- a/src/curated-corpus/components/ProspectListCard/ProspectListCard.styles.tsx
+++ b/src/curated-corpus/components/ProspectListCard/ProspectListCard.styles.tsx
@@ -23,6 +23,9 @@ export const useStyles = makeStyles((theme: Theme) =>
       color: theme.palette.primary.main,
       padding: '1.25 rem 0',
     },
+    listItemIcon: {
+      minWidth: '1.5rem',
+    },
     title: {
       fontSize: '1.25rem',
       fontWeight: 500,

--- a/src/curated-corpus/components/ProspectListCard/ProspectListCard.test.tsx
+++ b/src/curated-corpus/components/ProspectListCard/ProspectListCard.test.tsx
@@ -25,10 +25,12 @@ describe('The ProspectListCard component', () => {
       publisher: 'Amazing Inventions',
       authors: 'Charles Dickens,O. Henry',
       topic: Topics.Technology,
+      saveCount: 111222,
+      isSyndicated: false,
     };
   });
 
-  it('shows basic prospect information', () => {
+  const renderComponent = () => {
     render(
       <MemoryRouter>
         <ProspectListCard
@@ -39,6 +41,10 @@ describe('The ProspectListCard component', () => {
         />
       </MemoryRouter>
     );
+  };
+
+  it('shows basic prospect information', () => {
+    renderComponent();
 
     // The image is present and the alt text is the item title
     const photo = screen.getByAltText(prospect.title!);
@@ -65,50 +71,49 @@ describe('The ProspectListCard component', () => {
   });
 
   it('shows language correctly', () => {
-    render(
-      <MemoryRouter>
-        {' '}
-        <ProspectListCard
-          prospect={prospect}
-          onAddToCorpus={onAddToCorpus}
-          onRecommend={onRecommend}
-          onReject={onReject}
-        />
-      </MemoryRouter>
-    );
+    renderComponent();
 
     expect(screen.getByText(/^de$/i)).toBeInTheDocument();
   });
 
   it('shows topic correctly', () => {
-    render(
-      <MemoryRouter>
-        <ProspectListCard
-          prospect={prospect}
-          onAddToCorpus={onAddToCorpus}
-          onRecommend={onRecommend}
-          onReject={onReject}
-        />
-      </MemoryRouter>
-    );
+    renderComponent();
 
     expect(screen.getByText(/^technology$/i)).toBeInTheDocument();
   });
 
   it('should render prospect card with excerpt', () => {
-    render(
-      <MemoryRouter>
-        {' '}
-        <ProspectListCard
-          prospect={prospect}
-          onAddToCorpus={onAddToCorpus}
-          onRecommend={onRecommend}
-          onReject={onReject}
-        />
-      </MemoryRouter>
-    );
+    renderComponent();
 
     expect(screen.getByText(prospect.excerpt!)).toBeInTheDocument();
+  });
+
+  it('should show the number of saves', () => {
+    renderComponent();
+
+    expect(screen.getByText(`${prospect.saveCount} saves`)).toBeInTheDocument();
+  });
+
+  it("should show the prospect's source", () => {
+    renderComponent();
+
+    expect(
+      screen.getByText(prospect.prospectType.toLowerCase())
+    ).toBeInTheDocument();
+  });
+
+  it("should hide 'Syndicated' tag if prospect is not syndicated", () => {
+    renderComponent();
+
+    expect(screen.queryByText('Syndicated')).not.toBeInTheDocument();
+  });
+
+  it('should show "Syndicated" tag if displaying a syndicated article', () => {
+    prospect.isSyndicated = true;
+
+    renderComponent();
+
+    expect(screen.getByText('Syndicated')).toBeInTheDocument();
   });
 
   it('should render curated item card with the action buttons', () => {

--- a/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
+++ b/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
@@ -8,13 +8,20 @@ import {
   Chip,
   Grid,
   Link,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
   Typography,
 } from '@material-ui/core';
 import { useStyles } from './ProspectListCard.styles';
 import LanguageIcon from '@material-ui/icons/Language';
 import LabelOutlinedIcon from '@material-ui/icons/LabelOutlined';
+import FavoriteBorderIcon from '@material-ui/icons/FavoriteBorder';
+import MyLocationIcon from '@material-ui/icons/MyLocation';
 import { Button } from '../../../_shared/components';
 import { getDisplayTopic } from '../../helpers/helperFunctions';
+import CheckCircleOutlineIcon from '@material-ui/icons/CheckCircleOutline';
 
 interface ProspectListCardProps {
   /**
@@ -57,11 +64,31 @@ export const ProspectListCard: React.FC<ProspectListCardProps> = (
             alt={prospect.title ?? 'No title supplied'}
             className={classes.image}
           />
-          <Typography variant="subtitle2" color="textSecondary">
-            Saves: {prospect.saveCount}
-            <br />
-            Source: {prospect.prospectType.toLowerCase()}
-          </Typography>
+
+          <List dense disablePadding>
+            <ListItem disableGutters>
+              <ListItemIcon className={classes.listItemIcon}>
+                <LanguageIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText
+                secondary={prospect.language?.toUpperCase() ?? 'N/A'}
+              />
+            </ListItem>
+
+            <ListItem disableGutters>
+              <ListItemIcon className={classes.listItemIcon}>
+                <FavoriteBorderIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText secondary={`${prospect.saveCount} saves`} />
+            </ListItem>
+
+            <ListItem disableGutters>
+              <ListItemIcon className={classes.listItemIcon}>
+                <MyLocationIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText secondary={prospect.prospectType.toLowerCase()} />
+            </ListItem>
+          </List>
         </Grid>
         <Grid item xs={12} sm={9}>
           <Link href={prospect.url} target="_blank" className={classes.link}>
@@ -89,15 +116,17 @@ export const ProspectListCard: React.FC<ProspectListCardProps> = (
             <Chip
               variant="outlined"
               color="primary"
-              label={prospect.language?.toUpperCase() ?? 'N/A'}
-              icon={<LanguageIcon />}
-            />{' '}
-            <Chip
-              variant="outlined"
-              color="primary"
               label={getDisplayTopic(prospect.topic)}
               icon={<LabelOutlinedIcon />}
-            />
+            />{' '}
+            {prospect.isSyndicated && (
+              <Chip
+                variant="outlined"
+                color="primary"
+                label="Syndicated"
+                icon={<CheckCircleOutlineIcon />}
+              />
+            )}
           </Box>
           <Typography component="div">{prospect.excerpt}</Typography>
         </Grid>


### PR DESCRIPTION
## Goal

Make it easier for the curators to see whether a prospect coming through is a syndicated article or not.

- Added a "Syndicated" tag to syndicated prospects on the prospecting page.

- Added unit tests.

- Moved language to secondary info area to free up the best real estate for the "Syndicated" tag.

- Updated the look of the saves and prospect type/source info under the prospect thumbnail image.

Note: screenshots are in Slack.


## Reference

https://getpocket.atlassian.net/browse/BACK-1542