### PR TITLE
feat(corpus item): [BACK-1570] Allow Reject action from corpus item page

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -7,39 +7,45 @@ import {
   searchCollectionsFieldPolicy,
 } from './field-policies';
 
-const apolloOptions = {
-  cache: new InMemoryCache({
-    typePolicies: {
-      CollectionAuthor: {
-        keyFields: ['externalId'],
-      },
-      CollectionStory: {
-        keyFields: ['externalId'],
-      },
-      Collection: {
-        keyFields: ['externalId'],
-      },
-      ApprovedCuratedCorpusItem: {
-        keyFields: ['externalId'],
-      },
-      RejectedCuratedCorpusItem: {
-        keyFields: ['externalId'],
-      },
-      ScheduledCuratedCorpusItem: {
-        keyFields: ['externalId'],
-      },
-      ScheduledCuratedCorpusItemsResult: {
-        keyFields: ['scheduledDate'],
-      },
-      Query: {
-        fields: {
-          getCollectionAuthors: getCollectionAuthorsFieldPolicy,
-          getCollectionPartners: getCollectionPartnersFieldPolicy,
-          searchCollections: searchCollectionsFieldPolicy,
-        },
+/**
+ * Custom type policies for Apollo Cache. Now in their own
+ * variable to feed them into integration tests, too.
+ */
+export const apolloCache = new InMemoryCache({
+  typePolicies: {
+    CollectionAuthor: {
+      keyFields: ['externalId'],
+    },
+    CollectionStory: {
+      keyFields: ['externalId'],
+    },
+    Collection: {
+      keyFields: ['externalId'],
+    },
+    ApprovedCorpusItem: {
+      keyFields: ['externalId'],
+    },
+    RejectedCorpusItem: {
+      keyFields: ['externalId'],
+    },
+    ScheduledCorpusItem: {
+      keyFields: ['externalId'],
+    },
+    ScheduledCorpusItemsResult: {
+      keyFields: ['scheduledDate'],
+    },
+    Query: {
+      fields: {
+        getCollectionAuthors: getCollectionAuthorsFieldPolicy,
+        getCollectionPartners: getCollectionPartnersFieldPolicy,
+        searchCollections: searchCollectionsFieldPolicy,
       },
     },
-  }),
+  },
+});
+
+const apolloOptions = {
+  cache: apolloCache,
   name: config.apolloClientName,
   version: config.version,
 };

--- a/src/curated-corpus/components/actions/RejectCorpusItemAction/RejectCorpusItemAction.test.tsx
+++ b/src/curated-corpus/components/actions/RejectCorpusItemAction/RejectCorpusItemAction.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
+import { render, screen } from '@testing-library/react';
+import { SnackbarProvider } from 'notistack';
+import { RejectCorpusItemAction } from './RejectCorpusItemAction';
+import { getTestApprovedItem } from '../../../helpers/approvedItem';
+import {
+  errorMock,
+  successMock,
+} from '../../../integration-test-mocks/rejectApprovedItem';
+import userEvent from '@testing-library/user-event';
+import { apolloCache } from '../../../../api/client';
+
+describe('The RejectCorpusItemAction', () => {
+  let mocks: MockedResponse[] = [];
+
+  it('renders the modal', async () => {
+    mocks = [];
+
+    render(
+      <MockedProvider mocks={mocks} cache={apolloCache}>
+        <SnackbarProvider maxSnack={3}>
+          <RejectCorpusItemAction
+            item={getTestApprovedItem()}
+            toggleModal={jest.fn()}
+            modalOpen={true}
+          />
+        </SnackbarProvider>
+      </MockedProvider>
+    );
+
+    // Do we have the modal heading
+    expect(screen.getByText(/reject this item/i)).toBeInTheDocument();
+
+    // How about the form?
+    expect(screen.getByRole('form')).toBeInTheDocument();
+  });
+
+  it('completes the action successfully', async () => {
+    mocks = [successMock];
+
+    render(
+      <MockedProvider mocks={mocks} cache={apolloCache}>
+        <SnackbarProvider maxSnack={3}>
+          <RejectCorpusItemAction
+            item={getTestApprovedItem()}
+            toggleModal={jest.fn()}
+            modalOpen={true}
+          />
+        </SnackbarProvider>
+      </MockedProvider>
+    );
+
+    const reason = screen.getByLabelText(/time sensitive/i);
+    userEvent.click(reason);
+    userEvent.click(screen.getByText(/save/i));
+
+    expect(
+      await screen.findByText(/item successfully moved to the rejected corpus/i)
+    ).toBeInTheDocument();
+  });
+
+  /**
+   * Note: this test *should* work but doesn't. There are past and open GitHub issues
+   * about it on the Apollo Client project. Unskip this test when the promised overhaul
+   * of the Mocked Provider materialises.
+   *
+   * https://github.com/apollographql/apollo-client/issues/4283 (closed)
+   * https://github.com/apollographql/apollo-client/issues/7167 (open since 2020).
+   *
+   */
+  xit('fails if approved item has scheduled entries', async () => {
+    mocks = [errorMock];
+
+    render(
+      <MockedProvider
+        mocks={mocks}
+        cache={apolloCache}
+        defaultOptions={{
+          mutate: {
+            errorPolicy: 'all',
+          },
+        }}
+      >
+        <SnackbarProvider maxSnack={3}>
+          <RejectCorpusItemAction
+            item={getTestApprovedItem({ externalId: '456-cde' })}
+            toggleModal={jest.fn()}
+            modalOpen={true}
+          />
+        </SnackbarProvider>
+      </MockedProvider>
+    );
+
+    const reason = screen.getByLabelText(/time sensitive/i);
+    userEvent.click(reason);
+    userEvent.click(screen.getByText(/save/i));
+
+    expect(
+      await screen.findByText(
+        /cannot remove item from approved corpus - scheduled entries exist/i
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/src/curated-corpus/components/actions/RejectCorpusItemAction/RejectCorpusItemAction.tsx
+++ b/src/curated-corpus/components/actions/RejectCorpusItemAction/RejectCorpusItemAction.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { useRunMutation } from '../../../../_shared/hooks';
+import {
+  ApprovedCorpusItem,
+  useRejectApprovedItemMutation,
+} from '../../../../api/generatedTypes';
+import { FormikHelpers, FormikValues } from 'formik';
+import { RejectItemModal } from '../../RejectItemModal/RejectItemModal';
+
+interface RejectCorpusItemActionProps {
+  /**
+   * The approved item that is about to become a rejected item instead.
+   */
+  item: ApprovedCorpusItem;
+
+  /**
+   * A state variable that tracks whether the RejectItemModal is visible
+   * on the page or not.
+   * This has to be passed down from the parent component as other components
+   * may need to use it, too.
+   */
+  modalOpen: boolean;
+
+  /**
+   * A function that toggles the RejectItemModal's visibility on and off.
+   * This has to be passed down from the parent component as other components
+   * may need to use it, too.
+   */
+  toggleModal: VoidFunction;
+
+  /**
+   * A function that triggers a new API call to refetch the data for a given
+   * query. Needed on the Corpus page to take the newly rejected curated item
+   * off the page. NOT needed on the CorpusItem page.
+   */
+  refetch?: VoidFunction;
+}
+
+/**
+ * This component encapsulates the logic needed to reject a corpus item -
+ * send through a mutation to the Curated Corpus API to move the corpus item
+ * from the approved to the rejected pile.
+ *
+ * @param props
+ * @constructor
+ */
+export const RejectCorpusItemAction: React.FC<RejectCorpusItemActionProps> = (
+  props
+) => {
+  const { item, toggleModal, modalOpen, refetch } = props;
+
+  // Get a helper function that will execute each mutation, show standard notifications
+  // and execute any additional actions in a callback
+  const { runMutation } = useRunMutation();
+
+  // 1. Prepare the "reject curated item" mutation
+  const [rejectCuratedItem] = useRejectApprovedItemMutation();
+
+  // 2. Remove the curated item from the recommendation corpus and place it
+  // into the rejected item list.
+  const onSave = (
+    values: FormikValues,
+    formikHelpers: FormikHelpers<any>
+  ): void => {
+    // Set out all the variables we need to pass to the mutation
+    const variables = {
+      data: {
+        externalId: item.externalId,
+        reason: values.reason,
+      },
+    };
+
+    // Run the mutation
+    runMutation(
+      rejectCuratedItem,
+      { variables },
+      `Item successfully moved to the rejected corpus.`,
+      () => {
+        toggleModal();
+        formikHelpers.setSubmitting(false);
+      },
+      () => {
+        formikHelpers.setSubmitting(false);
+      },
+      // If the data needs to be refreshed (as it does on the Corpus page),
+      // run the `refetch` helper function provided by the parent component.
+      refetch
+    );
+  };
+
+  return (
+    <RejectItemModal
+      prospect={item}
+      isOpen={modalOpen}
+      onSave={onSave}
+      toggleModal={toggleModal}
+    />
+  );
+};

--- a/src/curated-corpus/components/index.ts
+++ b/src/curated-corpus/components/index.ts
@@ -12,6 +12,7 @@ export { DuplicateProspectModal } from './DuplicateProspectModal/DuplicateProspe
 export { LoadExtraButton } from './LoadExtraButton/LoadExtraButton';
 export { NextPrevPagination } from './NextPrevPagination/NextPrevPagination';
 export { ProspectListCard } from './ProspectListCard/ProspectListCard';
+export { RejectCorpusItemAction } from './actions/RejectCorpusItemAction/RejectCorpusItemAction';
 export { RejectedItemListCard } from './RejectedItemListCard/RejectedItemListCard';
 export { RejectedItemSearchForm } from './RejectedItemSearchForm/RejectedItemSearchForm';
 export { RefreshProspectsModal } from './RefreshProspectsModal/RefreshProspectsModal';

--- a/src/curated-corpus/integration-test-mocks/rejectApprovedItem.ts
+++ b/src/curated-corpus/integration-test-mocks/rejectApprovedItem.ts
@@ -1,0 +1,23 @@
+import { rejectApprovedItem } from '../../api/mutations/rejectApprovedItem';
+import { getTestApprovedItem } from '../helpers/approvedItem';
+
+export const successMock = {
+  request: {
+    query: rejectApprovedItem,
+    variables: { data: { externalId: '123-abc', reason: 'TIME_SENSITIVE' } },
+  },
+  result: { data: { rejectApprovedCorpusItem: getTestApprovedItem() } },
+};
+
+export const errorMock = {
+  request: {
+    query: rejectApprovedItem,
+    variables: { data: { externalId: '456-cde', reason: 'TIME_SENSITIVE' } },
+  },
+  result: {
+    data: { rejectApprovedCorpusItem: null },
+    error: new Error(
+      'Cannot remove item from approved corpus - scheduled entries exist.'
+    ),
+  },
+};

--- a/src/curated-corpus/pages/CorpusItemPage/CorpusItemPage.tsx
+++ b/src/curated-corpus/pages/CorpusItemPage/CorpusItemPage.tsx
@@ -7,7 +7,9 @@ import { Alert } from '@material-ui/lab';
 import {
   ApprovedItemCurationHistory,
   ApprovedItemInfo,
+  RejectCorpusItemAction,
 } from '../../components';
+import { useToggle } from '../../../_shared/hooks';
 
 /**
  * This page displays all the details and schedule history of a single corpus item.
@@ -19,11 +21,17 @@ export const CorpusItemPage: React.FC = (): JSX.Element => {
   const params = useParams<{ id: string }>();
 
   // Query the API for data
-  const { loading, error, data } = useApprovedCorpusItemByExternalIdQuery({
-    variables: {
-      externalId: params.id,
-    },
-  });
+  const { loading, error, data, refetch } =
+    useApprovedCorpusItemByExternalIdQuery({
+      variables: {
+        externalId: params.id,
+      },
+    });
+
+  /**
+   * Keep track of whether the "Reject this item" modal is open or not.
+   */
+  const [rejectModalOpen, toggleRejectModal] = useToggle(false);
 
   return (
     <>
@@ -36,63 +44,70 @@ export const CorpusItemPage: React.FC = (): JSX.Element => {
             <Alert severity="info" variant="filled">
               A corpus item with ID of &quot;{params.id}&quot; could not be
               found.
+              <br />
+              <br />
+              Note that you will also see this message if you have just moved
+              this corpus item to the Rejected corpus.
             </Alert>
           </Box>
         </>
       )}
       {data && data.approvedCorpusItemByExternalId !== null && (
-        <Grid container spacing={6}>
-          <Grid item xs={12} sm={8}>
-            <h1>
-              {data.approvedCorpusItemByExternalId?.title}
-              <Typography variant="subtitle2" component="div">
-                Corpus Item
-              </Typography>
-            </h1>
+        <>
+          <Grid container spacing={6}>
+            <Grid item xs={12} sm={8}>
+              <h1>
+                {data.approvedCorpusItemByExternalId?.title}
+                <Typography variant="subtitle2" component="div">
+                  Corpus Item
+                </Typography>
+              </h1>
 
-            <ApprovedItemInfo item={data.approvedCorpusItemByExternalId!} />
-          </Grid>
+              <ApprovedItemInfo item={data.approvedCorpusItemByExternalId!} />
+            </Grid>
 
-          <Grid item xs={12} sm={4}>
-            <h2>Actions</h2>
-            <Box alignSelf="center" marginBottom={3}>
-              <ButtonGroup
-                orientation="horizontal"
-                color="primary"
-                variant="text"
-              >
-                <Button
+            <Grid item xs={12} sm={4}>
+              <h2>Actions</h2>
+              <Box alignSelf="center" marginBottom={3}>
+                <ButtonGroup
+                  orientation="horizontal"
                   color="primary"
-                  onClick={() => {
-                    alert('Ability to schedule is coming soon!');
-                  }}
+                  variant="text"
                 >
-                  Schedule
-                </Button>
-                <Button
-                  color="secondary"
-                  onClick={() => {
-                    alert('Ability to reject is coming soon!');
-                  }}
-                >
-                  Reject
-                </Button>
-                <Button
-                  color="primary"
-                  onClick={() => {
-                    alert('Ability to edit is coming soon!');
-                  }}
-                >
-                  Edit
-                </Button>
-              </ButtonGroup>
-            </Box>
+                  <Button
+                    color="primary"
+                    onClick={() => {
+                      alert('Ability to schedule is coming soon!');
+                    }}
+                  >
+                    Schedule
+                  </Button>
+                  <Button color="secondary" onClick={toggleRejectModal}>
+                    Reject
+                  </Button>
+                  <Button
+                    color="primary"
+                    onClick={() => {
+                      alert('Ability to edit is coming soon!');
+                    }}
+                  >
+                    Edit
+                  </Button>
+                </ButtonGroup>
+              </Box>
 
-            <ApprovedItemCurationHistory
-              item={data.approvedCorpusItemByExternalId!}
-            />
+              <ApprovedItemCurationHistory
+                item={data.approvedCorpusItemByExternalId!}
+              />
+            </Grid>
           </Grid>
-        </Grid>
+          <RejectCorpusItemAction
+            item={data.approvedCorpusItemByExternalId!}
+            modalOpen={rejectModalOpen}
+            toggleModal={toggleRejectModal}
+            refetch={refetch}
+          />
+        </>
       )}
     </>
   );

--- a/src/curated-corpus/pages/CorpusPage/CorpusPage.tsx
+++ b/src/curated-corpus/pages/CorpusPage/CorpusPage.tsx
@@ -9,7 +9,6 @@ import {
   CreateScheduledCorpusItemInput,
   useCreateScheduledCorpusItemMutation,
   useGetApprovedItemsLazyQuery,
-  useRejectApprovedItemMutation,
   useUpdateApprovedCorpusItemMutation,
 } from '../../../api/generatedTypes';
 import { HandleApiResponse } from '../../../_shared/components';
@@ -18,7 +17,7 @@ import {
   ApprovedItemModal,
   ApprovedItemSearchForm,
   NextPrevPagination,
-  RejectItemModal,
+  RejectCorpusItemAction,
   ScheduleItemModal,
 } from '../../components';
 import {
@@ -153,38 +152,6 @@ export const CorpusPage: React.FC = (): JSX.Element => {
     Omit<ApprovedCorpusItem, '__typename'> | undefined
   >(undefined);
 
-  // 1. Prepare the "reject curated item" mutation
-  const [rejectCuratedItem] = useRejectApprovedItemMutation();
-  // 2. Remove the curated item from the recommendation corpus and place it
-  // into the rejected item list.
-  const onRejectSave = (
-    values: FormikValues,
-    formikHelpers: FormikHelpers<any>
-  ): void => {
-    // Set out all the variables we need to pass to the mutation
-    const variables = {
-      data: {
-        externalId: currentItem?.externalId,
-        reason: values.reason,
-      },
-    };
-
-    // Run the mutation
-    runMutation(
-      rejectCuratedItem,
-      { variables },
-      `Item successfully moved to the rejected corpus.`,
-      () => {
-        toggleRejectModal();
-        formikHelpers.setSubmitting(false);
-      },
-      () => {
-        formikHelpers.setSubmitting(false);
-      },
-      refetch
-    );
-  };
-
   // 1. Prepare the "schedule curated item" mutation
   const [scheduleCuratedItem] = useCreateScheduledCorpusItemMutation();
   // 2. Schedule the curated item when the user saves a scheduling request
@@ -290,11 +257,11 @@ export const CorpusPage: React.FC = (): JSX.Element => {
             onSave={onEditItemSave}
             toggleModal={toggleEditModal}
           />
-          <RejectItemModal
-            prospect={currentItem}
-            isOpen={rejectModalOpen}
-            onSave={onRejectSave}
+          <RejectCorpusItemAction
+            item={currentItem}
+            modalOpen={rejectModalOpen}
             toggleModal={toggleRejectModal}
+            refetch={refetch}
           />
         </>
       )}


### PR DESCRIPTION
## Goal

Let users reject the corpus item right from the Corpus Item page.

## Todos

- [x] Abstract out the functionality used on the Corpus page and reuse it on the Corpus Item page
- [x] Add comments
- [x] Add tests - done, with the exception of sad path - see comments in test file
- [x] Inform the user the corpus item is no longer valid (refetching the data and showing an extended notice now). 
- [x] Rebase branch and squash commits - I'd like to branch off this branch for the other actions while this PR is being reviewed
- [x] Add a video walkthrough
- [x] Add self-review comments

## Video walkthrough

Note that the reason I have to go and add a corpus item before rejecting it is because everything else on Dev has scheduled entries and would not be able to be moved to the rejected pile anyway. The walkthrough shows both the new action off the Curated Item page and also the old one on the Corpus page - this is now powered by same code, just making sure it works after the refactor.

https://user-images.githubusercontent.com/22447785/188348746-e8b28fcd-da5a-424d-b8ba-36159d225549.mov

## Reference

 https://getpocket.atlassian.net/browse/BACK-1570