### PR TITLE
feat(moderation): {OSL-166] Add new "Moderation" tool to the suite

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,12 +10,17 @@ import { LandingPage } from './_shared/pages';
 import { PageNotFound } from './_shared/components/';
 import { CollectionsLandingPage } from './collections/pages';
 import { CuratedCorpusLandingPage } from './curated-corpus/pages';
+import { ModerationLandingPage } from './moderation/pages';
 import { useMozillaAuth } from './_shared/hooks';
 import { client } from './api/client';
 
 function App(): JSX.Element {
-  const { canAccessCuration, canAccessCollections, jwtIdToken } =
-    useMozillaAuth();
+  const {
+    canAccessCollections,
+    canAccessCuration,
+    canAccessModeration,
+    jwtIdToken,
+  } = useMozillaAuth();
 
   // create an ApolloLink that adds the authorization header
   const authLink = setContext((_, { headers }) => {
@@ -50,6 +55,11 @@ function App(): JSX.Element {
                 {canAccessCuration && (
                   <Route path="/curated-corpus">
                     <CuratedCorpusLandingPage />
+                  </Route>
+                )}
+                {canAccessModeration && (
+                  <Route path="/moderation">
+                    <ModerationLandingPage />
                   </Route>
                 )}
                 <Route component={PageNotFound} />

--- a/src/_shared/hooks/useMozillaAuth/useMozillaAuth.ts
+++ b/src/_shared/hooks/useMozillaAuth/useMozillaAuth.ts
@@ -28,6 +28,7 @@ export const useMozillaAuth = (): {
   jwtIdToken: string;
   canAccessCollections: boolean;
   canAccessCuration: boolean;
+  canAccessModeration: boolean;
 } => {
   const { authService } = pkceUseAuth();
   const parsedIdToken = authService.getUser() as IDToken;
@@ -46,8 +47,11 @@ export const useMozillaAuth = (): {
     authService,
     parsedIdToken,
     jwtIdToken,
-    //TODO: Setup mozillians.org groups
+    // Everyone at Pocket has read-only access to this tool
+    // Access groups are checked on the backend when actions (mutations)
+    // are performed.
     canAccessCollections: true, //parsedIdToken.groups.includes('asd'),
     canAccessCuration: true, //parsedIdToken.groups.includes('asd'),
+    canAccessModeration: true,
   };
 };

--- a/src/_shared/pages/LandingPage/LandingPage.tsx
+++ b/src/_shared/pages/LandingPage/LandingPage.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import { Grid, Paper, Typography } from '@mui/material';
 import CollectionsBookmarkIcon from '@mui/icons-material/CollectionsBookmark';
+import GavelIcon from '@mui/icons-material/Gavel';
 import LibraryAddCheckIcon from '@mui/icons-material/LibraryAddCheck';
 import { HeaderConnector } from '../../components';
 import { StyledContainer, StyledRouterLink } from '../../styled';
 import { useMozillaAuth } from '../../hooks';
 
 export const LandingPage = (): JSX.Element => {
-  const { canAccessCuration, canAccessCollections } = useMozillaAuth();
+  const { canAccessCuration, canAccessCollections, canAccessModeration } =
+    useMozillaAuth();
 
   return (
     <>
@@ -25,7 +27,7 @@ export const LandingPage = (): JSX.Element => {
           }}
         >
           {canAccessCollections && (
-            <Grid item xs={12} sm={6}>
+            <Grid item xs={12} sm={4}>
               <Paper>
                 <StyledRouterLink to="/collections">
                   <Typography variant="h3" component="div">
@@ -38,13 +40,26 @@ export const LandingPage = (): JSX.Element => {
           )}
 
           {canAccessCuration && (
-            <Grid item xs={12} sm={6}>
+            <Grid item xs={12} sm={4}>
               <Paper>
                 <StyledRouterLink to="/curated-corpus">
                   <Typography variant="h3" component="div">
                     <LibraryAddCheckIcon fontSize="inherit" />
                   </Typography>
                   <h2>Curated Corpus</h2>
+                </StyledRouterLink>
+              </Paper>
+            </Grid>
+          )}
+
+          {canAccessModeration && (
+            <Grid item xs={12} sm={4}>
+              <Paper>
+                <StyledRouterLink to="/moderation">
+                  <Typography variant="h3" component="div">
+                    <GavelIcon fontSize="inherit" />
+                  </Typography>
+                  <h2>Shareable Lists Moderation</h2>
                 </StyledRouterLink>
               </Paper>
             </Grid>

--- a/src/curated-corpus/pages/CuratedCorpusLandingPage/CuratedCorpusLandingPage.tsx
+++ b/src/curated-corpus/pages/CuratedCorpusLandingPage/CuratedCorpusLandingPage.tsx
@@ -55,7 +55,7 @@ export const CuratedCorpusLandingPage = (): JSX.Element => {
           <Route exact path={`${path}/`}>
             <h2>Welcome to Pocket&apos;s Curated Corpus management tool.</h2>
 
-            <p>Use the menu above to nagivate:</p>
+            <p>Use the menu above to navigate:</p>
 
             <List>
               <ListItem>

--- a/src/moderation/pages/ModerationLandingPage/ModerationLandingPage.tsx
+++ b/src/moderation/pages/ModerationLandingPage/ModerationLandingPage.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { ApolloProvider } from '@apollo/client';
+import { Link, Route, Switch, useRouteMatch } from 'react-router-dom';
+import { List, ListItem, ListItemText } from '@mui/material';
+import {
+  HeaderConnector,
+  MenuLink,
+  PageNotFound,
+} from '../../../_shared/components';
+import { StyledContainer } from '../../../_shared/styled';
+import { client } from '../../../api/client';
+
+/**
+ * Moderation landing page
+ */
+export const ModerationLandingPage = (): JSX.Element => {
+  // Get the base path (/moderation)
+  const { path } = useRouteMatch();
+
+  const menuLinks: MenuLink[] = [
+    {
+      text: 'Search',
+      url: `${path}/search/`,
+    },
+    {
+      text: 'Users',
+      url: `${path}/users/`,
+    },
+  ];
+
+  return (
+    <ApolloProvider client={client}>
+      <HeaderConnector
+        productName="Moderation"
+        productLink="/moderation"
+        menuLinks={menuLinks}
+      />
+      <StyledContainer maxWidth="xl" disableGutters>
+        <Switch>
+          <Route exact path={`${path}/`}>
+            <h2>Welcome to Pocket&apos;s Shareable Lists Moderation tool.</h2>
+
+            <p>Use the menu above to navigate:</p>
+
+            <List>
+              <ListItem>
+                <ListItemText>
+                  The <Link to={`${path}/search/`}>Search</Link> page will let
+                  you look up and moderate shareable lists.
+                </ListItemText>
+              </ListItem>
+              <ListItem>
+                <ListItemText>
+                  The <Link to={`${path}/users/`}>Users</Link> will allow you to
+                  manage access to the feature during the Pilot phase.
+                </ListItemText>
+              </ListItem>
+            </List>
+          </Route>
+          {/*<Route exact path={`${path}/search/`}>*/}
+          {/*  <SearchShareableListsPage />*/}
+          {/*</Route>*/}
+          {/*<Route exact path={`${path}/users/`}>*/}
+          {/*  <ManagePilotUsersPage />*/}
+          {/*</Route>*/}
+          <Route component={PageNotFound} />
+        </Switch>
+      </StyledContainer>
+    </ApolloProvider>
+  );
+};

--- a/src/moderation/pages/index.ts
+++ b/src/moderation/pages/index.ts
@@ -1,0 +1,1 @@
+export { ModerationLandingPage } from './ModerationLandingPage/ModerationLandingPage';


### PR DESCRIPTION
## Goal

- Added routing, menu, and page scaffolding to accommodate the new "Moderation" tool to Curation Admin Tools.

- Note while I added menu links and links to the intro on the landing page for the Moderation tool, I didn't actually add components for these pages so an attempt to follow the links will end up in a 404 for now, until they're added in subsequent tasks.

##  Video walkthrough


https://user-images.githubusercontent.com/22447785/222998578-d4603653-100a-4b5f-990b-097e1a6a31de.mov



## Reference


Tickets:

- https://getpocket.atlassian.net/browse/OSL-166
