### PR TITLE
feat(labels): [BACK-1644] Add labels to Collection form lookup query

### DIFF
--- a/src/api/queries/getInitialCollectionFormData.ts
+++ b/src/api/queries/getInitialCollectionFormData.ts
@@ -12,6 +12,11 @@ export const getInitialCollectionFormData = gql`
       }
     }
 
+    labels {
+      externalId
+      name
+    }
+
     getLanguages
 
     getCurationCategories {


### PR DESCRIPTION
## Goal

Add a lookup query for labels so that we can use them on the frontend very soon!

- Added labels to `getInitialCollectionFormData` query that fetches various additional data for the add/edit collection form to run, such as curation categories, IAB categories, language codes and now labels, too.

- Updated generated types file with new changes now on the production admin graph.


Tickets:

- https://getpocket.atlassian.net/browse/BACK-1644