### PR TITLE
fix(mui5): [BACK-1770] Restore less round corners on prospect card thumbnail images

### DIFF
--- a/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.tsx
+++ b/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.tsx
@@ -78,7 +78,7 @@ export const ExistingProspectCard: React.FC<ExistingProspectCardProps> = (
             src={item.imageUrl}
             alt={item.title}
             sx={{
-              borderRadius: 4,
+              borderRadius: 1,
               border: `1px solid ${curationPalette.lightGrey}`,
             }}
           />

--- a/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
+++ b/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
@@ -75,7 +75,7 @@ export const ProspectListCard: React.FC<ProspectListCardProps> = (
             }
             alt={prospect.title ?? 'No title supplied'}
             sx={{
-              borderRadius: 4,
+              borderRadius: 1,
               border: `1px solid ${curationPalette.lightGrey}`,
             }}
           />


### PR DESCRIPTION
## Goal

Apply one last tweak following the upgrade to MUI 5. It is documented in the ticket but I forgot to include it with the other fixes in https://github.com/Pocket/curation-admin-tools/pull/989. 

Before (prospect card & existing prospect card):

<img width="995" alt="prospect-thumbnails-before" src="https://user-images.githubusercontent.com/22447785/211935386-293e9d40-05e0-48a8-adcc-3aa765decfec.png">

After:

<img width="995" alt="prospect-thumbnails-after" src="https://user-images.githubusercontent.com/22447785/211935668-44d75bda-08f5-4fdf-aea0-907bf68ca4c3.png">

## Reference

https://getpocket.atlassian.net/browse/BACK-1770