### PR TITLE
BACK-1687: update curation category / topic icon

### DIFF
--- a/src/collections/components/CollectionInfo/CollectionInfo.tsx
+++ b/src/collections/components/CollectionInfo/CollectionInfo.tsx
@@ -6,6 +6,7 @@ import ReactMarkdown from 'react-markdown';
 import { useStyles } from './CollectionInfo.styles';
 import { Collection, CollectionStatus } from '../../../api/generatedTypes';
 import { flattenAuthors } from '../../../_shared/utils/flattenAuthors';
+import CategoryIcon from '@material-ui/icons/Category';
 
 interface CollectionInfoProps {
   /**
@@ -53,7 +54,7 @@ export const CollectionInfo: React.FC<CollectionInfoProps> = (
             variant="outlined"
             color="primary"
             label={collection.curationCategory.name}
-            icon={<LabelOutlinedIcon />}
+            icon={<CategoryIcon />}
           />
         )}{' '}
         {collection.IABParentCategory && collection.IABChildCategory && (

--- a/src/collections/components/CollectionListCard/CollectionListCard.tsx
+++ b/src/collections/components/CollectionListCard/CollectionListCard.tsx
@@ -15,6 +15,7 @@ import { Collection } from '../../../api/generatedTypes';
 import LabelOutlinedIcon from '@material-ui/icons/LabelOutlined';
 import { flattenAuthors } from '../../../_shared/utils/flattenAuthors';
 import LanguageIcon from '@material-ui/icons/Language';
+import CategoryIcon from '@material-ui/icons/Category';
 
 interface CollectionListCardProps {
   /**
@@ -88,7 +89,7 @@ export const CollectionListCard: React.FC<CollectionListCardProps> = (
                   variant="outlined"
                   color="primary"
                   label={collection.curationCategory.name}
-                  icon={<LabelOutlinedIcon />}
+                  icon={<CategoryIcon />}
                 />
               )}{' '}
               {collection.IABParentCategory && collection.IABChildCategory && (

--- a/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.tsx
+++ b/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.tsx
@@ -12,7 +12,7 @@ import {
 import AlarmIcon from '@material-ui/icons/Alarm';
 import BookmarksIcon from '@material-ui/icons/Bookmarks';
 import CheckCircleOutlineIcon from '@material-ui/icons/CheckCircleOutline';
-import LabelOutlinedIcon from '@material-ui/icons/LabelOutlined';
+import CategoryIcon from '@material-ui/icons/Category';
 import LanguageIcon from '@material-ui/icons/Language';
 import { useStyles } from './ApprovedItemListCard.styles';
 import { ApprovedCorpusItem, CuratedStatus } from '../../../api/generatedTypes';
@@ -132,7 +132,7 @@ export const ApprovedItemListCard: React.FC<ApprovedItemListCardProps> = (
         )}
         <ListItem>
           <ListItemIcon className={classes.listItemIcon}>
-            <LabelOutlinedIcon />
+            <CategoryIcon />
           </ListItemIcon>
           <ListItemText
             className={classes.topic}

--- a/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.tsx
+++ b/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.tsx
@@ -13,7 +13,7 @@ import {
   Typography,
 } from '@material-ui/core';
 import LanguageIcon from '@material-ui/icons/Language';
-import LabelOutlinedIcon from '@material-ui/icons/LabelOutlined';
+import CategoryIcon from '@material-ui/icons/Category';
 import CheckIcon from '@material-ui/icons/Check';
 import FaceIcon from '@material-ui/icons/Face';
 import CheckCircleOutlineIcon from '@material-ui/icons/CheckCircleOutline';
@@ -106,7 +106,7 @@ export const ExistingProspectCard: React.FC<ExistingProspectCardProps> = (
                 variant="outlined"
                 color="primary"
                 label={getDisplayTopic(item.topic)}
-                icon={<LabelOutlinedIcon />}
+                icon={<CategoryIcon />}
               />
             </Grid>
             <Grid item>

--- a/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
+++ b/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
@@ -15,12 +15,12 @@ import {
 } from '@material-ui/core';
 import { useStyles } from './ProspectListCard.styles';
 import LanguageIcon from '@material-ui/icons/Language';
-import LabelOutlinedIcon from '@material-ui/icons/LabelOutlined';
 import FavoriteBorderIcon from '@material-ui/icons/FavoriteBorder';
 import MyLocationIcon from '@material-ui/icons/MyLocation';
 import { Button } from '../../../_shared/components';
 import { getDisplayTopic } from '../../helpers/topics';
 import CheckCircleOutlineIcon from '@material-ui/icons/CheckCircleOutline';
+import CategoryIcon from '@material-ui/icons/Category';
 
 interface ProspectListCardProps {
   /**
@@ -117,7 +117,7 @@ export const ProspectListCard: React.FC<ProspectListCardProps> = (
                 variant="outlined"
                 color="primary"
                 label={getDisplayTopic(prospect.topic)}
-                icon={<LabelOutlinedIcon />}
+                icon={<CategoryIcon />}
               />
             </Grid>
             <Grid item>

--- a/src/curated-corpus/components/RejectedItemListCard/RejectedItemListCard.tsx
+++ b/src/curated-corpus/components/RejectedItemListCard/RejectedItemListCard.tsx
@@ -12,7 +12,7 @@ import {
 import LanguageIcon from '@material-ui/icons/Language';
 import ThumbDownIcon from '@material-ui/icons/ThumbDown';
 import FaceIcon from '@material-ui/icons/Face';
-import LabelOutlinedIcon from '@material-ui/icons/LabelOutlined';
+import CategoryIcon from '@material-ui/icons/Category';
 
 import { useStyles } from './RejectedItemListCard.styles';
 import { RejectedCorpusItem } from '../../../api/generatedTypes';
@@ -69,7 +69,7 @@ export const RejectedItemListCard: React.FC<RejectedItemListCardProps> = (
         </ListItem>
         <ListItem>
           <ListItemIcon className={classes.listItemIcon}>
-            <LabelOutlinedIcon />
+            <CategoryIcon />
           </ListItemIcon>
           <ListItemText
             className={classes.topic}


### PR DESCRIPTION
## Goal

With `labels` now using the MUI material label icon, `curation category / topic` icon is now updated to the [MUI category icon](https://mui.com/material-ui/material-icons/?query=category&selected=Category)

Tickets:

- [https://getpocket.atlassian.net/browse/BACK-1687](https://getpocket.atlassian.net/browse/BACK-1687)

Example:
<img width="638" alt="Screenshot 2022-11-14 at 13 05 38" src="https://user-images.githubusercontent.com/16909783/201765454-59a6a6aa-625b-4e34-842c-a5beb08e4913.png">

