### PR TITLE
chore(tests): [BACK-1530] Improve unit tests for RejectedListItemCard component

### DIFF
--- a/src/curated-corpus/components/RejectedItemListCard/RejectedItemListCard.test.tsx
+++ b/src/curated-corpus/components/RejectedItemListCard/RejectedItemListCard.test.tsx
@@ -53,7 +53,7 @@ describe('The RejectedItemListCard component', () => {
     expect(screen.getByText(rejectedItem.language)).toBeInTheDocument();
   });
 
-  it('should render rejected item card with reason', () => {
+  it('should render rejected item card with rejection reason', () => {
     render(
       <MemoryRouter>
         <RejectedItemListCard item={rejectedItem} />
@@ -81,5 +81,15 @@ describe('The RejectedItemListCard component', () => {
     );
 
     expect(screen.getByText(rejectedItem.topic)).toBeInTheDocument();
+  });
+
+  it('should render rejected item card with publisher', () => {
+    render(
+      <MemoryRouter>
+        <RejectedItemListCard item={rejectedItem} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(rejectedItem.publisher)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Goal

As the PR title says.

- Added a test for publisher (a later addition to the rejected item card).

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1530
