### PR TITLE
feat(labels): [BACK-1647] Update `CollectionSearchForm` component

### DIFF
--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -1,5 +1,6 @@
-import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+import { gql } from '@apollo/client';
+
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = {
@@ -3761,15 +3762,13 @@ export type GetScheduledSurfacesForUserQuery = {
   }>;
 };
 
-export type GetSearchCollectionsQueryVariables = Exact<{
+export type SearchCollectionsQueryVariables = Exact<{
+  filters: SearchCollectionsFilters;
   page?: InputMaybe<Scalars['Int']>;
   perPage?: InputMaybe<Scalars['Int']>;
-  status?: InputMaybe<CollectionStatus>;
-  author?: InputMaybe<Scalars['String']>;
-  title?: InputMaybe<Scalars['String']>;
 }>;
 
-export type GetSearchCollectionsQuery = {
+export type SearchCollectionsQuery = {
   __typename?: 'Query';
   searchCollections: {
     __typename?: 'CollectionsResult';
@@ -3825,7 +3824,13 @@ export type GetSearchCollectionsQuery = {
         blurb: any;
       } | null;
     }>;
-    pagination: { __typename?: 'Pagination'; totalResults: number };
+    pagination: {
+      __typename?: 'Pagination';
+      currentPage: number;
+      totalPages: number;
+      totalResults: number;
+      perPage: number;
+    };
   };
 };
 
@@ -3877,6 +3882,13 @@ export type GetUrlMetadataQuery = {
     isCollection?: boolean | null;
     authors?: string | null;
   };
+};
+
+export type LabelsQueryVariables = Exact<{ [key: string]: never }>;
+
+export type LabelsQuery = {
+  __typename?: 'Query';
+  labels: Array<{ __typename?: 'Label'; externalId: string; name: string }>;
 };
 
 export const CollectionAuthorDataFragmentDoc = gql`
@@ -7007,24 +7019,21 @@ export type GetScheduledSurfacesForUserQueryResult = Apollo.QueryResult<
   GetScheduledSurfacesForUserQuery,
   GetScheduledSurfacesForUserQueryVariables
 >;
-export const GetSearchCollectionsDocument = gql`
-  query getSearchCollections(
+export const SearchCollectionsDocument = gql`
+  query searchCollections(
+    $filters: SearchCollectionsFilters!
     $page: Int
     $perPage: Int
-    $status: CollectionStatus
-    $author: String
-    $title: String
   ) {
-    searchCollections(
-      filters: { status: $status, author: $author, title: $title }
-      page: $page
-      perPage: $perPage
-    ) {
+    searchCollections(filters: $filters, page: $page, perPage: $perPage) {
       collections {
         ...CollectionData
       }
       pagination {
+        currentPage
+        totalPages
         totalResults
+        perPage
       }
     }
   }
@@ -7032,58 +7041,56 @@ export const GetSearchCollectionsDocument = gql`
 `;
 
 /**
- * __useGetSearchCollectionsQuery__
+ * __useSearchCollectionsQuery__
  *
- * To run a query within a React component, call `useGetSearchCollectionsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetSearchCollectionsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useSearchCollectionsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useSearchCollectionsQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useGetSearchCollectionsQuery({
+ * const { data, loading, error } = useSearchCollectionsQuery({
  *   variables: {
+ *      filters: // value for 'filters'
  *      page: // value for 'page'
  *      perPage: // value for 'perPage'
- *      status: // value for 'status'
- *      author: // value for 'author'
- *      title: // value for 'title'
  *   },
  * });
  */
-export function useGetSearchCollectionsQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetSearchCollectionsQuery,
-    GetSearchCollectionsQueryVariables
+export function useSearchCollectionsQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    SearchCollectionsQuery,
+    SearchCollectionsQueryVariables
   >
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
-    GetSearchCollectionsQuery,
-    GetSearchCollectionsQueryVariables
-  >(GetSearchCollectionsDocument, options);
+    SearchCollectionsQuery,
+    SearchCollectionsQueryVariables
+  >(SearchCollectionsDocument, options);
 }
-export function useGetSearchCollectionsLazyQuery(
+export function useSearchCollectionsLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
-    GetSearchCollectionsQuery,
-    GetSearchCollectionsQueryVariables
+    SearchCollectionsQuery,
+    SearchCollectionsQueryVariables
   >
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
-    GetSearchCollectionsQuery,
-    GetSearchCollectionsQueryVariables
-  >(GetSearchCollectionsDocument, options);
+    SearchCollectionsQuery,
+    SearchCollectionsQueryVariables
+  >(SearchCollectionsDocument, options);
 }
-export type GetSearchCollectionsQueryHookResult = ReturnType<
-  typeof useGetSearchCollectionsQuery
+export type SearchCollectionsQueryHookResult = ReturnType<
+  typeof useSearchCollectionsQuery
 >;
-export type GetSearchCollectionsLazyQueryHookResult = ReturnType<
-  typeof useGetSearchCollectionsLazyQuery
+export type SearchCollectionsLazyQueryHookResult = ReturnType<
+  typeof useSearchCollectionsLazyQuery
 >;
-export type GetSearchCollectionsQueryResult = Apollo.QueryResult<
-  GetSearchCollectionsQuery,
-  GetSearchCollectionsQueryVariables
+export type SearchCollectionsQueryResult = Apollo.QueryResult<
+  SearchCollectionsQuery,
+  SearchCollectionsQueryVariables
 >;
 export const GetStoryFromParserDocument = gql`
   query getStoryFromParser($url: String!) {
@@ -7215,4 +7222,52 @@ export type GetUrlMetadataLazyQueryHookResult = ReturnType<
 export type GetUrlMetadataQueryResult = Apollo.QueryResult<
   GetUrlMetadataQuery,
   GetUrlMetadataQueryVariables
+>;
+export const LabelsDocument = gql`
+  query labels {
+    labels {
+      externalId
+      name
+    }
+  }
+`;
+
+/**
+ * __useLabelsQuery__
+ *
+ * To run a query within a React component, call `useLabelsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useLabelsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useLabelsQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useLabelsQuery(
+  baseOptions?: Apollo.QueryHookOptions<LabelsQuery, LabelsQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<LabelsQuery, LabelsQueryVariables>(
+    LabelsDocument,
+    options
+  );
+}
+export function useLabelsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<LabelsQuery, LabelsQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<LabelsQuery, LabelsQueryVariables>(
+    LabelsDocument,
+    options
+  );
+}
+export type LabelsQueryHookResult = ReturnType<typeof useLabelsQuery>;
+export type LabelsLazyQueryHookResult = ReturnType<typeof useLabelsLazyQuery>;
+export type LabelsQueryResult = Apollo.QueryResult<
+  LabelsQuery,
+  LabelsQueryVariables
 >;

--- a/src/api/queries/getSearchCollections.ts
+++ b/src/api/queries/getSearchCollections.ts
@@ -5,23 +5,20 @@ import { CollectionData } from '../fragments/CollectionData';
  * Seach collections
  */
 export const getSearchCollections = gql`
-  query getSearchCollections(
+  query searchCollections(
+    $filters: SearchCollectionsFilters!
     $page: Int
     $perPage: Int
-    $status: CollectionStatus
-    $author: String
-    $title: String
   ) {
-    searchCollections(
-      filters: { status: $status, author: $author, title: $title }
-      page: $page
-      perPage: $perPage
-    ) {
+    searchCollections(filters: $filters, page: $page, perPage: $perPage) {
       collections {
         ...CollectionData
       }
       pagination {
+        currentPage
+        totalPages
         totalResults
+        perPage
       }
     }
   }

--- a/src/api/queries/labels.ts
+++ b/src/api/queries/labels.ts
@@ -1,0 +1,10 @@
+import { gql } from '@apollo/client';
+
+export const labels = gql`
+  query labels {
+    labels {
+      externalId
+      name
+    }
+  }
+`;

--- a/src/collections/components/CollectionSearchForm/CollectionSearchForm.tsx
+++ b/src/collections/components/CollectionSearchForm/CollectionSearchForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Box,
   Grid,
@@ -10,6 +10,8 @@ import {
 import { Button } from '../../../_shared/components';
 import { FormikValues, useFormik } from 'formik';
 import { validationSchema } from './CollectionSearchForm.validation';
+import { Autocomplete } from '@material-ui/lab';
+import { Label } from '../../../api/generatedTypes';
 
 interface CollectionSearchFormProps {
   /**
@@ -25,6 +27,20 @@ export const CollectionSearchForm: React.FC<CollectionSearchFormProps> = (
   props
 ): JSX.Element => {
   const { onSubmit } = props;
+
+  // Keep track of selected labels
+  const [selectedLabels, setSelectedLabels] = useState<Label[]>([]);
+
+  // TODO: use a query to get this data!
+  const labels = [
+    { externalId: '123-abc', name: 'test-label-one' },
+    { externalId: '456-cbe', name: 'test-label-two' },
+  ];
+
+  // Update labels if the user has made any changes
+  const handleLabelChange = (e: React.ChangeEvent<unknown>, value: Label[]) => {
+    setSelectedLabels(value);
+  };
 
   /**
    * Set up form validation
@@ -121,6 +137,29 @@ export const CollectionSearchForm: React.FC<CollectionSearchFormProps> = (
               {formik.errors.filterRequired}
             </div>
           )}
+        </Grid>
+
+        <Grid item xs={12}>
+          <Autocomplete
+            multiple
+            id="labels"
+            onChange={handleLabelChange}
+            options={labels}
+            getOptionLabel={(option) => option.name}
+            getOptionSelected={(option, value) =>
+              option.externalId === value.externalId
+            }
+            value={selectedLabels}
+            filterSelectedOptions
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                variant="outlined"
+                label="Labels"
+                placeholder="Add a label"
+              />
+            )}
+          />
         </Grid>
 
         {formik.isSubmitting && (

--- a/src/collections/components/CollectionSearchForm/CollectionSearchForm.tsx
+++ b/src/collections/components/CollectionSearchForm/CollectionSearchForm.tsx
@@ -15,9 +15,14 @@ import { Label } from '../../../api/generatedTypes';
 
 interface CollectionSearchFormProps {
   /**
+   * All the labels in the system we can filter by.
+   */
+  labels: Label[];
+
+  /**
    * What do we do with the submitted data?
    */
-  onSubmit: (values: FormikValues) => void;
+  onSubmit: (values: FormikValues, labels: Label[]) => void;
 }
 
 /**
@@ -26,16 +31,10 @@ interface CollectionSearchFormProps {
 export const CollectionSearchForm: React.FC<CollectionSearchFormProps> = (
   props
 ): JSX.Element => {
-  const { onSubmit } = props;
+  const { labels, onSubmit } = props;
 
   // Keep track of selected labels
   const [selectedLabels, setSelectedLabels] = useState<Label[]>([]);
-
-  // TODO: use a query to get this data!
-  const labels = [
-    { externalId: '123-abc', name: 'test-label-one' },
-    { externalId: '456-cbe', name: 'test-label-two' },
-  ];
 
   // Update labels if the user has made any changes
   const handleLabelChange = (e: React.ChangeEvent<unknown>, value: Label[]) => {
@@ -60,7 +59,7 @@ export const CollectionSearchForm: React.FC<CollectionSearchFormProps> = (
     // fields is filled out
     validationSchema,
     onSubmit: (values) => {
-      onSubmit(values);
+      onSubmit(values, selectedLabels);
       formik.setSubmitting(false);
     },
   });

--- a/src/collections/components/CollectionSearchForm/CollectionSearchForm.tsx
+++ b/src/collections/components/CollectionSearchForm/CollectionSearchForm.tsx
@@ -1,13 +1,6 @@
 import React, { useState } from 'react';
-import {
-  Box,
-  Grid,
-  InputLabel,
-  LinearProgress,
-  Select,
-  TextField,
-} from '@material-ui/core';
-import { Button } from '../../../_shared/components';
+import { Box, Grid, LinearProgress, TextField } from '@material-ui/core';
+import { Button, FormikSelectField } from '../../../_shared/components';
 import { FormikValues, useFormik } from 'formik';
 import { validationSchema } from './CollectionSearchForm.validation';
 import { Autocomplete } from '@material-ui/lab';
@@ -22,7 +15,7 @@ interface CollectionSearchFormProps {
   /**
    * What do we do with the submitted data?
    */
-  onSubmit: (values: FormikValues, labels: Label[]) => void;
+  onSubmit: (values: FormikValues) => void;
 }
 
 /**
@@ -39,6 +32,10 @@ export const CollectionSearchForm: React.FC<CollectionSearchFormProps> = (
   // Update labels if the user has made any changes
   const handleLabelChange = (e: React.ChangeEvent<unknown>, value: Label[]) => {
     setSelectedLabels(value);
+
+    // Explicitly set labels within the validation library, too - otherwise the value
+    // sent through is undefined
+    formik.setFieldValue('labels', value);
   };
 
   /**
@@ -49,17 +46,16 @@ export const CollectionSearchForm: React.FC<CollectionSearchFormProps> = (
       title: '',
       author: '',
       status: '',
+      labels: [],
       filterRequired: '',
     },
     // We don't want to irritate users by displaying validation errors
     // before they actually submit the form
     validateOnBlur: false,
     validateOnChange: false,
-    // TODO: we should write a custom validator that makes sure at least one of the
-    // fields is filled out
     validationSchema,
     onSubmit: (values) => {
-      onSubmit(values, selectedLabels);
+      onSubmit(values);
       formik.setSubmitting(false);
     },
   });
@@ -78,14 +74,8 @@ export const CollectionSearchForm: React.FC<CollectionSearchFormProps> = (
             size="small"
             variant="outlined"
             {...formik.getFieldProps('title')}
-            error={
-              !!(formik.touched.title && formik.errors.title) ||
-              !!(formik.errors && formik.errors.filterRequired)
-            }
-            helperText={
-              (formik.errors.title && formik.errors.title) ||
-              (formik.errors && formik.errors.filterRequired)
-            }
+            error={!!(formik.touched.title && formik.errors.title)}
+            helperText={formik.errors.title && formik.errors.title}
           />
         </Grid>
 
@@ -100,42 +90,24 @@ export const CollectionSearchForm: React.FC<CollectionSearchFormProps> = (
             size="small"
             variant="outlined"
             {...formik.getFieldProps('author')}
-            error={
-              !!(formik.touched.author && formik.errors.author) ||
-              !!(formik.errors && formik.errors.filterRequired)
-            }
-            helperText={
-              (formik.errors.author && formik.errors.author) ||
-              (formik.errors && formik.errors.filterRequired)
-            }
+            error={!!(formik.touched.author && formik.errors.author)}
+            helperText={formik.errors.author}
           />
         </Grid>
 
         <Grid item xs={12}>
-          <InputLabel htmlFor="status" shrink={true}>
-            Status
-          </InputLabel>
-          <Select
-            variant="outlined"
+          <FormikSelectField
+            id="status"
             label="Status"
-            fullWidth
-            inputProps={{
-              name: 'status',
-              id: 'status',
-            }}
-            {...formik.getFieldProps('status')}
-            error={!!(formik.errors && formik.errors.filterRequired)}
+            fieldProps={formik.getFieldProps('status')}
+            fieldMeta={formik.getFieldMeta('status')}
           >
             <option value=""></option>
             <option value="DRAFT">Draft</option>
+            <option value="REVIEW">Review</option>
             <option value="PUBLISHED">Published</option>
             <option value="ARCHIVED">Archived</option>
-          </Select>
-          {formik.errors && formik.errors.filterRequired && (
-            <div className="MuiFormHelperText-root MuiFormHelperText-contained Mui-error MuiFormHelperText-marginDense">
-              {formik.errors.filterRequired}
-            </div>
-          )}
+          </FormikSelectField>
         </Grid>
 
         <Grid item xs={12}>
@@ -160,6 +132,14 @@ export const CollectionSearchForm: React.FC<CollectionSearchFormProps> = (
             )}
           />
         </Grid>
+
+        {formik.errors && formik.errors.filterRequired && (
+          <Grid item xs={12}>
+            <div className="MuiFormHelperText-root MuiFormHelperText-contained Mui-error MuiFormHelperText-marginDense">
+              {formik.errors.filterRequired}
+            </div>
+          </Grid>
+        )}
 
         {formik.isSubmitting && (
           <Grid item xs={12}>

--- a/src/collections/components/CollectionSearchForm/CollectionSearchForm.validation.tsx
+++ b/src/collections/components/CollectionSearchForm/CollectionSearchForm.validation.tsx
@@ -4,10 +4,12 @@ import { CollectionStatus } from '../../../api/generatedTypes';
 export const validationSchema = yup.object({
   title: yup.string().min(3),
   author: yup.string().min(3),
+  labels: yup.array(),
   status: yup.mixed<CollectionStatus>().oneOf(Object.values(CollectionStatus)),
-  filterRequired: yup.bool().when(['title', 'author', 'status'], {
-    is: (title: any, author: any, status: any) => !title && !author && !status,
-    then: yup.bool().required('at least one filter is required'),
+  filterRequired: yup.bool().when(['title', 'author', 'status', 'labels'], {
+    is: (title: any, author: any, status: any, labels: any) =>
+      !title && !author && !status && labels.length < 1,
+    then: yup.bool().required('At least one filter is required.'),
     otherwise: yup.bool(),
   }),
 });

--- a/src/collections/pages/CollectionSearchPage/CollectionSearchPage.tsx
+++ b/src/collections/pages/CollectionSearchPage/CollectionSearchPage.tsx
@@ -6,6 +6,8 @@ import { CollectionListCard, CollectionSearchForm } from '../../components';
 import { useGetSearchCollectionsLazyQuery } from '../../../api/generatedTypes';
 
 export const CollectionSearchPage: React.FC = (): JSX.Element => {
+  // TODO: Get all available labels and pass them onto the form
+
   // prepare the query for executing in the handleSubmit callback below
   const [searchCollections, { loading, error, data }] =
     useGetSearchCollectionsLazyQuery(

--- a/src/collections/pages/CollectionSearchPage/CollectionSearchPage.tsx
+++ b/src/collections/pages/CollectionSearchPage/CollectionSearchPage.tsx
@@ -27,8 +27,7 @@ export const CollectionSearchPage: React.FC = (): JSX.Element => {
    * Collect form data and send it to the API.
    * Update components on page if updates have been saved successfully
    */
-  const handleSubmit = (values: FormikValues, labels: Label[]): void => {
-    // prepare the search filters
+  const handleSubmit = (values: FormikValues): void => {
     const searchVars: any = {
       author: values.author,
       title: values.title,
@@ -40,8 +39,8 @@ export const CollectionSearchPage: React.FC = (): JSX.Element => {
       searchVars['status'] = values.status;
     }
 
-    if (labels.length > 0) {
-      searchVars['labelExternalIds'] = labels.map(
+    if (values.labels.length > 0) {
+      searchVars['labelExternalIds'] = values.labels.map(
         (value: Label) => value.externalId
       );
     }

--- a/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
+++ b/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
@@ -23,7 +23,6 @@ import CheckCircleOutlineIcon from '@material-ui/icons/CheckCircleOutline';
 import { DismissProspectAction } from '../actions/DismissProspectAction/DismissProspectAction';
 import CategoryIcon from '@material-ui/icons/Category';
 
-
 interface ProspectListCardProps {
   /**
    * An object with everything prospect-related in it.


### PR DESCRIPTION
## Goal

So that users can search by one or more labels on the "Search" page.

Did a minor refactor to the search query itself (sending all the filters as one variable instead of individual variables) and updated the "Status" field - the markup on the old one was a bit wonky (labels wouldn't shrink) and it also produced a warning on dev. Additionally, it was missing one of the status values - "Review". Added that, too.

## Video walkthrough


https://user-images.githubusercontent.com/22447785/202342577-e940fa6c-4692-4931-99fa-d2d14538381f.mov



## Reference

https://getpocket.atlassian.net/browse/BACK-1647