### PR TITLE
feat(schedule): [BACK-1556] Link to new Item details page from Schedule page

### DIFF
--- a/src/curated-corpus/components/ApprovedItemCardWrapper/ApprovedItemCardWrapper.test.tsx
+++ b/src/curated-corpus/components/ApprovedItemCardWrapper/ApprovedItemCardWrapper.test.tsx
@@ -1,46 +1,12 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import {
-  ApprovedCorpusItem,
-  CorpusItemSource,
-  CorpusLanguage,
-  CuratedStatus,
-} from '../../../api/generatedTypes';
+import { ApprovedCorpusItem } from '../../../api/generatedTypes';
 import { ApprovedItemCardWrapper } from './ApprovedItemCardWrapper';
+import { getTestApprovedItem } from '../../helpers/approvedItem';
 
 describe('The ApprovedItemCardWrapper component', () => {
-  let item: ApprovedCorpusItem;
-
-  beforeEach(() => {
-    item = {
-      externalId: '123-abc',
-      prospectId: '123-xyz',
-      title: 'How To Win Friends And Influence People with React',
-      url: 'http://www.test.com/how-to',
-      imageUrl: 'https://placeimg.com/640/480/people?random=494',
-      excerpt:
-        'Everything You Wanted to Know About React and Were Afraid To Ask',
-      source: CorpusItemSource.Prospect,
-      language: CorpusLanguage.De,
-      scheduledSurfaceHistory: [],
-      publisher: 'Amazing Inventions',
-      topic: 'Technology',
-      status: CuratedStatus.Recommendation,
-      isCollection: false,
-      isSyndicated: false,
-      isTimeSensitive: false,
-      createdAt: 1635014926,
-      createdBy: 'Amy',
-      updatedAt: 1635114926,
-      authors: [
-        {
-          name: 'Octavia Butler',
-          sortOrder: 1,
-        },
-      ],
-    };
-  });
+  const item: ApprovedCorpusItem = getTestApprovedItem();
 
   it('should render an approved item card', () => {
     render(

--- a/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.styles.tsx
+++ b/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.styles.tsx
@@ -13,6 +13,14 @@ export const useStyles = makeStyles((theme: Theme) =>
     },
     actions: {
       margin: 'auto',
+      paddingLeft: 0,
+      '& button': {
+        marginLeft: '0 !important',
+      },
+    },
+    link: {
+      color: theme.palette.primary.main,
+      textDecoration: 'none',
     },
   })
 );

--- a/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.test.tsx
+++ b/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.test.tsx
@@ -2,13 +2,9 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import {
-  CorpusItemSource,
-  CorpusLanguage,
-  CuratedStatus,
-  ScheduledCorpusItem,
-} from '../../../api/generatedTypes';
+import { ScheduledCorpusItem } from '../../../api/generatedTypes';
 import { ScheduledItemCardWrapper } from './ScheduledItemCardWrapper';
+import { getTestApprovedItem } from '../../helpers/approvedItem';
 
 describe('The ScheduledItemCardWrapper component', () => {
   let item: ScheduledCorpusItem;
@@ -22,33 +18,7 @@ describe('The ScheduledItemCardWrapper component', () => {
       updatedAt: 1635014926,
       updatedBy: 'Amy',
       scheduledSurfaceGuid: 'NEW_TAB_EN_US',
-      approvedItem: {
-        externalId: '123-abc',
-        prospectId: '123-xyz',
-        title: 'How To Win Friends And Influence People with React',
-        url: 'http://www.test.com/how-to',
-        imageUrl: 'https://placeimg.com/640/480/people?random=494',
-        excerpt:
-          'Everything You Wanted to Know About React and Were Afraid To Ask',
-        language: CorpusLanguage.De,
-        publisher: 'Amazing Inventions',
-        topic: 'Technology',
-        status: CuratedStatus.Recommendation,
-        isCollection: false,
-        isSyndicated: false,
-        isTimeSensitive: false,
-        createdAt: 1635014926,
-        createdBy: 'Amy',
-        updatedAt: 1635114926,
-        scheduledSurfaceHistory: [],
-        source: CorpusItemSource.Prospect,
-        authors: [
-          {
-            name: 'Octavia Butler',
-            sortOrder: 1,
-          },
-        ],
-      },
+      approvedItem: getTestApprovedItem(),
     };
   });
 
@@ -70,7 +40,7 @@ describe('The ScheduledItemCardWrapper component', () => {
     expect(title).toBeInTheDocument();
   });
 
-  it('should render the "Remove" button', () => {
+  it('should render all buttons', () => {
     render(
       <MemoryRouter>
         <ScheduledItemCardWrapper
@@ -82,11 +52,24 @@ describe('The ScheduledItemCardWrapper component', () => {
       </MemoryRouter>
     );
 
+    const viewButton = screen.getByRole('button', { name: /View/i });
+
     const removeButton = screen.getByRole('button', {
       name: /Remove/i,
     });
 
+    const rescheduleButton = screen.getByRole('button', {
+      name: /Reschedule/i,
+    });
+
+    const moveButton = screen.getByRole('button', {
+      name: /move to bottom/i,
+    });
+
+    expect(viewButton).toBeInTheDocument();
     expect(removeButton).toBeInTheDocument();
+    expect(rescheduleButton).toBeInTheDocument();
+    expect(moveButton).toBeInTheDocument();
   });
 
   it('should run an action on pressing the "Remove" button', () => {
@@ -112,25 +95,6 @@ describe('The ScheduledItemCardWrapper component', () => {
     expect(onRemove).toHaveBeenCalled();
   });
 
-  it('should render the "Reschedule" button', () => {
-    render(
-      <MemoryRouter>
-        <ScheduledItemCardWrapper
-          item={item}
-          onMoveToBottom={jest.fn()}
-          onReschedule={jest.fn()}
-          onRemove={jest.fn()}
-        />
-      </MemoryRouter>
-    );
-
-    const rescheduleButton = screen.getByRole('button', {
-      name: /Reschedule/i,
-    });
-
-    expect(rescheduleButton).toBeInTheDocument();
-  });
-
   it('should run an action on pressing the "Reschedule" button', () => {
     const onReschedule = jest.fn();
 
@@ -152,25 +116,6 @@ describe('The ScheduledItemCardWrapper component', () => {
     );
 
     expect(onReschedule).toHaveBeenCalled();
-  });
-
-  it('should render the "Move to bottom" button', () => {
-    render(
-      <MemoryRouter>
-        <ScheduledItemCardWrapper
-          item={item}
-          onMoveToBottom={jest.fn()}
-          onReschedule={jest.fn()}
-          onRemove={jest.fn()}
-        />
-      </MemoryRouter>
-    );
-
-    const button = screen.getByRole('button', {
-      name: /move to bottom/i,
-    });
-
-    expect(button).toBeInTheDocument();
   });
 
   it('should run an action on pressing the "Remove" button', () => {

--- a/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.tsx
+++ b/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.tsx
@@ -4,6 +4,7 @@ import { useStyles } from './ScheduledItemCardWrapper.styles';
 import { ScheduledCorpusItem } from '../../../api/generatedTypes';
 import { Button } from '../../../_shared/components';
 import { ApprovedItemListCard } from '../ApprovedItemListCard/ApprovedItemListCard';
+import { Link } from 'react-router-dom';
 
 interface ScheduledItemCardWrapperProps {
   /**
@@ -60,6 +61,14 @@ export const ScheduledItemCardWrapper: React.FC<
         />
 
         <CardActions className={classes.actions}>
+          <Button buttonType="positive" variant="text">
+            <Link
+              to={`/curated-corpus/corpus/item/${item.externalId}`}
+              className={classes.link}
+            >
+              View
+            </Link>
+          </Button>
           <Button buttonType="positive" variant="text" onClick={onReschedule}>
             Reschedule
           </Button>


### PR DESCRIPTION
## Goal

Make the new Corpus Item page accessible both from the Corpus and Schedule pages. The links from the Corpus page were added in BACK-1490, and this ticket follows up with similar changes to the Schedule page.

Due to limited width on the cards, it's hard to fit in another button/link in there well - right now the rightmost button is up against the edge of the card which bothers me (!) 😄. Perhaps we can revisit this at a later point in time and shorten copy on the other buttons or change the "Remove" button from a word to the rubbish bin icon, which would reclaim some space.

- Added a "View" link to corpus item page from the Schedule page.

- Updated unit tests for the relevant component - also simplified
some of those tests by combining separate button rendering tests
into a single test.

- Updated both *CardWrapper unit tests to use `getTestApprovedItem()`, which resulted in some boilerplate code removed.

## Reference

https://getpocket.atlassian.net/browse/BACK-1556
