### PR TITLE
chore(tests): [BACK-1490] Add integration tests for Curated Item page

### DIFF
--- a/src/curated-corpus/integration-test-mocks/approvedItemByExternalId.ts
+++ b/src/curated-corpus/integration-test-mocks/approvedItemByExternalId.ts
@@ -1,0 +1,56 @@
+import {
+  ApprovedCorpusItem,
+  CorpusItemSource,
+  CorpusLanguage,
+  CuratedStatus,
+  Topics,
+} from '../../api/generatedTypes';
+import { constructMock } from './utils';
+import { approvedItemByExternalId } from '../../api/queries/approvedItemByExternalId';
+
+const approvedItem: ApprovedCorpusItem = {
+  externalId: '123-abc',
+  prospectId: '123-xyz',
+  title: 'How To Win Friends And Influence People with React',
+  url: 'http://www.test.com/how-to',
+  imageUrl: 'https://placeimg.com/640/480/people?random=494',
+  excerpt: 'Everything You Wanted to Know About React and Were Afraid To Ask',
+  language: CorpusLanguage.De,
+  publisher: 'Amazing Inventions',
+  topic: Topics.Politics,
+  status: CuratedStatus.Recommendation,
+  isCollection: false,
+  isSyndicated: false,
+  isTimeSensitive: false,
+  createdAt: 1635014926,
+  createdBy: 'Amy',
+  updatedAt: 1635114926,
+  scheduledSurfaceHistory: [], // TODO: fill this out
+  source: CorpusItemSource.Prospect,
+  authors: [
+    {
+      name: 'Octavia Butler',
+      sortOrder: 1,
+    },
+  ],
+};
+
+/**
+ * Return the mocked approvedItem
+ */
+export const mock_approvedItemByExternalId = constructMock(
+  'approvedCorpusItemByExternalId',
+  approvedItemByExternalId,
+  { externalId: approvedItem.externalId },
+  approvedItem
+);
+
+/**
+ * Return a null (approved item is not found)
+ */
+export const mock_approvedItemByExternalIdNoResults = constructMock(
+  'approvedCorpusItemByExternalId',
+  approvedItemByExternalId,
+  { externalId: approvedItem.externalId },
+  null
+);

--- a/src/curated-corpus/integration-test-mocks/getScheduledItems.ts
+++ b/src/curated-corpus/integration-test-mocks/getScheduledItems.ts
@@ -109,6 +109,9 @@ export const mock_scheduledItems = constructMock(
   data
 );
 
+/**
+ * And this mocked query doesn't return any results
+ */
 export const mock_scheduledItemsNoResults = constructMock(
   'getScheduledCorpusItems',
   getScheduledItems,

--- a/src/curated-corpus/pages/CorpusItemPage/CorpusItemPage.test.tsx
+++ b/src/curated-corpus/pages/CorpusItemPage/CorpusItemPage.test.tsx
@@ -1,10 +1,53 @@
-import { MockedResponse } from '@apollo/client/testing';
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route } from 'react-router-dom';
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
+import {
+  mock_approvedItemByExternalId,
+  mock_approvedItemByExternalIdNoResults,
+} from '../../integration-test-mocks/approvedItemByExternalId';
+import { CorpusItemPage } from './CorpusItemPage';
 
 describe('The CorpusItemPage', () => {
   let mocks: MockedResponse[] = [];
 
-  it('has integration tests', () => {
-    mocks = [];
-    console.log(mocks);
+  it('renders the page after the initial load', async () => {
+    mocks = [mock_approvedItemByExternalId];
+
+    await waitFor(() => {
+      render(
+        <MemoryRouter initialEntries={['/curated-corpus/corpus/item/123-abc/']}>
+          <Route path="/curated-corpus/corpus/item/:id/">
+            <MockedProvider mocks={mocks}>
+              <CorpusItemPage />
+            </MockedProvider>
+          </Route>
+        </MemoryRouter>
+      );
+    });
+    // Wait for the query to run before looking up elements on the page
+    await waitFor(() => {
+      expect(
+        screen.getByText('How To Win Friends And Influence People with React')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('renders the page with an error message if an item was not found', async () => {
+    mocks = [mock_approvedItemByExternalIdNoResults];
+
+    // Wrap the render call in a `waitFor` call to make sure
+    // the initial render has finished.
+    await waitFor(() => {
+      render(
+        <MockedProvider mocks={mocks}>
+          <MemoryRouter
+            initialEntries={['/curated-corpus/corpus/item/123-abc/']}
+          >
+            <CorpusItemPage />
+          </MemoryRouter>
+        </MockedProvider>
+      );
+    });
   });
 });


### PR DESCRIPTION
## Goal

Make sure the new Curated Item page has integration test coverage

## Todos

- [x] Set up mocks for the query, start on the first test.
- [ ] Figure out why the mock query appears to return `undefined` values and cuts through all TypeScript type checking to fail in helper functions. 
- [ ] Add the remaining tests.


