### PR TITLE
fix(prospecting): Fix Prospecting page breaking on no scheduled items.

### DIFF
--- a/src/curated-corpus/components/ScheduleSummaryConnector/ScheduleSummaryConnector.tsx
+++ b/src/curated-corpus/components/ScheduleSummaryConnector/ScheduleSummaryConnector.tsx
@@ -74,8 +74,12 @@ export const ScheduleSummaryConnector: React.FC<
     },
     onCompleted: (data) => {
       // Save the scheduled items in a state var to be passed
-      // on to the layout component to prep for display
-      setScheduledItems(data.getScheduledCorpusItems[0]?.items);
+      // on to the layout component to prep for display.
+      //
+      // Note that if there's nothing scheduled for a particular day,
+      // `items` in the query result will be undefined, which is why
+      // we fall back to an empty array just in case.
+      setScheduledItems(data.getScheduledCorpusItems[0]?.items ?? []);
     },
   });
 


### PR DESCRIPTION
## Goal

Follow-up to BACK-1555 which included a refactor of scheduled summary on the Prospecting page. If no items are scheduled for the default day, the Prospecting page dies with a type error. Discovered on Dev, does not affect Prod at the moment as they have stories scheduled for tomorrow.
