### PR TITLE
feat(corpus item): [BACK-1559] Allow "Edit" action from the full details page

### DIFF
--- a/src/curated-corpus/components/actions/EditCorpusItemAction/EditCorpusItemAction.test.tsx
+++ b/src/curated-corpus/components/actions/EditCorpusItemAction/EditCorpusItemAction.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
+import { render, screen } from '@testing-library/react';
+import { SnackbarProvider } from 'notistack';
+import { EditCorpusItemAction } from './EditCorpusItemAction';
+import { getTestApprovedItem } from '../../../helpers/approvedItem';
+import { successMock } from '../../../integration-test-mocks/updateApprovedItem';
+import userEvent from '@testing-library/user-event';
+import { apolloCache } from '../../../../api/client';
+
+describe('The EditCorpusItemAction', () => {
+  let mocks: MockedResponse[] = [];
+
+  it('renders the modal', async () => {
+    mocks = [];
+
+    render(
+      <MockedProvider mocks={mocks} cache={apolloCache}>
+        <SnackbarProvider maxSnack={3}>
+          <EditCorpusItemAction
+            item={getTestApprovedItem()}
+            toggleModal={jest.fn()}
+            modalOpen={true}
+          />
+        </SnackbarProvider>
+      </MockedProvider>
+    );
+
+    // Do we have the modal heading?
+    expect(screen.getByText(/edit item/i)).toBeInTheDocument();
+
+    // How about the form?
+    expect(screen.getByRole('form')).toBeInTheDocument();
+  });
+
+  it('completes the action successfully', async () => {
+    mocks = [successMock];
+
+    render(
+      <MockedProvider mocks={mocks} cache={apolloCache}>
+        <SnackbarProvider maxSnack={3}>
+          <EditCorpusItemAction
+            item={getTestApprovedItem()}
+            toggleModal={jest.fn()}
+            modalOpen={true}
+          />
+        </SnackbarProvider>
+      </MockedProvider>
+    );
+
+    // The most basic of integration tests - we simply send through
+    // the corpus item without any actual edits.
+    userEvent.click(screen.getByText(/save/i));
+
+    expect(
+      await screen.findByText(/curated item .* successfully updated/i)
+    ).toBeInTheDocument();
+  });
+
+  // See notes in RejectCorpusItemAction.test.tsx - add a fail test once it's
+  // possible to do so
+  it.todo('fails if an error is returned');
+});

--- a/src/curated-corpus/components/actions/EditCorpusItemAction/EditCorpusItemAction.tsx
+++ b/src/curated-corpus/components/actions/EditCorpusItemAction/EditCorpusItemAction.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { useRunMutation } from '../../../../_shared/hooks';
+import {
+  ApprovedCorpusItem,
+  useUpdateApprovedCorpusItemMutation,
+} from '../../../../api/generatedTypes';
+import { FormikHelpers, FormikValues } from 'formik';
+import { ApprovedItemModal } from '../../ApprovedItemModal/ApprovedItemModal';
+import { transformAuthors } from '../../../../_shared/utils/transformAuthors';
+
+interface EditCorpusItemActionProps {
+  /**
+   * The approved item that is about to become a rejected item instead.
+   */
+  item: ApprovedCorpusItem;
+
+  /**
+   * A state variable that tracks whether the ApprovedIteModal is visible
+   * on the page or not.
+   * This has to be passed down from the parent component as other components
+   * may need to use it, too.
+   */
+  modalOpen: boolean;
+
+  /**
+   * A function that toggles the ApprovedItemModal's visibility on and off.
+   * This has to be passed down from the parent component as other components
+   * may need to use it, too.
+   */
+  toggleModal: VoidFunction;
+
+  /**
+   * A function that triggers a new API call to refetch the data for a given
+   * query. Needed on the Corpus page to take the newly rejected curated item
+   * off the page. NOT needed on the CorpusItem page.
+   */
+  refetch?: VoidFunction;
+}
+
+/**
+ * This component encapsulates the logic needed to edit a corpus item's data
+ *
+ * @param props
+ * @constructor
+ */
+export const EditCorpusItemAction: React.FC<EditCorpusItemActionProps> = (
+  props
+) => {
+  const { item, toggleModal, modalOpen, refetch } = props;
+
+  // Get a helper function that will execute each mutation, show standard notifications
+  // and execute any additional actions in a callback
+  const { runMutation } = useRunMutation();
+
+  // 1. Prepare the "update curated item" mutation
+  const [updateCorpusItem] = useUpdateApprovedCorpusItemMutation();
+
+  // 2. Update the curated item with the data the curator submitted in the edit form.
+  const onSave = (
+    values: FormikValues,
+    formikHelpers: FormikHelpers<any>
+  ): void => {
+    const variables = {
+      data: {
+        externalId: item.externalId,
+        title: values.title,
+        excerpt: values.excerpt,
+        status: values.curationStatus,
+        language: values.language,
+        authors: transformAuthors(values.authors),
+        publisher: values.publisher,
+        imageUrl: values.imageUrl,
+        topic: values.topic,
+        isTimeSensitive: values.timeSensitive,
+      },
+    };
+
+    // Executed the mutation to update the approved item
+    runMutation(
+      updateCorpusItem,
+      { variables },
+      `Curated item "${item.title.substring(0, 40)}..." successfully updated`,
+      () => {
+        toggleModal();
+        formikHelpers.setSubmitting(false);
+      },
+      () => {
+        formikHelpers.setSubmitting(false);
+      },
+      refetch
+    );
+  };
+
+  return (
+    <ApprovedItemModal
+      approvedItem={item}
+      heading="Edit Item"
+      showItemTitle={true}
+      isOpen={modalOpen}
+      onSave={onSave}
+      toggleModal={toggleModal}
+    />
+  );
+};

--- a/src/curated-corpus/helpers/approvedItem.ts
+++ b/src/curated-corpus/helpers/approvedItem.ts
@@ -14,7 +14,7 @@ export const approvedCorpusItem: ApprovedCorpusItem = {
   imageUrl: 'https://placeimg.com/640/480/people?random=494',
   excerpt: 'Everything You Wanted to Know About React and Were Afraid To Ask',
   language: CorpusLanguage.De,
-  authors: [{ name: 'One Author', sortOrder: 1 }],
+  authors: [{ name: 'One Author', sortOrder: 0 }],
   publisher: 'Amazing Inventions',
   topic: Topics.HealthFitness,
   source: CorpusItemSource.Prospect,

--- a/src/curated-corpus/integration-test-mocks/updateApprovedItem.ts
+++ b/src/curated-corpus/integration-test-mocks/updateApprovedItem.ts
@@ -1,0 +1,25 @@
+import { getTestApprovedItem } from '../helpers/approvedItem';
+import { updateApprovedItem } from '../../api/mutations/updateApprovedItem';
+
+const item = getTestApprovedItem();
+
+export const successMock = {
+  request: {
+    query: updateApprovedItem,
+    variables: {
+      data: {
+        externalId: item.externalId,
+        title: item.title,
+        excerpt: item.excerpt,
+        status: item.status,
+        language: item.language,
+        authors: item.authors,
+        publisher: item.publisher,
+        imageUrl: item.imageUrl,
+        topic: item.topic,
+        isTimeSensitive: item.isTimeSensitive,
+      },
+    },
+  },
+  result: { data: { updateApprovedCorpusItem: item } },
+};

--- a/src/curated-corpus/pages/CorpusItemPage/CorpusItemPage.tsx
+++ b/src/curated-corpus/pages/CorpusItemPage/CorpusItemPage.tsx
@@ -11,6 +11,7 @@ import {
   ScheduleCorpusItemAction,
 } from '../../components';
 import { useToggle } from '../../../_shared/hooks';
+import { EditCorpusItemAction } from '../../components/actions/EditCorpusItemAction/EditCorpusItemAction';
 
 /**
  * This page displays all the details and schedule history of a single corpus item.
@@ -38,6 +39,11 @@ export const CorpusItemPage: React.FC = (): JSX.Element => {
    * Keep track of whether the "Schedule this item" modal is open or not.
    */
   const [scheduleModalOpen, toggleScheduleModal] = useToggle(false);
+
+  /**
+   * Keep track of whether the "Edit this item" modal is open or not.
+   */
+  const [editModalOpen, toggleEditModal] = useToggle(false);
 
   return (
     <>
@@ -86,12 +92,7 @@ export const CorpusItemPage: React.FC = (): JSX.Element => {
                   <Button color="secondary" onClick={toggleRejectModal}>
                     Reject
                   </Button>
-                  <Button
-                    color="primary"
-                    onClick={() => {
-                      alert('Ability to edit is coming soon!');
-                    }}
-                  >
+                  <Button color="primary" onClick={toggleEditModal}>
                     Edit
                   </Button>
                 </ButtonGroup>
@@ -112,6 +113,12 @@ export const CorpusItemPage: React.FC = (): JSX.Element => {
             item={data.approvedCorpusItemByExternalId!}
             modalOpen={scheduleModalOpen}
             toggleModal={toggleScheduleModal}
+            refetch={refetch}
+          />
+          <EditCorpusItemAction
+            item={data.approvedCorpusItemByExternalId!}
+            modalOpen={editModalOpen}
+            toggleModal={toggleEditModal}
             refetch={refetch}
           />
         </>


### PR DESCRIPTION
## Goal

To get the last remaining actions working on the Corpus Item page. The "Edit" action was targeted for this ticket, however since the image upload/reupload form and mutation are part of the form component, they came along for the ride and got included in this ticket instead of being addressed separately in BACK-1572. 

- Refactored the Edit action out of the Corpus page and into its own component.

- Reused this component on the Corpus Item page. Both Edit and Upload Image actions are now working on the Corpus Item page.

- Added tests.

## Video walkthrough

Demonstrates that the old, now refactored action on the Corpus page is working, and then moves on to the Corpus Item page to demonstrate the very same functionality working there, too. 


https://user-images.githubusercontent.com/22447785/189311842-2f603c40-5383-47f7-a2d7-3fe14f536d47.mov



## Reference

https://getpocket.atlassian.net/browse/BACK-1559