### PR TITLE
fix(prospecting page): Fix prospecting page not rendering anything after switching to it from another page

### DIFF
--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -566,7 +566,6 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
 
   return (
     <>
-      {console.log('RENDER')}
       {currentProspect && (
         <>
           <RejectItemModal


### PR DESCRIPTION
## Goal

Hoist lazy query function/hook declarations to that they are available in the lexical scope for the initial page render query request.

### Bug

https://user-images.githubusercontent.com/16694733/181013682-9b9e649f-9b89-4911-ad75-3664d3999c0a.mov

### Fix (on DEV)

https://user-images.githubusercontent.com/16694733/181013734-eedfbf3b-a980-4db6-a085-8cdd6f166d8c.mov


