### PR TITLE
feat(mui5): [BACK-1757] Transition Corpus Item page to MUI 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@material-ui/lab": "4.0.0-alpha.61",
         "@material-ui/pickers": "3.3.10",
         "@mui/icons-material": "^5.10.15",
-        "@mui/lab": "^5.0.0-alpha.109",
         "@mui/material": "^5.10.15",
         "@mui/styles": "^5.10.15",
         "@mui/x-date-pickers": "^5.0.9",
@@ -3820,52 +3819,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@mui/lab": {
-      "version": "5.0.0-alpha.109",
-      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.109.tgz",
-      "integrity": "sha512-9ZyzM4AHA1qWh48ZcvqxqwWRH1CzBhQuP9VYP2eEprEjEeraiuvvsZILCNhCemc9WWN04GJh8UiD1FeCaU4kWg==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@mui/base": "5.0.0-alpha.107",
-        "@mui/system": "^5.10.15",
-        "@mui/types": "^7.2.1",
-        "@mui/utils": "^5.10.15",
-        "clsx": "^1.2.1",
-        "prop-types": "^15.8.1",
-        "react-is": "^18.2.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@mui/material": "^5.0.0",
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/lab/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/@mui/material": {
       "version": "5.10.15",
@@ -29432,28 +29385,6 @@
       "integrity": "sha512-fXkz7CtYTt4AH4YYT67VFhM/A3YCUqZGGLp/3BlzRPQRNEfFKknw3MgG1S5UYrY5weti8jxMx3mwwfhVP8OMhQ==",
       "requires": {
         "@babel/runtime": "^7.20.1"
-      }
-    },
-    "@mui/lab": {
-      "version": "5.0.0-alpha.109",
-      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.109.tgz",
-      "integrity": "sha512-9ZyzM4AHA1qWh48ZcvqxqwWRH1CzBhQuP9VYP2eEprEjEeraiuvvsZILCNhCemc9WWN04GJh8UiD1FeCaU4kWg==",
-      "requires": {
-        "@babel/runtime": "^7.20.1",
-        "@mui/base": "5.0.0-alpha.107",
-        "@mui/system": "^5.10.15",
-        "@mui/types": "^7.2.1",
-        "@mui/utils": "^5.10.15",
-        "clsx": "^1.2.1",
-        "prop-types": "^15.8.1",
-        "react-is": "^18.2.0"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
-        }
       }
     },
     "@mui/material": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@material-ui/lab": "4.0.0-alpha.61",
     "@material-ui/pickers": "3.3.10",
     "@mui/icons-material": "^5.10.15",
-    "@mui/lab": "^5.0.0-alpha.109",
     "@mui/material": "^5.10.15",
     "@mui/styles": "^5.10.15",
     "@mui/x-date-pickers": "^5.0.9",

--- a/src/collections/components/CollectionForm/CollectionForm.test.tsx
+++ b/src/collections/components/CollectionForm/CollectionForm.test.tsx
@@ -21,6 +21,9 @@ describe('The CollectionForm component', () => {
   let languages: CollectionLanguage[];
   const handleSubmit = jest.fn();
 
+  // This test suite occasionally takes forever to run on a local machine
+  jest.setTimeout(10000);
+
   beforeEach(() => {
     collection = {
       externalId: '124abc',

--- a/src/curated-corpus/components/ApprovedItemCurationHistory/ApprovedItemCurationHistory.tsx
+++ b/src/curated-corpus/components/ApprovedItemCurationHistory/ApprovedItemCurationHistory.tsx
@@ -7,9 +7,9 @@ import {
   ListItemIcon,
   ListItemText,
   Typography,
-} from '@material-ui/core';
-import FaceIcon from '@material-ui/icons/Face';
-import ThumbUpIcon from '@material-ui/icons/ThumbUp';
+} from '@mui/material';
+import FaceIcon from '@mui/icons-material/Face';
+import ThumbUpIcon from '@mui/icons-material/ThumbUp';
 import { getCuratorNameFromLdap } from '../../helpers/helperFunctions';
 import { DateTime } from 'luxon';
 

--- a/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.tsx
+++ b/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.tsx
@@ -1,4 +1,13 @@
 import React from 'react';
+import {
+  Box,
+  FormControlLabel,
+  FormHelperText,
+  Grid,
+  LinearProgress,
+  Switch,
+  TextField,
+} from '@mui/material';
 import { FormikHelpers, FormikValues, useFormik } from 'formik';
 import { validationSchema } from './ApprovedItemForm.validation';
 import { ApprovedCorpusItem, CuratedStatus } from '../../../api/generatedTypes';
@@ -9,15 +18,6 @@ import {
   languages,
   topics,
 } from '../../helpers/definitions';
-import {
-  Box,
-  FormControlLabel,
-  FormHelperText,
-  Grid,
-  LinearProgress,
-  Switch,
-  TextField,
-} from '@material-ui/core';
 import {
   FormikSelectField,
   FormikTextField,

--- a/src/curated-corpus/components/ApprovedItemInfo/ApprovedItemInfo.tsx
+++ b/src/curated-corpus/components/ApprovedItemInfo/ApprovedItemInfo.tsx
@@ -10,7 +10,7 @@ import {
   TableContainer,
   TableRow,
   Typography,
-} from '@material-ui/core';
+} from '@mui/material';
 import { flattenAuthors } from '../../../_shared/utils/flattenAuthors';
 import { getDisplayTopic } from '../../helpers/topics';
 

--- a/src/curated-corpus/components/ApprovedItemModal/ApprovedItemModal.tsx
+++ b/src/curated-corpus/components/ApprovedItemModal/ApprovedItemModal.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { Modal } from '../../../_shared/components';
-import { Box, Grid, Typography } from '@material-ui/core';
-import { ApprovedCorpusItem } from '../../../api/generatedTypes';
+import { Box, Grid, Typography } from '@mui/material';
 import { FormikValues } from 'formik';
 import { FormikHelpers } from 'formik/dist/types';
+import { ApprovedCorpusItem } from '../../../api/generatedTypes';
+import { Modal } from '../../../_shared/components';
 import { ApprovedItemForm } from '../ApprovedItemForm/ApprovedItemForm';
 import { ApprovedItemFromProspect } from '../../helpers/definitions';
 

--- a/src/curated-corpus/components/RejectItemForm/RejectItemForm.tsx
+++ b/src/curated-corpus/components/RejectItemForm/RejectItemForm.tsx
@@ -8,7 +8,7 @@ import {
   FormHelperText,
   Grid,
   LinearProgress,
-} from '@material-ui/core';
+} from '@mui/material';
 import {
   SharedFormButtons,
   SharedFormButtonsProps,

--- a/src/curated-corpus/components/RejectItemModal/RejectItemModal.tsx
+++ b/src/curated-corpus/components/RejectItemModal/RejectItemModal.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { Modal } from '../../../_shared/components';
-import { Box, Grid, Typography } from '@material-ui/core';
+import { Box, Grid, Typography } from '@mui/material';
 import { FormikValues } from 'formik';
 import { FormikHelpers } from 'formik/dist/types';
 import { ApprovedCorpusItem, Prospect } from '../../../api/generatedTypes';
-import { RejectItemForm } from '../RejectItemForm/RejectItemForm';
+import { Modal } from '../../../_shared/components';
+import { RejectItemForm } from '../';
 
 interface RejectProspectModalProps {
   prospect: Prospect | ApprovedCorpusItem;

--- a/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.test.tsx
+++ b/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.test.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import LuxonUtils from '@date-io/luxon';
-import { MuiPickersUtilsProvider } from '@material-ui/pickers';
+import { DateTime } from 'luxon';
 import { render, screen } from '@testing-library/react';
 import { ScheduleItemForm } from './ScheduleItemForm';
 import { ProspectType, ScheduledSurface } from '../../../api/generatedTypes';
-import { DateTime } from 'luxon';
 
 describe('The ScheduleItemForm component', () => {
   const handleSubmit = jest.fn();
@@ -31,16 +29,14 @@ describe('The ScheduleItemForm component', () => {
 
   it('renders successfully', () => {
     render(
-      <MuiPickersUtilsProvider utils={LuxonUtils}>
-        <ScheduleItemForm
-          handleDateChange={jest.fn()}
-          lookupCopy=""
-          selectedDate={DateTime.local()}
-          onSubmit={handleSubmit}
-          scheduledSurfaces={scheduledSurfaces}
-          approvedItemExternalId={'123abc'}
-        />
-      </MuiPickersUtilsProvider>
+      <ScheduleItemForm
+        handleDateChange={jest.fn()}
+        lookupCopy=""
+        selectedDate={DateTime.local()}
+        onSubmit={handleSubmit}
+        scheduledSurfaces={scheduledSurfaces}
+        approvedItemExternalId={'123abc'}
+      />
     );
 
     // there is at least a form and nothing falls over
@@ -48,38 +44,35 @@ describe('The ScheduleItemForm component', () => {
     expect(form).toBeInTheDocument();
   });
 
-  it('has two buttons', () => {
+  it('has three buttons', () => {
     render(
-      <MuiPickersUtilsProvider utils={LuxonUtils}>
-        <ScheduleItemForm
-          handleDateChange={jest.fn()}
-          lookupCopy=""
-          selectedDate={DateTime.local()}
-          onSubmit={handleSubmit}
-          scheduledSurfaces={scheduledSurfaces}
-          approvedItemExternalId={'123abc'}
-        />
-      </MuiPickersUtilsProvider>
+      <ScheduleItemForm
+        handleDateChange={jest.fn()}
+        lookupCopy=""
+        selectedDate={DateTime.local()}
+        onSubmit={handleSubmit}
+        scheduledSurfaces={scheduledSurfaces}
+        approvedItemExternalId={'123abc'}
+      />
     );
 
     const buttons = screen.getAllByRole('button');
-    // "Save" and "Cancel" buttons.
-    expect(buttons).toHaveLength(2);
+    // "Save" and "Cancel" buttons, plus the "DatePicker"
+    // button in the far right of the date picker field
+    expect(buttons).toHaveLength(3);
   });
 
   it('does not pre-select a scheduled surface if none was passed in and the user has access to many', () => {
     render(
-      <MuiPickersUtilsProvider utils={LuxonUtils}>
-        <ScheduleItemForm
-          data-testId="surface-selector"
-          handleDateChange={jest.fn()}
-          lookupCopy=""
-          selectedDate={DateTime.local()}
-          onSubmit={handleSubmit}
-          scheduledSurfaces={scheduledSurfaces}
-          approvedItemExternalId={'123abc'}
-        />
-      </MuiPickersUtilsProvider>
+      <ScheduleItemForm
+        data-testId="surface-selector"
+        handleDateChange={jest.fn()}
+        lookupCopy=""
+        selectedDate={DateTime.local()}
+        onSubmit={handleSubmit}
+        scheduledSurfaces={scheduledSurfaces}
+        approvedItemExternalId={'123abc'}
+      />
     );
 
     const select = screen.getByLabelText(
@@ -95,18 +88,16 @@ describe('The ScheduleItemForm component', () => {
 
   it('pre-selects the passed in scheduled surface', () => {
     render(
-      <MuiPickersUtilsProvider utils={LuxonUtils}>
-        <ScheduleItemForm
-          data-testId="surface-selector"
-          handleDateChange={jest.fn()}
-          lookupCopy=""
-          selectedDate={DateTime.local()}
-          onSubmit={handleSubmit}
-          scheduledSurfaces={scheduledSurfaces}
-          scheduledSurfaceGuid="NEW_TAB_EN_US"
-          approvedItemExternalId={'123abc'}
-        />
-      </MuiPickersUtilsProvider>
+      <ScheduleItemForm
+        data-testId="surface-selector"
+        handleDateChange={jest.fn()}
+        lookupCopy=""
+        selectedDate={DateTime.local()}
+        onSubmit={handleSubmit}
+        scheduledSurfaces={scheduledSurfaces}
+        scheduledSurfaceGuid="NEW_TAB_EN_US"
+        approvedItemExternalId={'123abc'}
+      />
     );
 
     const select = screen.getByLabelText(
@@ -123,17 +114,15 @@ describe('The ScheduleItemForm component', () => {
 
   it('pre-selects the only available scheduled surface if none was specified and the user only has access to a single one', () => {
     render(
-      <MuiPickersUtilsProvider utils={LuxonUtils}>
-        <ScheduleItemForm
-          data-testId="surface-selector"
-          handleDateChange={jest.fn()}
-          lookupCopy=""
-          selectedDate={DateTime.local()}
-          onSubmit={handleSubmit}
-          scheduledSurfaces={[scheduledSurfaces[0]]}
-          approvedItemExternalId={'123abc'}
-        />
-      </MuiPickersUtilsProvider>
+      <ScheduleItemForm
+        data-testId="surface-selector"
+        handleDateChange={jest.fn()}
+        lookupCopy=""
+        selectedDate={DateTime.local()}
+        onSubmit={handleSubmit}
+        scheduledSurfaces={[scheduledSurfaces[0]]}
+        approvedItemExternalId={'123abc'}
+      />
     );
 
     const select = screen.getByLabelText(

--- a/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.tsx
+++ b/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.tsx
@@ -1,16 +1,16 @@
 import React, { useEffect } from 'react';
-import { Box, Grid, LinearProgress, TextField } from '@material-ui/core';
+import { Box, Grid, LinearProgress, TextField } from '@mui/material';
 import { FormikHelpers, FormikValues, useFormik } from 'formik';
-import { DatePicker } from '@material-ui/pickers';
+import { DatePicker, LocalizationProvider } from '@mui/x-date-pickers';
+import { DateTime } from 'luxon';
+import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
 import {
   FormikSelectField,
   SharedFormButtons,
   SharedFormButtonsProps,
 } from '../../../_shared/components';
 import { getValidationSchema } from './ScheduleItemForm.validation';
-import { MaterialUiPickersDate } from '@material-ui/pickers/typings/date';
 import { ScheduledSurface } from '../../../api/generatedTypes';
-import { DateTime } from 'luxon';
 
 interface ScheduleItemFormProps {
   /**
@@ -21,10 +21,7 @@ interface ScheduleItemFormProps {
   /**
    * What to do when the user picks a date.
    */
-  handleDateChange: (
-    date: MaterialUiPickersDate,
-    value?: string | null | undefined
-  ) => void;
+  handleDateChange: (date: any, value?: string | null | undefined) => void;
 
   /**
    * The copy/JSX to show underneath the form when the user picks a date
@@ -117,7 +114,7 @@ export const ScheduleItemForm: React.FC<
   });
 
   return (
-    <>
+    <LocalizationProvider dateAdapter={AdapterLuxon}>
       <form name="schedule-item-form" onSubmit={formik.handleSubmit}>
         <Grid container spacing={3}>
           <Grid item xs={12}>
@@ -146,20 +143,21 @@ export const ScheduleItemForm: React.FC<
           </Grid>
           <Grid item xs={12}>
             <DatePicker
-              variant="inline"
-              inputVariant="outlined"
-              format="MMMM d, yyyy"
-              margin="none"
-              id="scheduled-date"
-              label="Choose a date"
+              inputFormat="MMMM d, yyyy"
               value={selectedDate}
               onChange={handleDateChange}
               disablePast
-              initialFocusedDate={tomorrow}
+              openTo="day"
               maxDate={tomorrow.plus({ days: 59 })}
-              disableToolbar
-              autoOk
-              fullWidth
+              renderInput={(params: any) => (
+                <TextField
+                  fullWidth
+                  variant="outlined"
+                  id="scheduled-date"
+                  label="Choose a date"
+                  {...params}
+                />
+              )}
             />
           </Grid>
 
@@ -189,6 +187,6 @@ export const ScheduleItemForm: React.FC<
           </Box>
         </Grid>
       </Grid>
-    </>
+    </LocalizationProvider>
   );
 };

--- a/src/curated-corpus/components/ScheduleItemFormConnector/ScheduleItemFormConnector.test.tsx
+++ b/src/curated-corpus/components/ScheduleItemFormConnector/ScheduleItemFormConnector.test.tsx
@@ -1,18 +1,16 @@
 import React from 'react';
+import { SnackbarProvider } from 'notistack';
+import { DateTime } from 'luxon';
 import { render, screen } from '@testing-library/react';
 import { MockedProvider } from '@apollo/client/testing';
-import { SnackbarProvider } from 'notistack';
+import userEvent from '@testing-library/user-event';
 import { ScheduleItemFormConnector } from './ScheduleItemFormConnector';
-import LuxonUtils from '@date-io/luxon';
-import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 import {
   mock_AllScheduledSurfaces,
   mock_OneScheduledSurface,
   mock_TwoScheduledSurfaces,
 } from '../../integration-test-mocks/getScheduledSurfacesForUser';
-import userEvent from '@testing-library/user-event';
 import { mock_ScheduledItemCountsZero } from '../../integration-test-mocks/getScheduledItemCounts';
-// import { DateTime } from 'luxon';
 
 describe('ScheduleItemFormConnector', () => {
   let mocks = [];
@@ -23,12 +21,10 @@ describe('ScheduleItemFormConnector', () => {
     render(
       <MockedProvider mocks={mocks}>
         <SnackbarProvider>
-          <MuiPickersUtilsProvider utils={LuxonUtils}>
-            <ScheduleItemFormConnector
-              approvedItemExternalId="dummyId"
-              onSubmit={jest.fn()}
-            />
-          </MuiPickersUtilsProvider>
+          <ScheduleItemFormConnector
+            approvedItemExternalId="dummyId"
+            onSubmit={jest.fn()}
+          />
         </SnackbarProvider>
       </MockedProvider>
     );
@@ -68,12 +64,10 @@ describe('ScheduleItemFormConnector', () => {
     render(
       <MockedProvider mocks={mocks}>
         <SnackbarProvider>
-          <MuiPickersUtilsProvider utils={LuxonUtils}>
-            <ScheduleItemFormConnector
-              approvedItemExternalId="dummyId"
-              onSubmit={jest.fn()}
-            />
-          </MuiPickersUtilsProvider>
+          <ScheduleItemFormConnector
+            approvedItemExternalId="dummyId"
+            onSubmit={jest.fn()}
+          />
         </SnackbarProvider>
       </MockedProvider>
     );
@@ -105,12 +99,10 @@ describe('ScheduleItemFormConnector', () => {
     render(
       <MockedProvider mocks={mocks}>
         <SnackbarProvider>
-          <MuiPickersUtilsProvider utils={LuxonUtils}>
-            <ScheduleItemFormConnector
-              approvedItemExternalId="dummyId"
-              onSubmit={jest.fn()}
-            />
-          </MuiPickersUtilsProvider>
+          <ScheduleItemFormConnector
+            approvedItemExternalId="dummyId"
+            onSubmit={jest.fn()}
+          />
         </SnackbarProvider>
       </MockedProvider>
     );
@@ -140,12 +132,10 @@ describe('ScheduleItemFormConnector', () => {
     render(
       <MockedProvider mocks={mocks}>
         <SnackbarProvider>
-          <MuiPickersUtilsProvider utils={LuxonUtils}>
-            <ScheduleItemFormConnector
-              approvedItemExternalId="dummyId"
-              onSubmit={jest.fn()}
-            />
-          </MuiPickersUtilsProvider>
+          <ScheduleItemFormConnector
+            approvedItemExternalId="dummyId"
+            onSubmit={jest.fn()}
+          />
         </SnackbarProvider>
       </MockedProvider>
     );
@@ -162,28 +152,26 @@ describe('ScheduleItemFormConnector', () => {
     // Select a scheduled surface
     userEvent.selectOptions(surfaceSelect, 'POCKET_HITS_EN_US');
 
-    // const today = DateTime.local();
-
-    const datePicker = screen.getByRole('textbox', {
-      name: 'Choose a date',
+    const datePicker = screen.getByRole('button', {
+      name: /choose date/i,
     }) as HTMLInputElement;
 
     // Click on the date field to bring up the calendar
     userEvent.click(datePicker);
 
-    // Find today's date on the monthly calendar (it's actually a button)
-    // const dates = screen.getAllByRole('button', {
-    //   name: today.toFormat('d'),
-    // });
+    // Find today's date on the monthly calendar (in MUI 5, it's a grid cell)
+    const today = DateTime.local();
+    const todaysDate = screen.getAllByRole('gridcell', {
+      name: today.toFormat('d'),
+    })[0];
 
-    // Click on the date to fire off the query to look up "already scheduled for this day" counts.
-    // It's the second "date" pretend button, as the first one is actually hidden from view.
-    // Note: doesn't work! ...and is super flaky!
-    //userEvent.click(dates[1]);
+    // Choose it
+    userEvent.click(todaysDate);
 
     // TODO:
-    //  - ????
-    //  - Profit!!!
+    //  - wait for the API call to go through
+    //  - Assert that the copy with the number of items already scheduled
+    //  appears on the screen
   });
 
   // TODO: More tests:

--- a/src/curated-corpus/components/ScheduleItemFormConnector/ScheduleItemFormConnector.tsx
+++ b/src/curated-corpus/components/ScheduleItemFormConnector/ScheduleItemFormConnector.tsx
@@ -1,6 +1,8 @@
-import { ScheduleItemForm } from '../ScheduleItemForm/ScheduleItemForm';
 import React, { useEffect, useState } from 'react';
+import { ApolloError } from '@apollo/client';
 import { FormikHelpers, FormikValues } from 'formik';
+import { DateTime } from 'luxon';
+import { CircularProgress } from '@mui/material';
 import {
   HandleApiResponse,
   SharedFormButtonsProps,
@@ -10,11 +12,9 @@ import {
   useGetScheduledItemCountsLazyQuery,
   useGetScheduledSurfacesForUserQuery,
 } from '../../../api/generatedTypes';
-import { DateTime } from 'luxon';
 import { MaterialUiPickersDate } from '@material-ui/pickers/typings/date';
-import { ApolloError } from '@apollo/client';
 import { useNotifications } from '../../../_shared/hooks';
-import { CircularProgress } from '@material-ui/core';
+import { ScheduleItemForm } from '../';
 
 interface ScheduleItemFormConnectorProps {
   /**

--- a/src/curated-corpus/components/ScheduleItemModal/ScheduleItemModal.tsx
+++ b/src/curated-corpus/components/ScheduleItemModal/ScheduleItemModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FormikValues } from 'formik';
 import { FormikHelpers } from 'formik/dist/types';
-import { Box, Grid, Typography } from '@material-ui/core';
+import { Box, Grid, Typography } from '@mui/material';
 import { ApprovedCorpusItem } from '../../../api/generatedTypes';
 import { Modal } from '../../../_shared/components';
 import { ScheduleItemFormConnector } from '../';

--- a/src/curated-corpus/components/actions/EditCorpusItemAction/EditCorpusItemAction.tsx
+++ b/src/curated-corpus/components/actions/EditCorpusItemAction/EditCorpusItemAction.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { useRunMutation } from '../../../../_shared/hooks';
+import { FormikHelpers, FormikValues } from 'formik';
 import {
   ApprovedCorpusItem,
   useUpdateApprovedCorpusItemMutation,
 } from '../../../../api/generatedTypes';
-import { FormikHelpers, FormikValues } from 'formik';
-import { ApprovedItemModal } from '../../ApprovedItemModal/ApprovedItemModal';
+import { useRunMutation } from '../../../../_shared/hooks';
 import { transformAuthors } from '../../../../_shared/utils/transformAuthors';
+import { ApprovedItemModal } from '../../';
 
 interface EditCorpusItemActionProps {
   /**

--- a/src/curated-corpus/components/actions/RejectCorpusItemAction/RejectCorpusItemAction.tsx
+++ b/src/curated-corpus/components/actions/RejectCorpusItemAction/RejectCorpusItemAction.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { useRunMutation } from '../../../../_shared/hooks';
+import { FormikHelpers, FormikValues } from 'formik';
 import {
   ApprovedCorpusItem,
   useRejectApprovedItemMutation,
 } from '../../../../api/generatedTypes';
-import { FormikHelpers, FormikValues } from 'formik';
-import { RejectItemModal } from '../../RejectItemModal/RejectItemModal';
+import { useRunMutation } from '../../../../_shared/hooks';
+import { RejectItemModal } from '../../';
 
 interface RejectCorpusItemActionProps {
   /**

--- a/src/curated-corpus/components/actions/ScheduleCorpusItemAction/ScheduleCorpusItemAction.test.tsx
+++ b/src/curated-corpus/components/actions/ScheduleCorpusItemAction/ScheduleCorpusItemAction.test.tsx
@@ -3,9 +3,6 @@ import { MockedProvider, MockedResponse } from '@apollo/client/testing';
 import { render, screen } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
 import userEvent from '@testing-library/user-event';
-import LuxonUtils from '@date-io/luxon';
-import { MuiPickersUtilsProvider } from '@material-ui/pickers';
-
 import { getTestApprovedItem } from '../../../helpers/approvedItem';
 import { successMock } from '../../../integration-test-mocks/createScheduledCorpusItem';
 import { apolloCache } from '../../../../api/client';
@@ -16,6 +13,9 @@ import { DateTime } from 'luxon';
 describe('The ScheduleCorpusItemAction', () => {
   let mocks: MockedResponse[] = [];
 
+  // This test suite occasionally takes forever to run on a local machine
+  jest.setTimeout(10000);
+
   it('renders the modal and form', async () => {
     // This first mock is needed for the form to load
     mocks = [mock_AllScheduledSurfaces];
@@ -23,13 +23,11 @@ describe('The ScheduleCorpusItemAction', () => {
     render(
       <MockedProvider mocks={mocks} cache={apolloCache}>
         <SnackbarProvider maxSnack={3}>
-          <MuiPickersUtilsProvider utils={LuxonUtils}>
-            <ScheduleCorpusItemAction
-              item={getTestApprovedItem()}
-              toggleModal={jest.fn()}
-              modalOpen={true}
-            />
-          </MuiPickersUtilsProvider>
+          <ScheduleCorpusItemAction
+            item={getTestApprovedItem()}
+            toggleModal={jest.fn()}
+            modalOpen={true}
+          />
         </SnackbarProvider>
       </MockedProvider>
     );
@@ -54,13 +52,11 @@ describe('The ScheduleCorpusItemAction', () => {
     render(
       <MockedProvider mocks={mocks} cache={apolloCache}>
         <SnackbarProvider maxSnack={3}>
-          <MuiPickersUtilsProvider utils={LuxonUtils}>
-            <ScheduleCorpusItemAction
-              item={getTestApprovedItem()}
-              toggleModal={jest.fn()}
-              modalOpen={true}
-            />
-          </MuiPickersUtilsProvider>
+          <ScheduleCorpusItemAction
+            item={getTestApprovedItem()}
+            toggleModal={jest.fn()}
+            modalOpen={true}
+          />
         </SnackbarProvider>
       </MockedProvider>
     );
@@ -77,20 +73,20 @@ describe('The ScheduleCorpusItemAction', () => {
     // Select a scheduled surface
     userEvent.selectOptions(surfaceSelect, 'NEW_TAB_EN_US');
 
-    const datePicker = screen.getByRole('textbox', {
-      name: 'Choose a date',
+    const datePicker = screen.getByRole('button', {
+      name: /choose date/i,
     }) as HTMLInputElement;
 
     // Click on the date field to bring up the calendar
     userEvent.click(datePicker);
 
-    // Find today's date on the monthly calendar (it's actually a button)
-    const todaysDateButton = screen.getAllByRole('button', {
+    // Find today's date on the monthly calendar (in MUI 5, it's a grid cell)
+    const todaysDate = screen.getAllByRole('gridcell', {
       name: today.toFormat('d'),
     })[0];
 
     // Choose it
-    userEvent.click(todaysDateButton);
+    userEvent.click(todaysDate);
 
     userEvent.click(screen.getByText('Save'));
 

--- a/src/curated-corpus/components/actions/ScheduleCorpusItemAction/ScheduleCorpusItemAction.tsx
+++ b/src/curated-corpus/components/actions/ScheduleCorpusItemAction/ScheduleCorpusItemAction.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { useNotifications, useRunMutation } from '../../../../_shared/hooks';
+import { FormikHelpers, FormikValues } from 'formik';
+import { DateTime } from 'luxon';
 import {
   ApprovedCorpusItem,
   CreateScheduledCorpusItemInput,
   useCreateScheduledCorpusItemMutation,
 } from '../../../../api/generatedTypes';
-import { FormikHelpers, FormikValues } from 'formik';
-import { ScheduleItemModal } from '../../ScheduleItemModal/ScheduleItemModal';
-import { DateTime } from 'luxon';
+import { useNotifications, useRunMutation } from '../../../../_shared/hooks';
+import { ScheduleItemModal } from '../../';
 
 interface ScheduleCorpusItemActionProps {
   /**

--- a/src/curated-corpus/components/index.ts
+++ b/src/curated-corpus/components/index.ts
@@ -7,6 +7,7 @@ export { ApprovedItemInfo } from './ApprovedItemInfo/ApprovedItemInfo';
 export { ApprovedItemListCard } from './ApprovedItemListCard/ApprovedItemListCard';
 export { ApprovedItemModal } from './ApprovedItemModal/ApprovedItemModal';
 export { ApprovedItemSearchForm } from './ApprovedItemSearchForm/ApprovedItemSearchForm';
+export { EditCorpusItemAction } from './actions/EditCorpusItemAction/EditCorpusItemAction';
 export { ExistingProspectCard } from './ExistingProspectCard/ExistingProspectCard';
 export { DuplicateProspectModal } from './DuplicateProspectModal/DuplicateProspectModal';
 export { LoadExtraButton } from './LoadExtraButton/LoadExtraButton';

--- a/src/curated-corpus/helpers/helperFunctions.test.ts
+++ b/src/curated-corpus/helpers/helperFunctions.test.ts
@@ -5,8 +5,8 @@ import {
   downloadAndUploadApprovedItemImageToS3,
   fetchFileFromUrl,
   getCuratorNameFromLdap,
-  getScheduledSurfaceName,
   getLocalDateTimeForGuid,
+  getScheduledSurfaceName,
   readImageFileFromDisk,
 } from './helperFunctions';
 
@@ -138,7 +138,7 @@ describe('helperFunctions ', () => {
     });
   });
 
-  describe('downloadAndUploadApprovedItemImageToS3 function', async () => {
+  describe('downloadAndUploadApprovedItemImageToS3 function', () => {
     const testMutationResponseData = {
       data: { uploadApprovedCorpusItemImage: { url: 's3-test-image-url' } },
     };

--- a/src/curated-corpus/pages/CorpusItemPage/CorpusItemPage.tsx
+++ b/src/curated-corpus/pages/CorpusItemPage/CorpusItemPage.tsx
@@ -2,16 +2,22 @@ import React from 'react';
 import { useParams } from 'react-router-dom';
 import { useApprovedCorpusItemByExternalIdQuery } from '../../../api/generatedTypes';
 import { HandleApiResponse } from '../../../_shared/components';
-import { Box, Button, ButtonGroup, Grid, Typography } from '@material-ui/core';
-import { Alert } from '@material-ui/lab';
+import {
+  Alert,
+  Box,
+  Button,
+  ButtonGroup,
+  Grid,
+  Typography,
+} from '@mui/material';
 import {
   ApprovedItemCurationHistory,
   ApprovedItemInfo,
+  EditCorpusItemAction,
   RejectCorpusItemAction,
   ScheduleCorpusItemAction,
 } from '../../components';
 import { useToggle } from '../../../_shared/hooks';
-import { EditCorpusItemAction } from '../../components/actions/EditCorpusItemAction/EditCorpusItemAction';
 
 /**
  * This page displays all the details and schedule history of a single corpus item.


### PR DESCRIPTION
## Goal

This change encompasses updates to the main forms and form action components for "Edit", "Schedule" and "Reject" actions in addition to UI updates to the Corpus Item page itself.

As such, the most work was to tame the date pickers used on the Schedule Item form - using MUI's x-date-pickers package proved to be the easier option of the two (the mui/lab package is being removed with this PR as that was the second option, and we don't use Lab components for anything else).

Tests interacting with the date pickers have been updated; an unfinished integration test has been updated but not yet finished as that will come in a separate test sweep PR.

## Deployment

This PR's target is the `feature/mui-5-upgrade` branch. 

## Reference

https://getpocket.atlassian.net/browse/BACK-1757