### PR TITLE
fix(linting): Run the lint check over AWS files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,8 @@ module.exports = {
     'plugin:react/recommended',
     'plugin:prettier/recommended',
   ],
-  ignorePatterns: ['src/api/generatedTypes.ts'],
+  // Ignore generated types, but check infra files under the `.aws` folder.
+  ignorePatterns: ['src/api/generatedTypes.ts', '!/.aws'],
   parserOptions: {
     ecmaFeatures: {
       jsx: true,


### PR DESCRIPTION
## Goal

Remove annoying GitHub linter warnings for files under the `.aws` folder, such as on this PR under the heading "Unchanged files with check annotations": https://github.com/Pocket/curation-admin-tools/pull/990/files. 

We're not using Pocket's backend-centric `eslint-config` package for this repository, so we need to add the ignore pattern manually. 
