### PR TITLE
BACK-1643: Update CollectionInfo and CollectionListCard components

### DIFF
--- a/src/collections/components/CollectionInfo/CollectionInfo.test.tsx
+++ b/src/collections/components/CollectionInfo/CollectionInfo.test.tsx
@@ -182,4 +182,36 @@ describe('The CollectionInfo component', () => {
 
     expect(screen.queryByText('Careers → Job Fairs')).not.toBeInTheDocument();
   });
+
+  it('shows label if labels are set', () => {
+    collection.labels = [
+      {
+        externalId: 'label-1',
+        name: 'region-east-africa',
+      },
+      {
+        externalId: 'label-2',
+        name: 'region-west-africa',
+      },
+    ];
+
+    render(
+      <MemoryRouter>
+        <CollectionInfo collection={collection} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('region-east-africa')).toBeInTheDocument();
+    expect(screen.getByText('region-west-africa')).toBeInTheDocument();
+  });
+
+  it('omits label if labels are not set', () => {
+    render(
+      <MemoryRouter>
+        <CollectionInfo collection={collection} />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText('region-east-africa')).not.toBeInTheDocument();
+  });
 });

--- a/src/collections/components/CollectionInfo/CollectionInfo.tsx
+++ b/src/collections/components/CollectionInfo/CollectionInfo.tsx
@@ -64,6 +64,19 @@ export const CollectionInfo: React.FC<CollectionInfoProps> = (
             icon={<Avatar className={classes.iabAvatar}>IAB</Avatar>}
           />
         )}{' '}
+        {collection.labels &&
+          collection.labels.length > 0 &&
+          collection.labels.map((data, index) => {
+            return (
+              <Chip
+                key={data?.externalId}
+                variant="outlined"
+                color="primary"
+                label={data?.name}
+                icon={<LabelOutlinedIcon />}
+              />
+            );
+          })}
       </Box>
 
       <h3>Slug</h3>

--- a/src/collections/components/CollectionListCard/CollectionListCard.test.tsx
+++ b/src/collections/components/CollectionListCard/CollectionListCard.test.tsx
@@ -140,6 +140,38 @@ describe('The CollectionListCard component', () => {
     expect(screen.queryByText('Careers → Job Fairs')).not.toBeInTheDocument();
   });
 
+  it('shows label if labels are set', () => {
+    collection.labels = [
+      {
+        externalId: 'label-1',
+        name: 'region-east-africa',
+      },
+      {
+        externalId: 'label-2',
+        name: 'region-west-africa',
+      },
+    ];
+
+    render(
+      <MemoryRouter>
+        <CollectionListCard collection={collection} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('region-east-africa')).toBeInTheDocument();
+    expect(screen.getByText('region-west-africa')).toBeInTheDocument();
+  });
+
+  it('omits label if labels are not set', () => {
+    render(
+      <MemoryRouter>
+        <CollectionListCard collection={collection} />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText('region-east-africa')).not.toBeInTheDocument();
+  });
+
   it("links to an individual collection's page", () => {
     const history = createMemoryHistory({
       initialEntries: ['/collections/collections/'],

--- a/src/collections/components/CollectionListCard/CollectionListCard.tsx
+++ b/src/collections/components/CollectionListCard/CollectionListCard.tsx
@@ -98,7 +98,20 @@ export const CollectionListCard: React.FC<CollectionListCardProps> = (
                   label={`${collection.IABParentCategory.name} → ${collection.IABChildCategory.name}`}
                   icon={<Avatar className={classes.iabAvatar}>IAB</Avatar>}
                 />
-              )}
+              )}{' '}
+              {collection.labels &&
+                collection.labels.length > 0 &&
+                collection.labels.map((data, index) => {
+                  return (
+                    <Chip
+                      key={data?.externalId}
+                      variant="outlined"
+                      color="primary"
+                      label={data?.name}
+                      icon={<LabelOutlinedIcon />}
+                    />
+                  );
+                })}
             </Box>
             <Typography noWrap component="div">
               <ReactMarkdown>


### PR DESCRIPTION
## Goal

- Updating the CollectionInfo and CollectionListCard components to show labels. The label icon (currently used for topics / curation categories) is used for labels.
- Related integration tests are updated.

Tickets:

- [https://getpocket.atlassian.net/browse/BACK-1643](https://getpocket.atlassian.net/browse/BACK-1643)