### PR TITLE
feat(mui): [BACK-1720] MUI 5 Upgrade: Transition Collection Search, home and landing pages

### DIFF
--- a/src/_shared/components/HandleApiResponse/HandleApiResponse.tsx
+++ b/src/_shared/components/HandleApiResponse/HandleApiResponse.tsx
@@ -1,29 +1,14 @@
 import React, { useState } from 'react';
 import { ApolloError } from '@apollo/client';
-import { makeStyles } from '@material-ui/core/styles';
 import {
+  Alert,
   Box,
   CircularProgress,
   Collapse,
   Grow,
   IconButton,
-} from '@material-ui/core';
-import { Alert } from '@material-ui/lab';
-import CloseIcon from '@material-ui/icons/Close';
-
-/**
- * Styles for the error message alert.
- */
-const useStyles = makeStyles(() => ({
-  root: {
-    fontWeight: 400,
-    fontSize: '0.875rem',
-  },
-  title: {
-    fontWeight: 400,
-    fontSize: '1.125rem',
-  },
-}));
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
 
 interface HandleApiResponseProps {
   /**
@@ -57,8 +42,6 @@ interface HandleApiResponseProps {
 export const HandleApiResponse: React.FC<HandleApiResponseProps> = (
   props
 ): JSX.Element | null => {
-  const classes = useStyles();
-
   const [isErrorVisible, setIsErrorVisible] = useState(true);
 
   const { loading, error, errorIsDismissible = true, loadingText = '' } = props;
@@ -122,7 +105,7 @@ export const HandleApiResponse: React.FC<HandleApiResponseProps> = (
             }
             severity="error"
             variant="filled"
-            className={classes.root}
+            sx={{ fontWeight: 400, fontSize: '0.875rem' }}
           >
             {messages}
           </Alert>

--- a/src/collections/pages/CollectionSearchPage/CollectionSearchPage.tsx
+++ b/src/collections/pages/CollectionSearchPage/CollectionSearchPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Paper } from '@material-ui/core';
+import { Box, Paper } from '@mui/material';
 import { FormikValues } from 'formik';
 import { HandleApiResponse, ScrollToTop } from '../../../_shared/components';
 import { CollectionListCard, CollectionSearchForm } from '../../components';

--- a/src/collections/pages/CollectionsHomePage/CollectionsHomePage.tsx
+++ b/src/collections/pages/CollectionsHomePage/CollectionsHomePage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Box, Button } from '@material-ui/core';
+import { Box, Button } from '@mui/material';
 import {
   Collection,
   CollectionStatus,


### PR DESCRIPTION
## Goal

Transition all Collections code to MUI 5 except for Collection & Collection List pages which will be tackled in the next ticket.

- Minimal updates required here, so upgraded one of the shared components alongside the pages: `HandleApiResponse`.

## Reference

https://getpocket.atlassian.net/browse/BACK-1720