### PR TITLE
fix(schedule page): [BACK-1568] "View" links to go to Corpus Item pages off Schedule page are broken

### DIFF
--- a/src/curated-corpus/components/ApprovedItemCardWrapper/ApprovedItemCardWrapper.test.tsx
+++ b/src/curated-corpus/components/ApprovedItemCardWrapper/ApprovedItemCardWrapper.test.tsx
@@ -55,4 +55,25 @@ describe('The ApprovedItemCardWrapper component', () => {
     expect(rejectButton).toBeInTheDocument();
     expect(editButton).toBeInTheDocument();
   });
+
+  it('should have the correct link to corpus item page', () => {
+    render(
+      <MemoryRouter>
+        <ApprovedItemCardWrapper
+          item={item}
+          onEdit={jest.fn()}
+          onReject={jest.fn()}
+          onSchedule={jest.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    // The link to the corpus item page is present and is well-formed
+    const linkToItemPage = screen.getByText(/view/i) as HTMLAnchorElement;
+    expect(linkToItemPage).toBeInTheDocument();
+    expect(linkToItemPage).toHaveAttribute(
+      'href',
+      expect.stringContaining(item.externalId)
+    );
+  });
 });

--- a/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.test.tsx
+++ b/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.test.tsx
@@ -140,4 +140,25 @@ describe('The ScheduledItemCardWrapper component', () => {
 
     expect(onMoveToBottom).toHaveBeenCalled();
   });
+
+  it('should have the correct link to corpus item page', () => {
+    render(
+      <MemoryRouter>
+        <ScheduledItemCardWrapper
+          item={item}
+          onMoveToBottom={jest.fn()}
+          onReschedule={jest.fn()}
+          onRemove={jest.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    // The link to the corpus item page is present and is well-formed
+    const linkToItemPage = screen.getByText(/view/i) as HTMLAnchorElement;
+    expect(linkToItemPage).toBeInTheDocument();
+    expect(linkToItemPage).toHaveAttribute(
+      'href',
+      expect.stringContaining(item.approvedItem.externalId)
+    );
+  });
 });

--- a/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.tsx
+++ b/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.tsx
@@ -63,7 +63,7 @@ export const ScheduledItemCardWrapper: React.FC<
         <CardActions className={classes.actions}>
           <Button buttonType="positive" variant="text">
             <Link
-              to={`/curated-corpus/corpus/item/${item.externalId}`}
+              to={`/curated-corpus/corpus/item/${item.approvedItem.externalId}`}
               className={classes.link}
             >
               View


### PR DESCRIPTION
## Goal

To have all links in the app working.

- Fixed the bug.

- Added regression tests to the two wrapper components that link to the Corpus Item page.

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1568