### PR TITLE
chore(husky): fix incorrect file extension for aws folder lint check

### DIFF
--- a/.aws/package.json
+++ b/.aws/package.json
@@ -8,7 +8,7 @@
     "build:dev": "rm -rf dist && NODE_ENV=development npm run synth",
     "synth": "cdktf synth",
     "compile": "tsc --pretty",
-    "lint-fix": "tsc --noEmit && eslint src/**/*.ts{,x} --fix",
+    "lint-fix": "tsc --noEmit && eslint src/**/*.ts --fix",
     "watch": "tsc -w"
   },
   "dependencies": {


### PR DESCRIPTION
## Goal

 fix incorrect file extension for aws folder lint check

Tickets:

- [chore ticket](https://getpocket.atlassian.net/browse/BACK-1725)

[BACK-1725]: https://getpocket.atlassian.net/browse/BACK-1725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ