### PR TITLE
BACK-1690: Adding Labels page

### DIFF
--- a/src/collections/components/LabelListCard/LabelListCard.styles.tsx
+++ b/src/collections/components/LabelListCard/LabelListCard.styles.tsx
@@ -1,0 +1,28 @@
+import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+
+/**
+ * Styles for the LabelListCard component.
+ */
+export const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      margin: 'auto',
+      padding: '1.25rem 0.25rem',
+      border: 0,
+      borderBottom: `1px solid ${theme.palette.grey[300]}`,
+      cursor: 'pointer',
+      '&:active': {
+        backgroundColor: theme.palette.grey[300],
+      },
+    },
+    title: {
+      fontSize: '1.25rem',
+      fontWeight: 500,
+    },
+    [theme.breakpoints.down('sm')]: {
+      title: {
+        fontSize: '1rem',
+      },
+    },
+  })
+);

--- a/src/collections/components/LabelListCard/LabelListCard.test.tsx
+++ b/src/collections/components/LabelListCard/LabelListCard.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Router } from 'react-router-dom';
+import { LabelListCard } from './LabelListCard';
+import { Label } from '../../../api/generatedTypes';
+import { MockedProvider } from '@apollo/client/testing';
+import userEvent from '@testing-library/user-event';
+import { createMemoryHistory } from 'history';
+
+describe('The LabelListCard component', () => {
+  let label: Label;
+
+  beforeEach(() => {
+    label = {
+      externalId: '124abc',
+      name: 'region-east-africa',
+    };
+  });
+
+  it('shows label name', () => {
+    render(
+      <MemoryRouter>
+        <LabelListCard label={label} />
+      </MemoryRouter>
+    );
+
+    const name = screen.getByText(/region-east-africa/i);
+    expect(name).toBeInTheDocument();
+  });
+});

--- a/src/collections/components/LabelListCard/LabelListCard.tsx
+++ b/src/collections/components/LabelListCard/LabelListCard.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Card, Grid, Typography } from '@material-ui/core';
+import { useStyles } from './LabelListCard.styles';
+import { Label } from '../../../api/generatedTypes';
+
+interface LabelListCardProps {
+  /**
+   * An object with everything label-related in it.
+   */
+  label: Label;
+}
+
+/**
+ * A compact card that displays label name.
+ *
+ * @param props
+ */
+export const LabelListCard: React.FC<LabelListCardProps> = (props) => {
+  const classes = useStyles();
+  const { label } = props;
+  return (
+    <Card variant="outlined" square className={classes.root}>
+      <Grid container spacing={2}>
+        <Grid item xs={8} sm={10}>
+          <Typography
+            className={classes.title}
+            variant="h3"
+            align="left"
+            gutterBottom
+          >
+            {label.name}
+          </Typography>
+        </Grid>
+      </Grid>
+    </Card>
+  );
+};

--- a/src/collections/components/index.ts
+++ b/src/collections/components/index.ts
@@ -9,6 +9,7 @@ export { CollectionPartnerAssociationInfo } from './CollectionPartnerAssociation
 export { CollectionSearchForm } from './CollectionSearchForm/CollectionSearchForm';
 export { FileUploadInfo } from './FileUploadInfo/FileUploadInfo';
 export { ImageUpload } from './ImageUpload/ImageUpload';
+export { LabelListCard } from './LabelListCard/LabelListCard';
 export { PartnerForm } from './PartnerForm/PartnerForm';
 export { PartnerInfo } from './PartnerInfo/PartnerInfo';
 export { PartnerListCard } from './PartnerListCard/PartnerListCard';

--- a/src/collections/pages/CollectionsLandingPage/CollectionsLandingPage.tsx
+++ b/src/collections/pages/CollectionsLandingPage/CollectionsLandingPage.tsx
@@ -20,6 +20,7 @@ import {
   CollectionPage,
   CollectionSearchPage,
   CollectionsHomePage,
+  LabelListPage,
   PartnerListPage,
   PartnerPage,
 } from '../';
@@ -39,6 +40,10 @@ export const CollectionsLandingPage = (): JSX.Element => {
     {
       text: 'Authors',
       url: `${path}/authors/`,
+    },
+    {
+      text: 'Labels',
+      url: `${path}/labels/`,
     },
     {
       text: 'Partners',
@@ -81,6 +86,9 @@ export const CollectionsLandingPage = (): JSX.Element => {
           </Route>
           <Route exact path={`${path}/collections/:id/`}>
             <CollectionPage />
+          </Route>
+          <Route exact path={`${path}/labels/`}>
+            <LabelListPage />
           </Route>
           <Route exact path={`${path}/partners/`}>
             <PartnerListPage />

--- a/src/collections/pages/LabelListPage/LabelListPage.tsx
+++ b/src/collections/pages/LabelListPage/LabelListPage.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Box } from '@material-ui/core';
+import { Button, HandleApiResponse } from '../../../_shared/components';
+import { LabelListCard } from '../../components';
+import { Label, useLabelsQuery } from '../../../api/generatedTypes';
+
+/**
+ * Label List Page
+ */
+export const LabelListPage = (): JSX.Element => {
+  const { loading, error, data } = useLabelsQuery({});
+
+  return (
+    <>
+      <Box display="flex">
+        <Box flexGrow={1} alignSelf="center">
+          <h1>Labels</h1>
+        </Box>
+        <Box alignSelf="center">
+          <Button
+            component={Link}
+            to="/collections/labels/add/"
+            buttonType="hollow"
+          >
+            Add label
+          </Button>
+        </Box>
+      </Box>
+      {!data && <HandleApiResponse loading={loading} error={error} />}
+
+      {data &&
+        data.labels.map((label: Label) => {
+          return <LabelListCard key={label.externalId} label={label} />;
+        })}
+    </>
+  );
+};

--- a/src/collections/pages/index.ts
+++ b/src/collections/pages/index.ts
@@ -10,6 +10,8 @@ export { CollectionPage } from './CollectionPage/CollectionPage';
 export { CollectionSearchPage } from './CollectionSearchPage/CollectionSearchPage';
 export { AddCollectionPage } from './AddCollectionPage/AddCollectionPage';
 
+export { LabelListPage } from './LabelListPage/LabelListPage';
+
 export { PartnerListPage } from './PartnerListPage/PartnerListPage';
 export { PartnerPage } from './PartnerPage/PartnerPage';
 export { AddPartnerPage } from './AddPartnerPage/AddPartnerPage';

--- a/src/curated-corpus/components/actions/ScheduleCorpusItemAction/ScheduleCorpusItemAction.test.tsx
+++ b/src/curated-corpus/components/actions/ScheduleCorpusItemAction/ScheduleCorpusItemAction.test.tsx
@@ -44,7 +44,16 @@ describe('The ScheduleCorpusItemAction', () => {
   });
 
   it('completes the action successfully', async () => {
-    const today = DateTime.local();
+    // When running the test case on the last day of a month,
+    // MUI date picker also grabs a few previous dates which are marked
+    // as hidden and disabled.
+    // The current date is not disabled, but it
+    // is marked as hidden, hence, MUI complains that it doesn't have a
+    // pointer event set on the hidden date.
+    // The solution is to add an extra day to ensure that MUI does not fetch
+    // the days from a previous month when running the test case on the
+    // last day of a month.
+    const today = DateTime.local().plus({ days: 1 });
 
     mocks = [
       mock_AllScheduledSurfaces,

--- a/src/curated-corpus/helpers/helperFunctions.test.ts
+++ b/src/curated-corpus/helpers/helperFunctions.test.ts
@@ -138,7 +138,7 @@ describe('helperFunctions ', () => {
     });
   });
 
-  describe('downloadAndUploadApprovedItemImageToS3 function', async () => {
+  describe('downloadAndUploadApprovedItemImageToS3 function', () => {
     const testMutationResponseData = {
       data: { uploadApprovedCorpusItemImage: { url: 's3-test-image-url' } },
     };


### PR DESCRIPTION
## Goal

* Adding a labels page to display non-paginated list of available labels. Only label names are displayed. 
* `Add Label` button does not function yet. This functionality will be implemented in another PR.

Tickets:

- [https://getpocket.atlassian.net/browse/BACK-1690](https://getpocket.atlassian.net/browse/BACK-1690)

Video


https://user-images.githubusercontent.com/16909783/204396720-8c70eb1a-1b66-4886-afbc-a32db03e6468.mov

