### PR TITLE
fix(prospecting page): [BACK-1592] Add loading indicator to Prospecting page

### DIFF
--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -87,7 +87,11 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
     });
 
   // Get the list of Scheduled Surfaces the currently logged-in user has access to.
-  const { data: scheduledSurfaceData } = useGetScheduledSurfacesForUserQuery({
+  const {
+    data: scheduledSurfaceData,
+    loading: scheduledSurfaceLoading,
+    error: scheduledSurfaceError,
+  } = useGetScheduledSurfacesForUserQuery({
     onCompleted: (data) => {
       const options = data.getScheduledSurfacesForUser.map(
         (scheduledSurface) => {
@@ -613,6 +617,12 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
         <Grid item xs={12} sm={8}>
           <Grid container spacing={3}>
             <Grid item xs={12} sm={6}>
+              {!scheduledSurfaceData && (
+                <HandleApiResponse
+                  loading={scheduledSurfaceLoading}
+                  error={scheduledSurfaceError}
+                />
+              )}
               {scheduledSurfaceOptions.length > 0 && (
                 <>
                   I am prospecting for


### PR DESCRIPTION
## Goal

While working on https://getpocket.atlassian.net/browse/BACK-1570, I noticed  that the very first query the Prospecting page loads doesn’t show anything  while the API call is in progress unlike the other queries on the page.

I’ve added the HandleApiResponse component to show the loading state for that first query - this is the query that loads the surfaces the user has access to for the dropdown menu.

## Video walkthrough

https://user-images.githubusercontent.com/22447785/188535579-10868a21-99a8-4982-a8fc-9129b67d6511.mov

## Reference

https://getpocket.atlassian.net/browse/BACK-1592