### PR TITLE
OSL-464: Adding shareable list restoration functionality to moderation tool

### DIFF
--- a/src/api/fragments/ShareableListCompleteProps.ts
+++ b/src/api/fragments/ShareableListCompleteProps.ts
@@ -18,6 +18,8 @@ export const ShareableListCompleteProps = gql`
     moderatedBy
     moderationReason
     moderationDetails
+    restorationReason
+    listItemNoteVisibility
     listItems {
       ...ShareableListItemProps
     }

--- a/src/api/fragments/ShareableListItemProps.ts
+++ b/src/api/fragments/ShareableListItemProps.ts
@@ -14,6 +14,7 @@ export const ShareableListItemProps = gql`
     imageUrl
     publisher
     authors
+    note
     sortOrder
     createdAt
     updatedAt

--- a/src/moderation/components/ShareableListCard/ShareableListCard.test.tsx
+++ b/src/moderation/components/ShareableListCard/ShareableListCard.test.tsx
@@ -4,7 +4,7 @@ import { dateFormat, ShareableListCard } from './ShareableListCard';
 import {
   ShareableListComplete,
   ShareableListModerationStatus,
-  ShareableListStatus,
+  ShareableListVisibility,
 } from '../../../api/generatedTypes';
 import { DateTime } from 'luxon';
 
@@ -15,7 +15,7 @@ describe('The ShareableListCard component', () => {
     title: 'Test list title',
     description: 'Some description',
     slug: 'test-list-title',
-    status: ShareableListStatus.Public,
+    status: ShareableListVisibility.Public,
     moderationStatus: ShareableListModerationStatus.Visible,
     createdAt: '2023-03-27T11:54:03.000Z',
     updatedAt: '2023-03-28T23:09:57.000Z',
@@ -55,7 +55,7 @@ describe('The ShareableListCard component', () => {
     // set up a different list that is private
     const privateList = {
       ...list,
-      status: ShareableListStatus.Private,
+      status: ShareableListVisibility.Private,
       slug: undefined,
     };
     render(<ShareableListCard list={privateList} />);
@@ -77,7 +77,7 @@ describe('The ShareableListCard component', () => {
     };
     render(<ShareableListCard list={privateList} />);
 
-    const hideListButton = screen.queryByRole('button');
+    const hideListButton = screen.getByTestId('hide-list-button');
     expect(hideListButton).toHaveAttribute('disabled');
   });
 
@@ -93,49 +93,57 @@ describe('The ShareableListCard component', () => {
     expect(hideListButton).toBeInTheDocument();
   });
 
-  it('shows moderationStatus and moderationDetails if list moderationStatus is Hidden', () => {
+  it('the "Restore List" button is disabled if the list moderationStatus is Visible', () => {
     // set up a different list that is private
     const privateList = {
       ...list,
-      moderationStatus: ShareableListModerationStatus.Hidden,
-      moderationReason: 'FRAUD',
-      moderationDetails: 'more details',
       slug: undefined,
     };
     render(<ShareableListCard list={privateList} />);
 
-    // let make sure hide list button is not present
-    const hideListButton = screen.queryByRole('button');
-    expect(hideListButton).toHaveAttribute('disabled');
+    const restoreListButton = screen.getByTestId('restore-list-button');
+    expect(restoreListButton).toHaveAttribute('disabled');
+  });
+
+  it('shows the "Restore List" button if the list moderationStatus is Hidden', () => {
+    // set up a different list that is private
+    const privateList = {
+      ...list,
+      moderationStatus: ShareableListModerationStatus.Hidden,
+      slug: undefined,
+    };
+    render(<ShareableListCard list={privateList} />);
+
+    const restoreListButton = screen.getByTestId('restore-list-button');
+    expect(restoreListButton).toBeInTheDocument();
+  });
+
+  it('shows moderationStatus, moderationDetails and restorationReason if properties are present', () => {
+    // set up a different list that is private
+    const privateList = {
+      ...list,
+      moderationStatus: ShareableListModerationStatus.Visible,
+      moderationReason: 'FRAUD',
+      moderationDetails: 'more details',
+      restorationReason: 'restored, restored',
+      slug: undefined,
+    };
+    render(<ShareableListCard list={privateList} />);
+
+    // let make sure restore list button is not present
+    const restoreListButton = screen.getByTestId('restore-list-button');
+    expect(restoreListButton).toHaveAttribute('disabled');
 
     // expect moderationReason to be present
     const moderationReason = screen.getByText(/FRAUD/i);
     expect(moderationReason).toBeInTheDocument();
 
-    // expect moderationDetails to be present
+    //expect moderationDetails to be present
     const moderationDetails = screen.getByText(/more details/i);
     expect(moderationDetails).toBeInTheDocument();
-  });
 
-  it('shows moderationStatus and does not show moderationDetails if list moderationStatus is Hidden and moderationDetails is null', () => {
-    // set up a different list that is private
-    const privateList = {
-      ...list,
-      moderationStatus: ShareableListModerationStatus.Hidden,
-      moderationReason: 'FRAUD',
-      slug: undefined,
-    };
-    render(<ShareableListCard list={privateList} />);
-
-    // let make sure hide list button is not present
-    const hideListButton = screen.queryByRole('button');
-    expect(hideListButton).toHaveAttribute('disabled');
-
-    const moderationReason = screen.getByText(/FRAUD/i);
-    expect(moderationReason).toBeInTheDocument();
-
-    // make sure moderationDetails is not present if null
-    const moderationDetails = screen.queryByText(/more details/i);
-    expect(moderationDetails).not.toBeInTheDocument();
+    // expect restorationReason to be present
+    const restorationReason = screen.getByText(/restored, restored/i);
+    expect(restorationReason).toBeInTheDocument();
   });
 });

--- a/src/moderation/components/ShareableListCard/ShareableListCard.tsx
+++ b/src/moderation/components/ShareableListCard/ShareableListCard.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { Box, CardContent, Link, Typography } from '@mui/material';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
+import VisibilityIcon from '@mui/icons-material/Visibility';
 
 import { ShareableListModal } from '../';
 import {
   ShareableListComplete,
-  ShareableListStatus,
+  ShareableListVisibility,
   ShareableListModerationStatus,
 } from '../../../api/generatedTypes';
 import { Button, Chip } from '../../../_shared/components';
@@ -37,8 +38,15 @@ export const ShareableListCard: React.FC<ShareableListCardProps> = (
   // flag to disable or enable hide list button
   let disableHideListButton = false;
 
+  // flag to disable or enable restore list button
+  let disableRestoreListButton = false;
+
   if (list.moderationStatus === ShareableListModerationStatus.Hidden) {
     disableHideListButton = true;
+  }
+
+  if (list.moderationStatus === ShareableListModerationStatus.Visible) {
+    disableRestoreListButton = true;
   }
 
   const [shareableListModalOpen, toggleShareableListModal] = useToggle(false);
@@ -72,7 +80,7 @@ export const ShareableListCard: React.FC<ShareableListCardProps> = (
           )}
         </Typography>
         <Box sx={{ lineHeight: 2 }}>
-          {list.status == ShareableListStatus.Public && (
+          {list.status == ShareableListVisibility.Public && (
             <Link
               href={fullUrlToList}
               target="_blank"
@@ -83,26 +91,32 @@ export const ShareableListCard: React.FC<ShareableListCardProps> = (
               {fullUrlToList}
             </Link>
           )}
-          {list.status == ShareableListStatus.Private && (
+          {list.status == ShareableListVisibility.Private && (
             <Box sx={{ lineHeight: 2 }}>
               <em>This list is private (no public link).</em>
             </Box>
           )}
         </Box>
-        {list.moderationStatus === ShareableListModerationStatus.Hidden && (
+        {list.moderationReason && (
           <Box sx={{ lineHeight: 2 }}>
             <strong>Moderation Reason</strong>: {list.moderationReason}
           </Box>
         )}
-        {list.moderationStatus === ShareableListModerationStatus.Hidden &&
-          list.moderationDetails && (
-            <Box sx={{ lineHeight: 2 }}>
-              <strong>Moderation Details</strong>: {list.moderationDetails}
-            </Box>
-          )}
-        <Box sx={{ lineHeight: 2 }}>
-          <strong>Description</strong>: {list.description}
-        </Box>
+        {list.moderationDetails && (
+          <Box sx={{ lineHeight: 2 }}>
+            <strong>Moderation Details</strong>: {list.moderationDetails}
+          </Box>
+        )}
+        {list.restorationReason && (
+          <Box sx={{ lineHeight: 2 }}>
+            <strong>Restoration Reason</strong>: {list.restorationReason}
+          </Box>
+        )}
+        {list.description && (
+          <Box sx={{ lineHeight: 2 }}>
+            <strong>Description</strong>: {list.description}
+          </Box>
+        )}
         <Box sx={{ lineHeight: 2 }}>
           <strong>Created at</strong>:{' '}
           {DateTime.fromISO(list.createdAt).toFormat(dateFormat)}
@@ -111,26 +125,50 @@ export const ShareableListCard: React.FC<ShareableListCardProps> = (
           <strong>Updated at</strong>:{' '}
           {DateTime.fromISO(list.updatedAt).toFormat(dateFormat)}
         </Box>
-        <Box display="flex">
+
+        {/*hide list button*/}
+        {disableRestoreListButton && (
           <ShareableListModal
             isOpen={shareableListModalOpen}
             toggleModal={toggleShareableListModal}
             modalTitle="Hide List"
             refetch={refetch}
             shareableList={list}
-            runModerateShareableListMutation={true} // this modal is in charge of moderating a list, so passing flag
+            hideList={true} // this modal is in charge of moderating a list (hide), so passing flag
           />
-          <Button
-            buttonType="negative"
-            disabled={disableHideListButton}
-            startIcon={<VisibilityOffIcon />}
-            variant="text"
-            onClick={toggleShareableListModal}
-            data-testid="hide-list-button"
-          >
-            Hide List
-          </Button>
-        </Box>
+        )}
+        <Button
+          buttonType="negative"
+          disabled={disableHideListButton}
+          startIcon={<VisibilityOffIcon />}
+          variant="text"
+          onClick={toggleShareableListModal}
+          data-testid="hide-list-button"
+        >
+          Hide List
+        </Button>
+
+        {/*restore list button*/}
+        {disableHideListButton && (
+          <ShareableListModal
+            isOpen={shareableListModalOpen}
+            toggleModal={toggleShareableListModal}
+            modalTitle="Restore List"
+            refetch={refetch}
+            shareableList={list}
+            restoreList={true} // this modal is in charge of moderating a list (hide), so passing flag
+          />
+        )}
+        <Button
+          buttonType="positive"
+          disabled={disableRestoreListButton}
+          startIcon={<VisibilityIcon />}
+          variant="text"
+          onClick={toggleShareableListModal}
+          data-testid="restore-list-button"
+        >
+          Restore List
+        </Button>
       </CardContent>
     </StyledListCard>
   );

--- a/src/moderation/components/ShareableListFormConnector/ShareableListFormConnector.test.tsx
+++ b/src/moderation/components/ShareableListFormConnector/ShareableListFormConnector.test.tsx
@@ -5,17 +5,19 @@ import { MockedProvider } from '@apollo/client/testing';
 import userEvent from '@testing-library/user-event';
 import { ShareableListFormConnector } from './ShareableListFormConnector';
 import {
-  list,
+  visibleList,
+  hiddenList,
   moderationDetailsMultiLineText,
   moderateShareableList1SuccessMock,
+  restoreShareableList1SuccessMock,
 } from '../../integration-test-mocks/moderateShareableLists';
 
-describe('ShareableListFormConnector', () => {
+describe('ShareableListFormConnector -> Hiding List', () => {
   let mocks = [];
   const toggleModal = jest.fn();
   const refetch = jest.fn();
 
-  it('loads the form with all labels and buttons', async () => {
+  it('Hiding List: loads the form with all labels and buttons', async () => {
     mocks = [moderateShareableList1SuccessMock];
 
     render(
@@ -24,7 +26,8 @@ describe('ShareableListFormConnector', () => {
           <ShareableListFormConnector
             toggleModal={toggleModal}
             refetch={refetch}
-            shareableList={list}
+            shareableList={visibleList}
+            hideList={true}
           />
         </SnackbarProvider>
       </MockedProvider>
@@ -54,7 +57,7 @@ describe('ShareableListFormConnector', () => {
     expect(moderationDetailsField).toBeInTheDocument();
   });
 
-  it('resolves in an error when empty label name', async () => {
+  it('Hiding List: resolves in an error when empty label name', async () => {
     mocks = [moderateShareableList1SuccessMock];
 
     render(
@@ -63,7 +66,8 @@ describe('ShareableListFormConnector', () => {
           <ShareableListFormConnector
             toggleModal={toggleModal}
             refetch={refetch}
-            shareableList={list}
+            shareableList={visibleList}
+            hideList={true}
           />
         </SnackbarProvider>
       </MockedProvider>
@@ -86,7 +90,7 @@ describe('ShareableListFormConnector', () => {
     ).toBeInTheDocument();
   });
 
-  it('resolves in no errors, save button works, list is hidden', async () => {
+  it('Hiding List: resolves in no errors, save button works, list is hidden', async () => {
     mocks = [moderateShareableList1SuccessMock];
 
     render(
@@ -95,8 +99,8 @@ describe('ShareableListFormConnector', () => {
           <ShareableListFormConnector
             toggleModal={toggleModal}
             refetch={refetch}
-            shareableList={list}
-            runModerateShareableListMutation={true}
+            shareableList={visibleList}
+            hideList={true}
           />
         </SnackbarProvider>
       </MockedProvider>
@@ -125,7 +129,7 @@ describe('ShareableListFormConnector', () => {
     await waitFor(() => expect(toggleModal).toHaveBeenCalledTimes(1));
   });
 
-  it('cancel button works', async () => {
+  it('Hiding List: cancel button works', async () => {
     mocks = [moderateShareableList1SuccessMock];
 
     render(
@@ -134,8 +138,144 @@ describe('ShareableListFormConnector', () => {
           <ShareableListFormConnector
             toggleModal={toggleModal}
             refetch={refetch}
-            shareableList={list}
-            runModerateShareableListMutation={true}
+            shareableList={visibleList}
+            hideList={true}
+          />
+        </SnackbarProvider>
+      </MockedProvider>
+    );
+
+    // grab cancel button
+    const cancelButton = screen.getByText(/cancel/i);
+
+    expect(cancelButton).toBeInTheDocument();
+
+    await waitFor(() => {
+      userEvent.click(cancelButton);
+    });
+
+    await waitFor(() => expect(toggleModal).toHaveBeenCalled());
+    await waitFor(() => expect(toggleModal).toHaveBeenCalledTimes(1));
+  });
+});
+
+describe('ShareableListFormConnector -> Restoring List', () => {
+  let mocks = [];
+  const toggleModal = jest.fn();
+  const refetch = jest.fn();
+
+  it('Restoring List: loads the form with all labels and buttons', async () => {
+    mocks = [restoreShareableList1SuccessMock];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <SnackbarProvider>
+          <ShareableListFormConnector
+            toggleModal={toggleModal}
+            refetch={refetch}
+            shareableList={hiddenList}
+            restoreList={true}
+          />
+        </SnackbarProvider>
+      </MockedProvider>
+    );
+
+    // Wait for the form to load
+    await screen.findByRole('form');
+
+    // grab save button
+    const saveButton = screen.getByRole('button', {
+      name: /save/i,
+    });
+    expect(saveButton).toBeInTheDocument();
+
+    // grab cancel button
+    const cancelButton = screen.getByRole('button', {
+      name: /cancel/i,
+    });
+    expect(cancelButton).toBeInTheDocument();
+
+    // grab restorationReason field
+    const restorationReason = screen.getByLabelText(/restoration reason/i);
+    expect(restorationReason).toBeInTheDocument();
+  });
+
+  it('Restoring List: resolves in an error when empty label name', async () => {
+    mocks = [restoreShareableList1SuccessMock];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <SnackbarProvider>
+          <ShareableListFormConnector
+            toggleModal={toggleModal}
+            refetch={refetch}
+            shareableList={hiddenList}
+            restoreList={true}
+          />
+        </SnackbarProvider>
+      </MockedProvider>
+    );
+
+    // grab save button
+    const saveButton = screen.getByText(/save/i);
+
+    // grab restorationReason field
+    const restorationReason = screen.getByLabelText(/restoration reason/i);
+    expect(restorationReason).toBeInTheDocument();
+
+    // click save button
+    await waitFor(() => {
+      userEvent.click(saveButton);
+    });
+    // should resolve in error
+    expect(
+      screen.getByText('Please enter a reason for restoring this list.')
+    ).toBeInTheDocument();
+  });
+
+  it('Restoring List: resolves in no errors, save button works, list is restored', async () => {
+    mocks = [restoreShareableList1SuccessMock];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <SnackbarProvider>
+          <ShareableListFormConnector
+            toggleModal={toggleModal}
+            refetch={refetch}
+            shareableList={hiddenList}
+            restoreList={true}
+          />
+        </SnackbarProvider>
+      </MockedProvider>
+    );
+
+    // grab save button
+    const saveButton = screen.getByText(/save/i);
+
+    // grab restorationReason field
+    const restorationReasonField = screen.getByLabelText(/restoration reason/i);
+    expect(restorationReasonField).toBeInTheDocument();
+    // enter restorationReason
+    userEvent.type(restorationReasonField, moderationDetailsMultiLineText);
+
+    // click save button
+    userEvent.click(saveButton);
+
+    await waitFor(() => expect(toggleModal).toHaveBeenCalled());
+    // await waitFor(() => expect(toggleModal).toHaveBeenCalledTimes(1));
+  });
+
+  it('Restoring List: cancel button works', async () => {
+    mocks = [restoreShareableList1SuccessMock];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <SnackbarProvider>
+          <ShareableListFormConnector
+            toggleModal={toggleModal}
+            refetch={refetch}
+            shareableList={hiddenList}
+            restoreList={true}
           />
         </SnackbarProvider>
       </MockedProvider>

--- a/src/moderation/components/ShareableListModal/ShareableListModal.test.tsx
+++ b/src/moderation/components/ShareableListModal/ShareableListModal.test.tsx
@@ -6,7 +6,7 @@ import { ShareableListModal } from './ShareableListModal';
 import {
   ShareableListComplete,
   ShareableListModerationStatus,
-  ShareableListStatus,
+  ShareableListVisibility,
 } from '../../../api/generatedTypes';
 
 describe('The ShareableListModal component', () => {
@@ -18,7 +18,7 @@ describe('The ShareableListModal component', () => {
     title: 'Test list title',
     description: 'Some description',
     slug: 'test-list-title',
-    status: ShareableListStatus.Public,
+    status: ShareableListVisibility.Public,
     moderationStatus: ShareableListModerationStatus.Visible,
     createdAt: '2023-03-27T11:54:03.000Z',
     updatedAt: '2023-03-28T23:09:57.000Z',
@@ -35,6 +35,7 @@ describe('The ShareableListModal component', () => {
             modalTitle={'Hide List'}
             refetch={refetch}
             shareableList={list}
+            hideList={true} // this modal is in charge of moderating a list (hide), so passing flag
           />
         </SnackbarProvider>
       </MockedProvider>
@@ -50,5 +51,31 @@ describe('The ShareableListModal component', () => {
     expect(shareableListModal).toBeInTheDocument();
     expect(moderationReasonLabel).toBeInTheDocument();
     expect(moderationDetailsLabel).toBeInTheDocument();
+  });
+
+  it('should render the modal and the ShareableListRestorationForm component for restoring a list', () => {
+    render(
+      <MockedProvider>
+        <SnackbarProvider maxSnack={3}>
+          <ShareableListModal
+            isOpen={true}
+            toggleModal={toggleModal}
+            modalTitle={'Hide List'}
+            refetch={refetch}
+            shareableList={list}
+            restoreList={true} // this modal is in charge of moderating a list (hide), so passing flag
+          />
+        </SnackbarProvider>
+      </MockedProvider>
+    );
+
+    // using the modal heading to fetch it
+    const shareableListModal = screen.getByText(/hide list/i);
+
+    // fetching the form component that is rendered within this modal component
+    const restorationReasonLabel = screen.getByLabelText(/restoration reason/i);
+
+    expect(shareableListModal).toBeInTheDocument();
+    expect(restorationReasonLabel).toBeInTheDocument();
   });
 });

--- a/src/moderation/components/ShareableListModal/ShareableListModal.tsx
+++ b/src/moderation/components/ShareableListModal/ShareableListModal.tsx
@@ -32,9 +32,14 @@ interface ShareableListsModalProps {
   shareableList: ShareableListComplete;
 
   /**
-   * Whether or not to run the moderateShareableList mutation.
+   * Whether or not to run the moderateShareableList mutation (for hiding list).
    */
-  runModerateShareableListMutation?: boolean;
+  hideList?: boolean;
+
+  /**
+   * Whether or not to run the moderateShareableList mutation (for restoring list).
+   */
+  restoreList?: boolean;
 }
 
 /**
@@ -49,7 +54,8 @@ export const ShareableListModal: React.FC<ShareableListsModalProps> = (
     modalTitle,
     refetch,
     shareableList,
-    runModerateShareableListMutation,
+    hideList,
+    restoreList,
   } = props;
 
   return (
@@ -63,7 +69,8 @@ export const ShareableListModal: React.FC<ShareableListsModalProps> = (
           toggleModal={toggleModal}
           refetch={refetch}
           shareableList={shareableList}
-          runModerateShareableListMutation={runModerateShareableListMutation}
+          hideList={hideList}
+          restoreList={restoreList}
         />
       </Grid>
     </Modal>

--- a/src/moderation/components/ShareableListModerationForm/ShareableListModerationForm.test.tsx
+++ b/src/moderation/components/ShareableListModerationForm/ShareableListModerationForm.test.tsx
@@ -5,7 +5,7 @@ import { MockedProvider } from '@apollo/client/testing';
 import { SnackbarProvider } from 'notistack';
 import { ShareableListModerationForm } from './ShareableListModerationForm';
 import {
-  list,
+  visibleList,
   moderationDetailsMultiLineText,
   moderateShareableList1SuccessMock,
 } from '../../integration-test-mocks/moderateShareableLists';
@@ -21,7 +21,7 @@ describe('The ShareableListModerationForm component', () => {
         onSubmit={onSubmit}
         onCancel={onCancel}
         isLoaderShowing={false}
-        shareableList={list}
+        shareableList={visibleList}
       />
     );
 
@@ -44,7 +44,7 @@ describe('The ShareableListModerationForm component', () => {
             onSubmit={onSubmit}
             onCancel={onCancel}
             isLoaderShowing={false}
-            shareableList={list}
+            shareableList={visibleList}
           />
         </SnackbarProvider>
       </MockedProvider>
@@ -69,7 +69,7 @@ describe('The ShareableListModerationForm component', () => {
             onSubmit={onSubmit}
             onCancel={onCancel}
             isLoaderShowing={false}
-            shareableList={list}
+            shareableList={visibleList}
           />
         </SnackbarProvider>
       </MockedProvider>
@@ -102,7 +102,7 @@ describe('The ShareableListModerationForm component', () => {
             onSubmit={onSubmit}
             onCancel={onCancel}
             isLoaderShowing={false}
-            shareableList={list}
+            shareableList={visibleList}
           />
         </SnackbarProvider>
       </MockedProvider>
@@ -129,7 +129,7 @@ describe('The ShareableListModerationForm component', () => {
             onSubmit={onSubmit}
             onCancel={onCancel}
             isLoaderShowing={false}
-            shareableList={list}
+            shareableList={visibleList}
           />
         </SnackbarProvider>
       </MockedProvider>

--- a/src/moderation/components/ShareableListRestorationForm/ShareableListRestorationForm.test.tsx
+++ b/src/moderation/components/ShareableListRestorationForm/ShareableListRestorationForm.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MockedProvider } from '@apollo/client/testing';
+import { SnackbarProvider } from 'notistack';
+import { ShareableListRestorationForm } from './ShareableListRestorationForm';
+import {
+  hiddenList,
+  moderationDetailsMultiLineText,
+  restoreShareableList1SuccessMock,
+} from '../../integration-test-mocks/moderateShareableLists';
+
+describe('The ShareableListRestorationForm component', () => {
+  let mocks = [];
+  const onSubmit = jest.fn();
+  const onCancel = jest.fn();
+
+  it('should render all the form fields and elements', () => {
+    render(
+      <ShareableListRestorationForm
+        onSubmit={onSubmit}
+        onCancel={onCancel}
+        isLoaderShowing={false}
+        shareableList={hiddenList}
+      />
+    );
+
+    // Check if form input and buttons are rendered
+    const restorationReasonLabel = screen.getByLabelText(/restoration reason/i);
+    expect(restorationReasonLabel).toBeInTheDocument();
+
+    const saveButton = screen.getByText(/save/i);
+    expect(saveButton).toBeInTheDocument();
+
+    const cancelButton = screen.getByText(/cancel/i);
+    expect(cancelButton).toBeInTheDocument();
+  });
+
+  it('should render error message when no restorationReason is provided', async () => {
+    render(
+      <MockedProvider>
+        <SnackbarProvider maxSnack={3}>
+          <ShareableListRestorationForm
+            onSubmit={onSubmit}
+            onCancel={onCancel}
+            isLoaderShowing={false}
+            shareableList={hiddenList}
+          />
+        </SnackbarProvider>
+      </MockedProvider>
+    );
+
+    const saveButton = screen.getByText(/save/i);
+
+    userEvent.click(saveButton);
+    const emptyInputError = await screen.findByText(
+      /Please enter a reason for restoring this list./i
+    );
+
+    expect(emptyInputError).toBeInTheDocument();
+  });
+
+  it('should successfully restore a list', async () => {
+    mocks = [restoreShareableList1SuccessMock];
+    render(
+      <MockedProvider mocks={mocks}>
+        <SnackbarProvider maxSnack={3}>
+          <ShareableListRestorationForm
+            onSubmit={onSubmit}
+            onCancel={onCancel}
+            isLoaderShowing={false}
+            shareableList={hiddenList}
+          />
+        </SnackbarProvider>
+      </MockedProvider>
+    );
+
+    const saveButton = screen.getByText(/save/i);
+
+    // grab restorationReason field
+    const restorationReasonField = screen.getByLabelText(/restoration reason/i);
+    expect(restorationReasonField).toBeInTheDocument();
+    // enter restorationReason
+    userEvent.type(restorationReasonField, moderationDetailsMultiLineText);
+
+    userEvent.click(saveButton);
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+  });
+
+  it('cancel button should work', async () => {
+    mocks = [restoreShareableList1SuccessMock];
+    render(
+      <MockedProvider mocks={mocks}>
+        <SnackbarProvider maxSnack={3}>
+          <ShareableListRestorationForm
+            onSubmit={onSubmit}
+            onCancel={onCancel}
+            isLoaderShowing={false}
+            shareableList={hiddenList}
+          />
+        </SnackbarProvider>
+      </MockedProvider>
+    );
+
+    const cancelButton = screen.getByText(/cancel/i);
+
+    userEvent.click(cancelButton);
+    await waitFor(() => expect(onCancel).toHaveBeenCalled());
+  });
+});

--- a/src/moderation/components/ShareableListRestorationForm/ShareableListRestorationForm.tsx
+++ b/src/moderation/components/ShareableListRestorationForm/ShareableListRestorationForm.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { Grid, LinearProgress } from '@mui/material';
+import { FormikHelpers, FormikValues, useFormik } from 'formik';
+import {
+  FormikTextField,
+  SharedFormButtons,
+  SharedFormButtonsProps,
+} from '../../../_shared/components';
+import { ShareableListComplete } from '../../../api/generatedTypes';
+import { validationSchema } from './ShareableListRestorationForm.validation';
+
+interface ShareableListRestorationFormProps {
+  onSubmit: (
+    values: FormikValues,
+    formikHelpers: FormikHelpers<any>
+  ) => void | Promise<any>;
+
+  /**
+   * Show/hide the loading bar on submissions
+   */
+  isLoaderShowing: boolean;
+
+  /**
+   * An object with everything shareableList-related in it.
+   */
+  shareableList: ShareableListComplete;
+}
+
+/**
+ * This component houses all the logic and data that will be used in this form.
+ */
+export const ShareableListRestorationForm: React.FC<
+  ShareableListRestorationFormProps & SharedFormButtonsProps
+> = (props) => {
+  // de-structure props
+  const { onCancel, onSubmit, isLoaderShowing, shareableList } = props;
+
+  // set up formik object for this form
+  const formik = useFormik({
+    initialValues: {
+      restorationReason: shareableList.restorationReason ?? '',
+    },
+    validateOnBlur: false,
+    validateOnChange: false,
+    validationSchema,
+    onSubmit,
+  });
+
+  return (
+    <form name="restore-shareable-list-form" onSubmit={formik.handleSubmit}>
+      <Grid
+        container
+        spacing={2}
+        sx={{
+          width: {
+            sm: '100%',
+            md: 800,
+          },
+        }}
+      >
+        <Grid item xs={12}>
+          <FormikTextField
+            id="restorationReason"
+            label="Restoration Reason"
+            fieldProps={formik.getFieldProps('restorationReason')}
+            fieldMeta={formik.getFieldMeta('restorationReason')}
+            autoFocus
+            multiline
+            minRows={4}
+          />
+        </Grid>
+        <Grid item xs={12}>
+          {isLoaderShowing && <LinearProgress />}
+          <SharedFormButtons onCancel={onCancel} />
+        </Grid>
+      </Grid>
+    </form>
+  );
+};

--- a/src/moderation/components/ShareableListRestorationForm/ShareableListRestorationForm.validation.tsx
+++ b/src/moderation/components/ShareableListRestorationForm/ShareableListRestorationForm.validation.tsx
@@ -1,0 +1,7 @@
+import * as yup from 'yup';
+
+export const validationSchema = yup.object({
+  restorationReason: yup
+    .string()
+    .required('Please enter a reason for restoring this list.'),
+});

--- a/src/moderation/components/index.ts
+++ b/src/moderation/components/index.ts
@@ -4,3 +4,4 @@ export { ShareableListItemCard } from './ShareableListItemCard/ShareableListItem
 export { ShareableListsSearchForm } from './ShareableListsSearchForm/ShareableListsSearchForm';
 export { ShareableListFormConnector } from './ShareableListFormConnector/ShareableListFormConnector';
 export { ShareableListModerationForm } from './ShareableListModerationForm/ShareableListModerationForm';
+export { ShareableListRestorationForm } from './ShareableListRestorationForm/ShareableListRestorationForm';

--- a/src/moderation/integration-test-mocks/moderateShareableLists.ts
+++ b/src/moderation/integration-test-mocks/moderateShareableLists.ts
@@ -2,21 +2,40 @@ import { moderateShareableList } from '../../api/mutations/moderateShareableList
 import {
   ShareableListComplete,
   ShareableListModerationStatus,
-  ShareableListStatus,
+  ShareableListModerationReason,
+  ShareableListVisibility,
 } from '../../api/generatedTypes';
 
 export const moderationDetailsMultiLineText =
   'Incidunt corrupti earum. Quasi aut qui magnam eum. ' +
   'Quia non dolores voluptatem est aut. Id officiis nulla est.\n' +
   'Harum et velit debitis. Quia assumenda commodi et dolor. ';
-export const list: ShareableListComplete = {
+
+export const visibleList: ShareableListComplete = {
   externalId: '12345-qwerty',
   user: { id: '12345' },
   title: 'Test list title',
   description: 'Some description',
   slug: 'test-list-title',
-  status: ShareableListStatus.Public,
+  status: ShareableListVisibility.Public,
   moderationStatus: ShareableListModerationStatus.Visible,
+  listItemNoteVisibility: ShareableListVisibility.Private,
+  createdAt: '2023-03-27T11:54:03.000Z',
+  updatedAt: '2023-03-28T23:09:57.000Z',
+  listItems: [],
+};
+
+export const hiddenList: ShareableListComplete = {
+  externalId: '12345-qwerty',
+  user: { id: '12345' },
+  title: 'Test list title',
+  description: 'Some description',
+  slug: 'test-list-title',
+  status: ShareableListVisibility.Public,
+  moderationStatus: ShareableListModerationStatus.Hidden,
+  moderationReason: ShareableListModerationReason.Spam,
+  moderationDetails: 'bad content',
+  listItemNoteVisibility: ShareableListVisibility.Private,
   createdAt: '2023-03-27T11:54:03.000Z',
   updatedAt: '2023-03-28T23:09:57.000Z',
   listItems: [],
@@ -27,7 +46,7 @@ export const moderateShareableList1SuccessMock = {
     query: moderateShareableList,
     variables: {
       data: {
-        externalId: list.externalId,
+        externalId: visibleList.externalId,
         moderationStatus: ShareableListModerationStatus.Hidden,
         moderationReason: 'SPAM',
         moderationDetails: moderationDetailsMultiLineText,
@@ -37,10 +56,33 @@ export const moderateShareableList1SuccessMock = {
   result: {
     data: {
       moderateShareableList: {
-        ...list,
+        ...visibleList,
         moderationStatus: ShareableListModerationStatus.Hidden,
         moderationReason: 'SPAM',
         moderationDetails: moderationDetailsMultiLineText,
+        updatedAt: new Date(),
+      },
+    },
+  },
+};
+
+export const restoreShareableList1SuccessMock = {
+  request: {
+    query: moderateShareableList,
+    variables: {
+      data: {
+        externalId: hiddenList.externalId,
+        moderationStatus: ShareableListModerationStatus.Visible,
+        restorationReason: moderationDetailsMultiLineText,
+      },
+    },
+  },
+  result: {
+    data: {
+      moderateShareableList: {
+        ...visibleList,
+        moderationStatus: ShareableListModerationStatus.Visible,
+        restorationReason: moderationDetailsMultiLineText,
         updatedAt: new Date(),
       },
     },


### PR DESCRIPTION
## Goal

Adding a modal for restoring a shareable list after it has been hidden. Updated and added tests for this functionality.

## Todos

- [x] test in dev


## Tickets:

- [https://getpocket.atlassian.net/browse/OSL-464](https://getpocket.atlassian.net/browse/OSL-464)

## Demo


https://user-images.githubusercontent.com/16909783/235533038-443246d6-0e50-4470-a8e4-6848591a9ae7.mov





