### PR TITLE
feat(labels): [BACK-1646] Be able to create/update collections with labels

### DIFF
--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -1,6 +1,5 @@
-import * as Apollo from '@apollo/client';
 import { gql } from '@apollo/client';
-
+import * as Apollo from '@apollo/client';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = {
@@ -1683,6 +1682,7 @@ export type UpdateCollectionInput = {
   externalId?: InputMaybe<Scalars['String']>;
   imageUrl?: InputMaybe<Scalars['Url']>;
   intro?: InputMaybe<Scalars['Markdown']>;
+  labelExternalIds?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
   language: CollectionLanguage;
   slug: Scalars['String'];
   status: CollectionStatus;

--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -809,7 +809,7 @@ export type Item = {
   /** If the givenUrl redirects (once or many times), this is the final url. Otherwise, same as givenUrl */
   resolvedUrl?: Maybe<Scalars['Url']>;
   /**
-   * The http response code of the given url
+   * The http resonse code of the given url
    * @deprecated Clients should not use this
    */
   responseCode?: Maybe<Scalars['Int']>;
@@ -1170,7 +1170,7 @@ export type NumberedListElement = ListElement & {
   content: Scalars['Markdown'];
   /** Numeric index. If a nested item, the index is zero-indexed from the first child. */
   index: Scalars['Int'];
-  /** Zero-indexed level, for handling nested lists. */
+  /** Zero-indexed level, for handling nexted lists. */
   level: Scalars['Int'];
 };
 
@@ -1581,6 +1581,7 @@ export type ScheduledSurface = {
 /** available filters for searching collections */
 export type SearchCollectionsFilters = {
   author?: InputMaybe<Scalars['String']>;
+  labelExternalIds?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
   status?: InputMaybe<CollectionStatus>;
   title?: InputMaybe<Scalars['String']>;
 };
@@ -1751,7 +1752,7 @@ export type UrlMetadata = {
   url: Scalars['String'];
 };
 
-/** A Video, typically within an Article View of an {Item} or if the Item is a video itself. */
+/** A Video, typically within an Article View of an {Item} or if the Item is a video itself." */
 export type Video = {
   __typename?: 'Video';
   /** If known, the height of the video in px */
@@ -2149,16 +2150,7 @@ export type CreateApprovedCorpusItemMutation = {
 };
 
 export type CreateCollectionMutationVariables = Exact<{
-  title: Scalars['String'];
-  slug: Scalars['String'];
-  excerpt?: InputMaybe<Scalars['Markdown']>;
-  intro?: InputMaybe<Scalars['Markdown']>;
-  status: CollectionStatus;
-  authorExternalId: Scalars['String'];
-  curationCategoryExternalId?: InputMaybe<Scalars['String']>;
-  IABParentCategoryExternalId?: InputMaybe<Scalars['String']>;
-  IABChildCategoryExternalId?: InputMaybe<Scalars['String']>;
-  language: CollectionLanguage;
+  data: CreateCollectionInput;
 }>;
 
 export type CreateCollectionMutation = {
@@ -2634,18 +2626,7 @@ export type UpdateApprovedCorpusItemMutation = {
 };
 
 export type UpdateCollectionMutationVariables = Exact<{
-  externalId?: InputMaybe<Scalars['String']>;
-  title: Scalars['String'];
-  slug: Scalars['String'];
-  excerpt: Scalars['Markdown'];
-  intro?: InputMaybe<Scalars['Markdown']>;
-  status: CollectionStatus;
-  authorExternalId: Scalars['String'];
-  curationCategoryExternalId?: InputMaybe<Scalars['String']>;
-  IABParentCategoryExternalId?: InputMaybe<Scalars['String']>;
-  IABChildCategoryExternalId?: InputMaybe<Scalars['String']>;
-  language: CollectionLanguage;
-  imageUrl?: InputMaybe<Scalars['Url']>;
+  data: UpdateCollectionInput;
 }>;
 
 export type UpdateCollectionMutation = {
@@ -4090,32 +4071,8 @@ export type CreateApprovedCorpusItemMutationOptions =
     CreateApprovedCorpusItemMutationVariables
   >;
 export const CreateCollectionDocument = gql`
-  mutation createCollection(
-    $title: String!
-    $slug: String!
-    $excerpt: Markdown
-    $intro: Markdown
-    $status: CollectionStatus!
-    $authorExternalId: String!
-    $curationCategoryExternalId: String
-    $IABParentCategoryExternalId: String
-    $IABChildCategoryExternalId: String
-    $language: CollectionLanguage!
-  ) {
-    createCollection(
-      data: {
-        title: $title
-        slug: $slug
-        excerpt: $excerpt
-        intro: $intro
-        status: $status
-        authorExternalId: $authorExternalId
-        curationCategoryExternalId: $curationCategoryExternalId
-        IABParentCategoryExternalId: $IABParentCategoryExternalId
-        IABChildCategoryExternalId: $IABChildCategoryExternalId
-        language: $language
-      }
-    ) {
+  mutation createCollection($data: CreateCollectionInput!) {
+    createCollection(data: $data) {
       ...CollectionData
     }
   }
@@ -4139,16 +4096,7 @@ export type CreateCollectionMutationFn = Apollo.MutationFunction<
  * @example
  * const [createCollectionMutation, { data, loading, error }] = useCreateCollectionMutation({
  *   variables: {
- *      title: // value for 'title'
- *      slug: // value for 'slug'
- *      excerpt: // value for 'excerpt'
- *      intro: // value for 'intro'
- *      status: // value for 'status'
- *      authorExternalId: // value for 'authorExternalId'
- *      curationCategoryExternalId: // value for 'curationCategoryExternalId'
- *      IABParentCategoryExternalId: // value for 'IABParentCategoryExternalId'
- *      IABChildCategoryExternalId: // value for 'IABChildCategoryExternalId'
- *      language: // value for 'language'
+ *      data: // value for 'data'
  *   },
  * });
  */
@@ -4974,36 +4922,8 @@ export type UpdateApprovedCorpusItemMutationOptions =
     UpdateApprovedCorpusItemMutationVariables
   >;
 export const UpdateCollectionDocument = gql`
-  mutation updateCollection(
-    $externalId: String
-    $title: String!
-    $slug: String!
-    $excerpt: Markdown!
-    $intro: Markdown
-    $status: CollectionStatus!
-    $authorExternalId: String!
-    $curationCategoryExternalId: String
-    $IABParentCategoryExternalId: String
-    $IABChildCategoryExternalId: String
-    $language: CollectionLanguage!
-    $imageUrl: Url
-  ) {
-    updateCollection(
-      data: {
-        externalId: $externalId
-        title: $title
-        slug: $slug
-        excerpt: $excerpt
-        intro: $intro
-        status: $status
-        authorExternalId: $authorExternalId
-        curationCategoryExternalId: $curationCategoryExternalId
-        IABParentCategoryExternalId: $IABParentCategoryExternalId
-        IABChildCategoryExternalId: $IABChildCategoryExternalId
-        language: $language
-        imageUrl: $imageUrl
-      }
-    ) {
+  mutation updateCollection($data: UpdateCollectionInput!) {
+    updateCollection(data: $data) {
       ...CollectionData
     }
   }
@@ -5027,18 +4947,7 @@ export type UpdateCollectionMutationFn = Apollo.MutationFunction<
  * @example
  * const [updateCollectionMutation, { data, loading, error }] = useUpdateCollectionMutation({
  *   variables: {
- *      externalId: // value for 'externalId'
- *      title: // value for 'title'
- *      slug: // value for 'slug'
- *      excerpt: // value for 'excerpt'
- *      intro: // value for 'intro'
- *      status: // value for 'status'
- *      authorExternalId: // value for 'authorExternalId'
- *      curationCategoryExternalId: // value for 'curationCategoryExternalId'
- *      IABParentCategoryExternalId: // value for 'IABParentCategoryExternalId'
- *      IABChildCategoryExternalId: // value for 'IABChildCategoryExternalId'
- *      language: // value for 'language'
- *      imageUrl: // value for 'imageUrl'
+ *      data: // value for 'data'
  *   },
  * });
  */

--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -809,7 +809,7 @@ export type Item = {
   /** If the givenUrl redirects (once or many times), this is the final url. Otherwise, same as givenUrl */
   resolvedUrl?: Maybe<Scalars['Url']>;
   /**
-   * The http resonse code of the given url
+   * The http response code of the given url
    * @deprecated Clients should not use this
    */
   responseCode?: Maybe<Scalars['Int']>;
@@ -1170,7 +1170,7 @@ export type NumberedListElement = ListElement & {
   content: Scalars['Markdown'];
   /** Numeric index. If a nested item, the index is zero-indexed from the first child. */
   index: Scalars['Int'];
-  /** Zero-indexed level, for handling nexted lists. */
+  /** Zero-indexed level, for handling nested lists. */
   level: Scalars['Int'];
 };
 
@@ -1753,7 +1753,7 @@ export type UrlMetadata = {
   url: Scalars['String'];
 };
 
-/** A Video, typically within an Article View of an {Item} or if the Item is a video itself." */
+/** A Video, typically within an Article View of an {Item} or if the Item is a video itself. */
 export type Video = {
   __typename?: 'Video';
   /** If known, the height of the video in px */

--- a/src/api/mutations/createCollection.ts
+++ b/src/api/mutations/createCollection.ts
@@ -5,32 +5,8 @@ import { CollectionData } from '../fragments/CollectionData';
  * Create a collection
  */
 export const createCollection = gql`
-  mutation createCollection(
-    $title: String!
-    $slug: String!
-    $excerpt: Markdown
-    $intro: Markdown
-    $status: CollectionStatus!
-    $authorExternalId: String!
-    $curationCategoryExternalId: String
-    $IABParentCategoryExternalId: String
-    $IABChildCategoryExternalId: String
-    $language: CollectionLanguage!
-  ) {
-    createCollection(
-      data: {
-        title: $title
-        slug: $slug
-        excerpt: $excerpt
-        intro: $intro
-        status: $status
-        authorExternalId: $authorExternalId
-        curationCategoryExternalId: $curationCategoryExternalId
-        IABParentCategoryExternalId: $IABParentCategoryExternalId
-        IABChildCategoryExternalId: $IABChildCategoryExternalId
-        language: $language
-      }
-    ) {
+  mutation createCollection($data: CreateCollectionInput!) {
+    createCollection(data: $data) {
       ...CollectionData
     }
   }

--- a/src/api/mutations/updateCollection.ts
+++ b/src/api/mutations/updateCollection.ts
@@ -5,36 +5,8 @@ import { CollectionData } from '../fragments/CollectionData';
  * Update a collection
  */
 export const updateCollection = gql`
-  mutation updateCollection(
-    $externalId: String
-    $title: String!
-    $slug: String!
-    $excerpt: Markdown!
-    $intro: Markdown
-    $status: CollectionStatus!
-    $authorExternalId: String!
-    $curationCategoryExternalId: String
-    $IABParentCategoryExternalId: String
-    $IABChildCategoryExternalId: String
-    $language: CollectionLanguage!
-    $imageUrl: Url
-  ) {
-    updateCollection(
-      data: {
-        externalId: $externalId
-        title: $title
-        slug: $slug
-        excerpt: $excerpt
-        intro: $intro
-        status: $status
-        authorExternalId: $authorExternalId
-        curationCategoryExternalId: $curationCategoryExternalId
-        IABParentCategoryExternalId: $IABParentCategoryExternalId
-        IABChildCategoryExternalId: $IABChildCategoryExternalId
-        language: $language
-        imageUrl: $imageUrl
-      }
-    ) {
+  mutation updateCollection($data: UpdateCollectionInput!) {
+    updateCollection(data: $data) {
       ...CollectionData
     }
   }

--- a/src/collections/components/CollectionForm/CollectionForm.test.tsx
+++ b/src/collections/components/CollectionForm/CollectionForm.test.tsx
@@ -9,6 +9,7 @@ import {
   CollectionStatus,
   CurationCategory,
   IabParentCategory,
+  Label,
 } from '../../../api/generatedTypes';
 
 describe('The CollectionForm component', () => {
@@ -16,6 +17,7 @@ describe('The CollectionForm component', () => {
   let authors: CollectionAuthor[];
   let curationCategories: CurationCategory[];
   let iabCategories: IabParentCategory[];
+  let labels: Label[];
   let languages: CollectionLanguage[];
   const handleSubmit = jest.fn();
 
@@ -90,6 +92,11 @@ describe('The CollectionForm component', () => {
       },
     ];
 
+    labels = [
+      { externalId: '345-dfg', name: 'test-label-one' },
+      { externalId: '789-yui', name: 'test-label-two' },
+    ];
+
     languages = Object.values(CollectionLanguage);
   });
 
@@ -100,6 +107,7 @@ describe('The CollectionForm component', () => {
         collection={collection}
         curationCategories={curationCategories}
         iabCategories={iabCategories}
+        labels={labels}
         languages={Object.values(CollectionLanguage)}
         onSubmit={handleSubmit}
       />
@@ -117,13 +125,16 @@ describe('The CollectionForm component', () => {
         collection={collection}
         curationCategories={curationCategories}
         iabCategories={iabCategories}
+        labels={labels}
         languages={languages}
         onSubmit={handleSubmit}
       />
     );
 
     const buttons = screen.getAllByRole('button');
-    expect(buttons.length).toEqual(3);
+
+    // The fourth button is part of the MUI Autocomplete component
+    expect(buttons.length).toEqual(4);
   });
 
   it('only shows two buttons if not in edit mode', () => {
@@ -133,6 +144,7 @@ describe('The CollectionForm component', () => {
         collection={collection}
         curationCategories={curationCategories}
         iabCategories={iabCategories}
+        labels={labels}
         languages={languages}
         editMode={false}
         onSubmit={handleSubmit}
@@ -140,7 +152,9 @@ describe('The CollectionForm component', () => {
     );
 
     const buttons = screen.getAllByRole('button');
-    expect(buttons.length).toEqual(2);
+
+    // The third button is part of the MUI Autocomplete component
+    expect(buttons.length).toEqual(3);
   });
 
   it('displays collection information', () => {
@@ -150,6 +164,7 @@ describe('The CollectionForm component', () => {
         collection={collection}
         curationCategories={curationCategories}
         iabCategories={iabCategories}
+        labels={labels}
         languages={languages}
         onSubmit={handleSubmit}
       />
@@ -193,6 +208,7 @@ describe('The CollectionForm component', () => {
         collection={collection}
         curationCategories={curationCategories}
         iabCategories={iabCategories}
+        labels={labels}
         languages={languages}
         onSubmit={handleSubmit}
       />
@@ -245,6 +261,7 @@ describe('The CollectionForm component', () => {
         collection={collection}
         curationCategories={curationCategories}
         iabCategories={iabCategories}
+        labels={labels}
         languages={languages}
         onSubmit={handleSubmit}
       />
@@ -291,6 +308,7 @@ describe('The CollectionForm component', () => {
         collection={collection}
         curationCategories={curationCategories}
         iabCategories={iabCategories}
+        labels={labels}
         languages={languages}
         onSubmit={handleSubmit}
       />
@@ -332,6 +350,7 @@ describe('The CollectionForm component', () => {
         collection={collection}
         curationCategories={curationCategories}
         iabCategories={iabCategories}
+        labels={labels}
         languages={languages}
         onSubmit={handleSubmit}
       />
@@ -368,6 +387,7 @@ describe('The CollectionForm component', () => {
         collection={collection}
         curationCategories={curationCategories}
         iabCategories={iabCategories}
+        labels={labels}
         languages={languages}
         onSubmit={handleSubmit}
       />
@@ -378,5 +398,26 @@ describe('The CollectionForm component', () => {
 
     const previewTabs = screen.getAllByText(/preview/i);
     expect(previewTabs.length).toEqual(2);
+  });
+
+  it('displays pre-existing labels for a collection', () => {
+    // Let's assign the two mock labels that we have to a collection
+    collection.labels = labels;
+
+    render(
+      <CollectionForm
+        authors={authors}
+        collection={collection}
+        curationCategories={curationCategories}
+        iabCategories={iabCategories}
+        labels={labels}
+        languages={languages}
+        onSubmit={handleSubmit}
+      />
+    );
+
+    // Expect to see both of these labels on the screen
+    expect(screen.getByText(labels[0].name)).toBeInTheDocument();
+    expect(screen.getByText(labels[1].name)).toBeInTheDocument();
   });
 });

--- a/src/collections/components/CollectionForm/CollectionForm.tsx
+++ b/src/collections/components/CollectionForm/CollectionForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { Box, Grid, LinearProgress } from '@material-ui/core';
+import { Box, Grid, LinearProgress, TextField } from '@material-ui/core';
+import { Autocomplete } from '@material-ui/lab';
 import slugify from 'slugify';
 import { FormikValues, useFormik } from 'formik';
 import { FormikHelpers } from 'formik/dist/types';
@@ -22,6 +23,7 @@ import {
   CurationCategory,
   IabCategory,
   IabParentCategory,
+  Label,
 } from '../../../api/generatedTypes';
 
 interface CollectionFormProps {
@@ -44,6 +46,11 @@ interface CollectionFormProps {
    * A list of IAB categories
    */
   iabCategories: IabParentCategory[];
+
+  /**
+   * A list of available labels
+   */
+  labels: Label[];
 
   /**
    * A list of all supported languages
@@ -70,6 +77,7 @@ export const CollectionForm: React.FC<
     collection,
     curationCategories,
     iabCategories,
+    labels,
     languages,
     onSubmit,
     editMode = true,
@@ -96,6 +104,7 @@ export const CollectionForm: React.FC<
       slug: collection.slug ?? '',
       excerpt: collection.excerpt ?? '',
       intro: collection.intro ?? '',
+      labels: collection.labels ?? '',
       language: collection.language ?? CollectionLanguage.En,
       status: collection.status ?? CollectionStatus.Draft,
       authorExternalId,
@@ -108,7 +117,7 @@ export const CollectionForm: React.FC<
     // before they actually submit the form
     validateOnBlur: false,
     validateOnChange: false,
-    validationSchema: getValidationSchema(authorIds, languages),
+    validationSchema: getValidationSchema(authorIds, labels),
     onSubmit: (values, formikHelpers) => {
       onSubmit(values, formikHelpers);
     },
@@ -273,6 +282,27 @@ export const CollectionForm: React.FC<
               );
             })}
           </FormikSelectField>
+        </Grid>
+        <Grid item xs={12}>
+          <Autocomplete
+            multiple
+            id="tags-outlined"
+            options={labels}
+            getOptionLabel={(option) => option.name}
+            getOptionSelected={(option, value) =>
+              option.externalId === value.externalId
+            }
+            defaultValue={[labels[0]]}
+            filterSelectedOptions
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                variant="outlined"
+                label="Labels"
+                placeholder="Add a label"
+              />
+            )}
+          />
         </Grid>
         <Grid item xs={12}>
           <MarkdownPreview minHeight={6.5} source={formik.values.excerpt}>

--- a/src/collections/components/CollectionForm/CollectionForm.validation.tsx
+++ b/src/collections/components/CollectionForm/CollectionForm.validation.tsx
@@ -2,12 +2,10 @@ import * as yup from 'yup';
 import {
   CollectionLanguage,
   CollectionStatus,
+  Label,
 } from '../../../api/generatedTypes';
 
-export const getValidationSchema = (
-  authorIds: string[],
-  languages: CollectionLanguage[]
-) => {
+export const getValidationSchema = (authorIds: string[], labels: Label[]) => {
   return yup.object({
     title: yup
       .string()
@@ -26,6 +24,7 @@ export const getValidationSchema = (
       .min(6),
     excerpt: yup.string(),
     intro: yup.string(),
+    // labels:
     language: yup
       .mixed<CollectionLanguage>()
       .oneOf(Object.values(CollectionLanguage))

--- a/src/collections/components/CollectionForm/CollectionForm.validation.tsx
+++ b/src/collections/components/CollectionForm/CollectionForm.validation.tsx
@@ -2,10 +2,9 @@ import * as yup from 'yup';
 import {
   CollectionLanguage,
   CollectionStatus,
-  Label,
 } from '../../../api/generatedTypes';
 
-export const getValidationSchema = (authorIds: string[], labels: Label[]) => {
+export const getValidationSchema = (authorIds: string[]) => {
   return yup.object({
     title: yup
       .string()
@@ -24,7 +23,6 @@ export const getValidationSchema = (authorIds: string[], labels: Label[]) => {
       .min(6),
     excerpt: yup.string(),
     intro: yup.string(),
-    // labels:
     language: yup
       .mixed<CollectionLanguage>()
       .oneOf(Object.values(CollectionLanguage))

--- a/src/collections/pages/AddCollectionPage/AddCollectionPage.tsx
+++ b/src/collections/pages/AddCollectionPage/AddCollectionPage.tsx
@@ -11,6 +11,7 @@ import {
   CollectionLanguage,
   CollectionStatus,
   GetCollectionsDocument,
+  Label,
   useCreateCollectionMutation,
   useGetInitialCollectionFormDataQuery,
 } from '../../../api/generatedTypes';
@@ -32,6 +33,7 @@ export const AddCollectionPage: React.FC = (): JSX.Element => {
     excerpt: '',
     intro: '',
     imageUrl: '',
+    labels: [],
     language: CollectionLanguage.En,
     status: CollectionStatus.Draft,
     authors: [],
@@ -52,7 +54,8 @@ export const AddCollectionPage: React.FC = (): JSX.Element => {
    */
   const handleSubmit = (
     values: FormikValues,
-    formikHelpers: FormikHelpers<any>
+    formikHelpers: FormikHelpers<any>,
+    labels: Label[]
   ): void => {
     addCollection({
       variables: {
@@ -66,8 +69,8 @@ export const AddCollectionPage: React.FC = (): JSX.Element => {
           curationCategoryExternalId: values.curationCategoryExternalId,
           IABParentCategoryExternalId: values.IABParentCategoryExternalId,
           IABChildCategoryExternalId: values.IABChildCategoryExternalId,
+          labelExternalIds: labels.map((value: Label) => value.externalId),
           language: values.language,
-          labelExternalIds: values.labelExternalIds,
         },
       },
       // make sure the relevant Collections tab is updated

--- a/src/collections/pages/AddCollectionPage/AddCollectionPage.tsx
+++ b/src/collections/pages/AddCollectionPage/AddCollectionPage.tsx
@@ -56,16 +56,19 @@ export const AddCollectionPage: React.FC = (): JSX.Element => {
   ): void => {
     addCollection({
       variables: {
-        title: values.title,
-        slug: values.slug,
-        excerpt: values.excerpt,
-        intro: values.intro,
-        status: values.status,
-        authorExternalId: values.authorExternalId,
-        curationCategoryExternalId: values.curationCategoryExternalId,
-        IABParentCategoryExternalId: values.IABParentCategoryExternalId,
-        IABChildCategoryExternalId: values.IABChildCategoryExternalId,
-        language: values.language,
+        data: {
+          title: values.title,
+          slug: values.slug,
+          excerpt: values.excerpt,
+          intro: values.intro,
+          status: values.status,
+          authorExternalId: values.authorExternalId,
+          curationCategoryExternalId: values.curationCategoryExternalId,
+          IABParentCategoryExternalId: values.IABParentCategoryExternalId,
+          IABChildCategoryExternalId: values.IABChildCategoryExternalId,
+          language: values.language,
+          labelExternalIds: values.labelExternalIds,
+        },
       },
       // make sure the relevant Collections tab is updated
       // when we add a new collection
@@ -109,11 +112,13 @@ export const AddCollectionPage: React.FC = (): JSX.Element => {
             data.getCollectionAuthors &&
             data.getCurationCategories &&
             data.getIABCategories &&
-            data.getLanguages && (
+            data.getLanguages &&
+            data.labels && (
               <CollectionForm
                 authors={data.getCollectionAuthors.authors}
                 curationCategories={data.getCurationCategories}
                 iabCategories={data.getIABCategories}
+                labels={data.labels}
                 languages={data.getLanguages}
                 collection={collection}
                 onSubmit={handleSubmit}

--- a/src/collections/pages/CollectionPage/CollectionPage.tsx
+++ b/src/collections/pages/CollectionPage/CollectionPage.tsx
@@ -69,7 +69,7 @@ export const CollectionPage = (): JSX.Element => {
   // and execute any additional actions in a callback
   const { runMutation } = useRunMutation();
 
-  // And this one is only used to set the image url once the we know the S3 link
+  // And this one is only used to set the image url once we know the S3 link
   const [updateCollectionImageUrl] = useUpdateCollectionImageUrlMutation();
 
   // prepare the "create story" mutation
@@ -101,7 +101,7 @@ export const CollectionPage = (): JSX.Element => {
 
   /**
    * If the user came directly to this page (i.e., via a bookmarked page),
-   * fetch the Collection info from the the API.
+   * fetch the Collection info from the API.
    */
   const params = useParams<{ id: string }>();
   const { loading, error, data } = useGetCollectionByExternalIdQuery({
@@ -198,17 +198,20 @@ export const CollectionPage = (): JSX.Element => {
   ): void => {
     const options = {
       variables: {
-        externalId: collection!.externalId,
-        title: values.title,
-        slug: values.slug,
-        excerpt: values.excerpt,
-        intro: values.intro,
-        status: values.status,
-        authorExternalId: values.authorExternalId,
-        curationCategoryExternalId: values.curationCategoryExternalId,
-        IABParentCategoryExternalId: values.IABParentCategoryExternalId,
-        IABChildCategoryExternalId: values.IABChildCategoryExternalId,
-        language: values.language,
+        data: {
+          externalId: collection!.externalId,
+          title: values.title,
+          slug: values.slug,
+          excerpt: values.excerpt,
+          intro: values.intro,
+          status: values.status,
+          authorExternalId: values.authorExternalId,
+          curationCategoryExternalId: values.curationCategoryExternalId,
+          IABParentCategoryExternalId: values.IABParentCategoryExternalId,
+          IABChildCategoryExternalId: values.IABChildCategoryExternalId,
+          labelExternalIds: values.labelExternalIds,
+          language: values.language,
+        },
       },
       refetchQueries: [
         {
@@ -267,6 +270,7 @@ export const CollectionPage = (): JSX.Element => {
         collection.IABParentCategory =
           data?.updateCollection?.IABParentCategory;
         collection.IABChildCategory = data?.updateCollection?.IABChildCategory;
+        collection.labels = data?.updateCollection?.labels;
         collection.language = data?.updateCollection?.language!;
 
         toggleEditForm();
@@ -612,6 +616,7 @@ export const CollectionPage = (): JSX.Element => {
                         initialCollectionFormData.getCurationCategories
                       }
                       iabCategories={initialCollectionFormData.getIABCategories}
+                      labels={initialCollectionFormData.labels}
                       languages={initialCollectionFormData.getLanguages}
                       editMode={true}
                       onCancel={toggleEditForm}

--- a/src/collections/pages/CollectionPage/CollectionPage.tsx
+++ b/src/collections/pages/CollectionPage/CollectionPage.tsx
@@ -32,6 +32,7 @@ import {
   CollectionStory,
   GetCollectionByExternalIdDocument,
   GetCollectionsDocument,
+  Label,
   useCreateCollectionPartnerAssociationMutation,
   useCreateCollectionStoryMutation,
   useGetCollectionByExternalIdQuery,
@@ -194,7 +195,8 @@ export const CollectionPage = (): JSX.Element => {
   // 3. Update the story when the user submits the form
   const onCollectionUpdate = (
     values: FormikValues,
-    formikHelpers: FormikHelpers<any>
+    formikHelpers: FormikHelpers<any>,
+    labels: Label[]
   ): void => {
     const options = {
       variables: {
@@ -209,7 +211,7 @@ export const CollectionPage = (): JSX.Element => {
           curationCategoryExternalId: values.curationCategoryExternalId,
           IABParentCategoryExternalId: values.IABParentCategoryExternalId,
           IABChildCategoryExternalId: values.IABChildCategoryExternalId,
-          labelExternalIds: values.labelExternalIds,
+          labelExternalIds: labels.map((value: Label) => value.externalId),
           language: values.language,
         },
       },


### PR DESCRIPTION
## Note: DO NOT MERGE
Until https://github.com/Pocket/collection-api/pull/1010 is in.

## Goal

Finally! This PR will enable curators to add/update/remove labels on a collection, both when creating one and updating an existing collection

- [x] Updated `createCollection`, `updateCollection` mutations to simplify variable inputs and align the queries with integration tests in Collection API. Updated generated types.
- [x] Added a new Autocomplete field for labels to CollectionForm - it supports multiple labels which is something we don't need just yet but it's nice to have a future-proof form all the same.
- [x] Save labels for a collection correctly.
- [x] Display existing labels (or lack thereof) for a collection within the CollectionForm component.
- [ ] ~Validate the labels input field - to be added in a follow-up PR as it's not a blocker~ (note: ticket # 1684 filed)
- [x] Update any relevant unit tests. 

## Video walkthrough


https://user-images.githubusercontent.com/22447785/201078944-c28eeb42-1fa1-414b-aca3-147652fcb2b6.mov



## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1646