### PR TITLE
feat(labels): [BACK-1642] Update CollectionData fragment

### DIFF
--- a/src/api/fragments/CollectionData.ts
+++ b/src/api/fragments/CollectionData.ts
@@ -35,6 +35,10 @@ export const CollectionData = gql`
       name
       slug
     }
+    labels {
+      externalId
+      name
+    }
     partnership {
       externalId
       type

--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -1,5 +1,6 @@
-import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+import { gql } from '@apollo/client';
+
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = {
@@ -1845,6 +1846,11 @@ export type CollectionDataFragment = {
     name: string;
     slug: string;
   } | null;
+  labels?: Array<{
+    __typename?: 'Label';
+    externalId: string;
+    name: string;
+  } | null> | null;
   partnership?: {
     __typename?: 'CollectionPartnership';
     externalId: string;
@@ -2200,6 +2206,11 @@ export type CreateCollectionMutation = {
       name: string;
       slug: string;
     } | null;
+    labels?: Array<{
+      __typename?: 'Label';
+      externalId: string;
+      name: string;
+    } | null> | null;
     partnership?: {
       __typename?: 'CollectionPartnership';
       externalId: string;
@@ -2687,6 +2698,11 @@ export type UpdateCollectionMutation = {
       name: string;
       slug: string;
     } | null;
+    labels?: Array<{
+      __typename?: 'Label';
+      externalId: string;
+      name: string;
+    } | null> | null;
     partnership?: {
       __typename?: 'CollectionPartnership';
       externalId: string;
@@ -2783,6 +2799,11 @@ export type UpdateCollectionImageUrlMutation = {
       name: string;
       slug: string;
     } | null;
+    labels?: Array<{
+      __typename?: 'Label';
+      externalId: string;
+      name: string;
+    } | null> | null;
     partnership?: {
       __typename?: 'CollectionPartnership';
       externalId: string;
@@ -3286,6 +3307,11 @@ export type GetCollectionByExternalIdQuery = {
       name: string;
       slug: string;
     } | null;
+    labels?: Array<{
+      __typename?: 'Label';
+      externalId: string;
+      name: string;
+    } | null> | null;
     partnership?: {
       __typename?: 'CollectionPartnership';
       externalId: string;
@@ -3440,6 +3466,11 @@ export type GetCollectionsQuery = {
         name: string;
         slug: string;
       } | null;
+      labels?: Array<{
+        __typename?: 'Label';
+        externalId: string;
+        name: string;
+      } | null> | null;
       partnership?: {
         __typename?: 'CollectionPartnership';
         externalId: string;
@@ -3749,6 +3780,11 @@ export type GetSearchCollectionsQuery = {
         name: string;
         slug: string;
       } | null;
+      labels?: Array<{
+        __typename?: 'Label';
+        externalId: string;
+        name: string;
+      } | null> | null;
       partnership?: {
         __typename?: 'CollectionPartnership';
         externalId: string;
@@ -3850,6 +3886,10 @@ export const CollectionDataFragmentDoc = gql`
       externalId
       name
       slug
+    }
+    labels {
+      externalId
+      name
     }
     partnership {
       externalId


### PR DESCRIPTION
## Goal

Add labels to collection data returned with the fragment that is used in mutations and queries so that we can see this data on the frontend. 

Note: there is no change to current functionality; manually verified on Dev that things don't break after this update.

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1642

