### PR TITLE
fix(dismissProspect): allow dismiss for prospects already in corpus

### DIFF
--- a/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.test.tsx
+++ b/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.test.tsx
@@ -63,6 +63,7 @@ describe('The ExistingProspectCard component', () => {
         <MemoryRouter>
           <ExistingProspectCard
             item={prospect.approvedCorpusItem!}
+            prospectId={prospect.prospectId}
             onSchedule={onSchedule}
             onDismissProspect={onDismissProspect}
           />
@@ -92,6 +93,7 @@ describe('The ExistingProspectCard component', () => {
         <MemoryRouter>
           <ExistingProspectCard
             item={prospect.approvedCorpusItem!}
+            prospectId={prospect.prospectId}
             onSchedule={onSchedule}
             onDismissProspect={onDismissProspect}
           />
@@ -108,6 +110,7 @@ describe('The ExistingProspectCard component', () => {
         <MemoryRouter>
           <ExistingProspectCard
             item={prospect.approvedCorpusItem!}
+            prospectId={prospect.prospectId}
             onSchedule={onSchedule}
             onDismissProspect={onDismissProspect}
           />
@@ -124,6 +127,7 @@ describe('The ExistingProspectCard component', () => {
         <MemoryRouter>
           <ExistingProspectCard
             item={prospect.approvedCorpusItem!}
+            prospectId={prospect.prospectId}
             onSchedule={onSchedule}
             onDismissProspect={onDismissProspect}
           />
@@ -140,6 +144,7 @@ describe('The ExistingProspectCard component', () => {
         <MemoryRouter>
           <ExistingProspectCard
             item={prospect.approvedCorpusItem!}
+            prospectId={prospect.prospectId}
             onSchedule={onSchedule}
             onDismissProspect={onDismissProspect}
           />
@@ -159,6 +164,7 @@ describe('The ExistingProspectCard component', () => {
         <MemoryRouter>
           <ExistingProspectCard
             item={prospect.approvedCorpusItem!}
+            prospectId={prospect.prospectId}
             onSchedule={onSchedule}
             onDismissProspect={onDismissProspect}
           />
@@ -175,6 +181,7 @@ describe('The ExistingProspectCard component', () => {
         <MemoryRouter>
           <ExistingProspectCard
             item={prospect.approvedCorpusItem!}
+            prospectId={prospect.prospectId}
             onSchedule={onSchedule}
             onDismissProspect={onDismissProspect}
           />
@@ -219,6 +226,7 @@ describe('The ExistingProspectCard component', () => {
         <MemoryRouter>
           <ExistingProspectCard
             item={prospectWithScheduleHistory.approvedCorpusItem!}
+            prospectId={prospect.prospectId}
             onSchedule={onSchedule}
             onDismissProspect={onDismissProspect}
           />

--- a/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.test.tsx
+++ b/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.test.tsx
@@ -11,10 +11,12 @@ import {
 } from '../../../api/generatedTypes';
 import { ExistingProspectCard } from './ExistingProspectCard';
 import { ScheduledSurfaces } from '../../helpers/definitions';
+import { MockedProvider } from '@apollo/client/testing';
 
 describe('The ExistingProspectCard component', () => {
   let prospect: Prospect;
   const onSchedule = jest.fn();
+  const onDismissProspect = jest.fn();
 
   beforeEach(() => {
     prospect = {
@@ -57,12 +59,15 @@ describe('The ExistingProspectCard component', () => {
 
   it('should show basic prospect metadata', () => {
     render(
-      <MemoryRouter>
-        <ExistingProspectCard
-          item={prospect.approvedCorpusItem!}
-          onSchedule={onSchedule}
-        />
-      </MemoryRouter>
+      <MockedProvider>
+        <MemoryRouter>
+          <ExistingProspectCard
+            item={prospect.approvedCorpusItem!}
+            onSchedule={onSchedule}
+            onDismissProspect={onDismissProspect}
+          />
+        </MemoryRouter>
+      </MockedProvider>
     );
 
     // The image is present and the alt text is the item title
@@ -83,12 +88,15 @@ describe('The ExistingProspectCard component', () => {
 
   it('should show language correctly', () => {
     render(
-      <MemoryRouter>
-        <ExistingProspectCard
-          item={prospect.approvedCorpusItem!}
-          onSchedule={onSchedule}
-        />
-      </MemoryRouter>
+      <MockedProvider>
+        <MemoryRouter>
+          <ExistingProspectCard
+            item={prospect.approvedCorpusItem!}
+            onSchedule={onSchedule}
+            onDismissProspect={onDismissProspect}
+          />
+        </MemoryRouter>
+      </MockedProvider>
     );
 
     expect(screen.getByText(/^de$/i)).toBeInTheDocument();
@@ -96,12 +104,15 @@ describe('The ExistingProspectCard component', () => {
 
   it('should show topic correctly', () => {
     render(
-      <MemoryRouter>
-        <ExistingProspectCard
-          item={prospect.approvedCorpusItem!}
-          onSchedule={onSchedule}
-        />
-      </MemoryRouter>
+      <MockedProvider>
+        <MemoryRouter>
+          <ExistingProspectCard
+            item={prospect.approvedCorpusItem!}
+            onSchedule={onSchedule}
+            onDismissProspect={onDismissProspect}
+          />
+        </MemoryRouter>
+      </MockedProvider>
     );
 
     expect(screen.getByText(/^technology$/i)).toBeInTheDocument();
@@ -109,12 +120,15 @@ describe('The ExistingProspectCard component', () => {
 
   it('should render card with excerpt', () => {
     render(
-      <MemoryRouter>
-        <ExistingProspectCard
-          item={prospect.approvedCorpusItem!}
-          onSchedule={onSchedule}
-        />
-      </MemoryRouter>
+      <MockedProvider>
+        <MemoryRouter>
+          <ExistingProspectCard
+            item={prospect.approvedCorpusItem!}
+            onSchedule={onSchedule}
+            onDismissProspect={onDismissProspect}
+          />
+        </MemoryRouter>
+      </MockedProvider>
     );
 
     expect(screen.getByText(prospect.excerpt!)).toBeInTheDocument();
@@ -122,12 +136,15 @@ describe('The ExistingProspectCard component', () => {
 
   it('should not render "syndicated" tag for non-syndicated articles', () => {
     render(
-      <MemoryRouter>
-        <ExistingProspectCard
-          item={prospect.approvedCorpusItem!}
-          onSchedule={onSchedule}
-        />
-      </MemoryRouter>
+      <MockedProvider>
+        <MemoryRouter>
+          <ExistingProspectCard
+            item={prospect.approvedCorpusItem!}
+            onSchedule={onSchedule}
+            onDismissProspect={onDismissProspect}
+          />
+        </MemoryRouter>
+      </MockedProvider>
     );
 
     expect(screen.queryByText('Syndicated')).not.toBeInTheDocument();
@@ -138,32 +155,40 @@ describe('The ExistingProspectCard component', () => {
     prospect.approvedCorpusItem!.isSyndicated = true;
 
     render(
-      <MemoryRouter>
-        <ExistingProspectCard
-          item={prospect.approvedCorpusItem!}
-          onSchedule={onSchedule}
-        />
-      </MemoryRouter>
+      <MockedProvider>
+        <MemoryRouter>
+          <ExistingProspectCard
+            item={prospect.approvedCorpusItem!}
+            onSchedule={onSchedule}
+            onDismissProspect={onDismissProspect}
+          />
+        </MemoryRouter>
+      </MockedProvider>
     );
 
     expect(screen.queryByText('Syndicated')).toBeInTheDocument();
   });
 
-  it('should render curated item card with the action button', () => {
+  it('should render curated item card with the action buttons', () => {
     render(
-      <MemoryRouter>
-        <ExistingProspectCard
-          item={prospect.approvedCorpusItem!}
-          onSchedule={onSchedule}
-        />
-      </MemoryRouter>
+      <MockedProvider>
+        <MemoryRouter>
+          <ExistingProspectCard
+            item={prospect.approvedCorpusItem!}
+            onSchedule={onSchedule}
+            onDismissProspect={onDismissProspect}
+          />
+        </MemoryRouter>
+      </MockedProvider>
     );
 
     const scheduleButton = screen.getByRole('button', {
       name: /Schedule/i,
     });
+    const dismissProspectButton = screen.getByTestId('dismissButton');
 
     expect(scheduleButton).toBeInTheDocument();
+    expect(dismissProspectButton).toBeInTheDocument();
   });
 
   it('should render schedule history component', async () => {
@@ -190,12 +215,15 @@ describe('The ExistingProspectCard component', () => {
     };
 
     render(
-      <MemoryRouter>
-        <ExistingProspectCard
-          item={prospectWithScheduleHistory.approvedCorpusItem}
-          onSchedule={onSchedule}
-        />
-      </MemoryRouter>
+      <MockedProvider>
+        <MemoryRouter>
+          <ExistingProspectCard
+            item={prospectWithScheduleHistory.approvedCorpusItem!}
+            onSchedule={onSchedule}
+            onDismissProspect={onDismissProspect}
+          />
+        </MemoryRouter>
+      </MockedProvider>
     );
 
     // the button when clicked shows us the recent scheduled runs

--- a/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.tsx
+++ b/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.tsx
@@ -101,11 +101,12 @@ export const ExistingProspectCard: React.FC<ExistingProspectCardProps> = (
               </Link>
             </Grid>
             <Grid item xs={1}>
-              {/*TODO @Herraj the non-null assertion from the prospectId below */}
-              <DismissProspectAction
-                onDismissProspect={onDismissProspect}
-                prospectId={item.prospectId!}
-              />
+              {item.prospectId && (
+                <DismissProspectAction
+                  onDismissProspect={onDismissProspect}
+                  prospectId={item.prospectId}
+                />
+              )}
             </Grid>
           </Grid>
           <Typography

--- a/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.tsx
+++ b/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.tsx
@@ -33,10 +33,18 @@ interface ExistingProspectCardProps {
    */
   item: ApprovedCorpusItem;
 
+  /**
+   * Current Prospect id associated with this item from prospect-api.
+   */
+  prospectId: string;
+
+  /**
+   * Function called when the scheduled button is clicked.
+   */
   onSchedule: VoidFunction;
 
   /**
-   * Function called when the dismiss (cross) button is clicked
+   * Function called when the dismiss (cross) button is clicked.
    */
   onDismissProspect: (prospectId: string, errorMessage?: string) => void;
 }
@@ -52,7 +60,7 @@ export const ExistingProspectCard: React.FC<ExistingProspectCardProps> = (
   props
 ): JSX.Element => {
   const classes = useStyles();
-  const { item, onSchedule, onDismissProspect } = props;
+  const { item, onSchedule, onDismissProspect, prospectId } = props;
   const showScheduleHistory = item.scheduledSurfaceHistory.length != 0;
 
   return (
@@ -101,13 +109,10 @@ export const ExistingProspectCard: React.FC<ExistingProspectCardProps> = (
               </Link>
             </Grid>
             <Grid item xs={1}>
-              {/*TODO This is a temporary measure. We need to implement a better solution regarding manually added items showing up again on the prospecting page */}
-              {item.prospectId && (
-                <DismissProspectAction
-                  onDismissProspect={onDismissProspect}
-                  prospectId={item.prospectId}
-                />
-              )}
+              <DismissProspectAction
+                onDismissProspect={onDismissProspect}
+                prospectId={prospectId}
+              />
             </Grid>
           </Grid>
           <Typography

--- a/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.tsx
+++ b/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.tsx
@@ -25,6 +25,7 @@ import { Button } from '../../../_shared/components';
 import { getCuratorNameFromLdap } from '../../helpers/helperFunctions';
 import { ScheduleHistory } from '../ScheduleHistory/ScheduleHistory';
 import { getDisplayTopic } from '../../helpers/topics';
+import { DismissProspectAction } from '../actions/DismissProspectAction/DismissProspectAction';
 
 interface ExistingProspectCardProps {
   /**
@@ -33,6 +34,11 @@ interface ExistingProspectCardProps {
   item: ApprovedCorpusItem;
 
   onSchedule: VoidFunction;
+
+  /**
+   * Function called when the dismiss (cross) button is clicked
+   */
+  onDismissProspect: (prospectId: string, errorMessage?: string) => void;
 }
 
 /**
@@ -46,7 +52,7 @@ export const ExistingProspectCard: React.FC<ExistingProspectCardProps> = (
   props
 ): JSX.Element => {
   const classes = useStyles();
-  const { item, onSchedule } = props;
+  const { item, onSchedule, onDismissProspect } = props;
   const showScheduleHistory = item.scheduledSurfaceHistory.length != 0;
 
   return (
@@ -81,16 +87,27 @@ export const ExistingProspectCard: React.FC<ExistingProspectCardProps> = (
           </List>
         </Grid>
         <Grid item xs={12} sm={9}>
-          <Link href={item.url} target="_blank" className={classes.link}>
-            <Typography
-              className={classes.title}
-              variant="h3"
-              align="left"
-              gutterBottom
-            >
-              {item.title}
-            </Typography>
-          </Link>
+          <Grid container>
+            <Grid item xs={11}>
+              <Link href={item.url} target="_blank" className={classes.link}>
+                <Typography
+                  className={classes.title}
+                  variant="h3"
+                  align="left"
+                  gutterBottom
+                >
+                  {item.title}
+                </Typography>
+              </Link>
+            </Grid>
+            <Grid xs={1}>
+              {/*TODO @Herraj the non-null assertion from the prospectId below */}
+              <DismissProspectAction
+                onDismissProspect={onDismissProspect}
+                prospectId={item.prospectId!}
+              />
+            </Grid>
+          </Grid>
           <Typography
             className={classes.subtitle}
             variant="subtitle2"

--- a/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.tsx
+++ b/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.tsx
@@ -101,6 +101,7 @@ export const ExistingProspectCard: React.FC<ExistingProspectCardProps> = (
               </Link>
             </Grid>
             <Grid item xs={1}>
+              {/*TODO This is a temporary measure. We need to implement a better solution regarding manually added items showing up again on the prospecting page */}
               {item.prospectId && (
                 <DismissProspectAction
                   onDismissProspect={onDismissProspect}

--- a/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.tsx
+++ b/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.tsx
@@ -34,7 +34,7 @@ interface ExistingProspectCardProps {
   item: ApprovedCorpusItem;
 
   /**
-   * Current Prospect id associated with this item from prospect-api.
+   * This is the prospect.id and NOT prospect.prospectId
    */
   prospectId: string;
 

--- a/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.tsx
+++ b/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.tsx
@@ -100,7 +100,7 @@ export const ExistingProspectCard: React.FC<ExistingProspectCardProps> = (
                 </Typography>
               </Link>
             </Grid>
-            <Grid xs={1}>
+            <Grid item xs={1}>
               {/*TODO @Herraj the non-null assertion from the prospectId below */}
               <DismissProspectAction
                 onDismissProspect={onDismissProspect}

--- a/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
+++ b/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
@@ -23,7 +23,6 @@ import CheckCircleOutlineIcon from '@material-ui/icons/CheckCircleOutline';
 import { DismissProspectAction } from '../actions/DismissProspectAction/DismissProspectAction';
 import CategoryIcon from '@material-ui/icons/Category';
 
-
 interface ProspectListCardProps {
   /**
    * An object with everything prospect-related in it.

--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -727,6 +727,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
                   <ExistingProspectCard
                     key={prospect.id}
                     item={prospect.approvedCorpusItem}
+                    prospectId={prospect.prospectId}
                     onSchedule={() => {
                       setCurrentProspect(prospect);
                       setApprovedItem(prospect.approvedCorpusItem!);

--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -727,7 +727,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
                   <ExistingProspectCard
                     key={prospect.id}
                     item={prospect.approvedCorpusItem}
-                    prospectId={prospect.prospectId}
+                    prospectId={prospect.id}
                     onSchedule={() => {
                       setCurrentProspect(prospect);
                       setApprovedItem(prospect.approvedCorpusItem!);

--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -732,6 +732,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
                       setApprovedItem(prospect.approvedCorpusItem!);
                       toggleScheduleModalAndDisableScheduledSurface();
                     }}
+                    onDismissProspect={onDismissProspect}
                   />
                 );
               }


### PR DESCRIPTION
## Goal

We need to be able to dismiss prospects that are already in corpus.

Tickets:

- [BACK-1691]

[BACK-1691]: https://getpocket.atlassian.net/browse/BACK-1691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ