### PR TITLE
OSL-398: displaying list item notes in moderation tool

### DIFF
--- a/src/moderation/components/ShareableListItemCard/ShareableListItemCard.test.tsx
+++ b/src/moderation/components/ShareableListItemCard/ShareableListItemCard.test.tsx
@@ -14,6 +14,7 @@ describe('The ShareableListItemCard component', () => {
     imageUrl: 'https://image-domain.com/image.png',
     authors: 'A.B. Cdefg',
     publisher: 'Random Penguin',
+    note: 'some note here',
     sortOrder: 0,
     createdAt: '2023-03-27T11:55:03.000Z',
     updatedAt: '2023-03-28T23:19:57.000Z',
@@ -46,6 +47,9 @@ describe('The ShareableListItemCard component', () => {
     expect(excerpt).toBeInTheDocument();
 
     expect(screen.getByText(listItem.publisher!)).toBeInTheDocument();
+
+    const note = screen.getByText(/some note here/i);
+    expect(note).toBeInTheDocument();
 
     // The image
     expect(screen.getByAltText(listItem.title!)).toBeInTheDocument();

--- a/src/moderation/components/ShareableListItemCard/ShareableListItemCard.tsx
+++ b/src/moderation/components/ShareableListItemCard/ShareableListItemCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ShareableListItem } from '../../../api/generatedTypes';
-import { CardMedia, Grid, Hidden, Typography } from '@mui/material';
+import { Box, CardMedia, Grid, Hidden, Typography } from '@mui/material';
 import { StyledListCard } from '../../../_shared/styled';
 
 interface ShareableListItemCardProps {
@@ -68,6 +68,11 @@ export const ShareableListItemCard: React.FC<ShareableListItemCardProps> = (
               {listItem.excerpt ?? 'No excerpt'}
             </Typography>
           </Hidden>
+          {listItem.note && (
+            <Box sx={{ lineHeight: 2 }}>
+              <strong>Note</strong>: {listItem.note}
+            </Box>
+          )}
         </Grid>
       </Grid>
     </StyledListCard>


### PR DESCRIPTION
## Goal

Display notes on admin moderation screen for a list item.

## Tickets:

- [https://getpocket.atlassian.net/browse/OSL-398](https://getpocket.atlassian.net/browse/OSL-398)
