### PR TITLE
[TML-75] Add title fix button

### DIFF
--- a/src/_shared/utils/applyApTitleCase.test.ts
+++ b/src/_shared/utils/applyApTitleCase.test.ts
@@ -1,0 +1,84 @@
+import { applyApTitleCase } from './applyApTitleCase';
+
+// examples taken from https://www.grammarly.com/blog/capitalization-in-the-titles/
+// tested at https://headlinecapitalization.com/ (AP style)
+describe('applyApTitleCase', () => {
+  it('returns an empty string if no text added', () => {
+    const result = applyApTitleCase('');
+    expect(result).toEqual('');
+  });
+
+  // articles - https://www.grammarly.com/blog/articles/
+  // e.g 'after "the" long day, "the" cup of tea tasted good'
+  it('articles in text should be lowercase', () => {
+    const articles = [
+      {
+        result: 'Ernest Hemingway wrote For Whom The Bell Tolls.',
+        expected: 'Ernest Hemingway Wrote for Whom the Bell Tolls.',
+      },
+      {
+        result: 'Girl on A Train is a thriller by A. J. Waines.',
+        expected: 'Girl on a Train Is a Thriller by A. J. Waines.',
+      },
+    ];
+    articles.forEach((article) => {
+      expect(applyApTitleCase(article.result)).toEqual(article.expected);
+    });
+  });
+
+  it('first word should be capitalized even if it is an article', () => {
+    const result = applyApTitleCase('a Visit from The Goon Squad.');
+    expect(result).toEqual('A Visit From the Goon Squad.');
+  });
+
+  // conjunctions - https://www.grammarly.com/blog/articles/
+  // e.g 'Fact "or" fiction'
+  it('conjunctions in text should be lowercase', () => {
+    const conjunctions = [
+      {
+        result: 'She titled her thesis “Urban Legends: Fact Or Fiction?”',
+        expected: 'She Titled Her Thesis “Urban Legends: Fact or Fiction?”',
+      },
+      {
+        result: 'Shakespeare wrote Romeo And Juliet.',
+        expected: 'Shakespeare Wrote Romeo and Juliet.',
+      },
+    ];
+    conjunctions.forEach((conjunction) => {
+      expect(applyApTitleCase(conjunction.result)).toEqual(
+        conjunction.expected
+      );
+    });
+  });
+
+  // nouns, verbs, adjectives, adverbs
+  it('nouns, verbs, adjectives, adverbs in text should be uppercase', () => {
+    const allUppercaseTypes = [
+      {
+        result: 'The lion, the witch and the wardrobe is by C. S. Lewis.',
+        expected: 'The Lion, the Witch and the Wardrobe Is by C. S. Lewis.',
+      },
+      {
+        result: 'Things fall Apart is by Chinua Achebe.',
+        expected: 'Things Fall Apart Is by Chinua Achebe.',
+      },
+      {
+        result: 'Roald Dahl wrote Charlie and the chocolate Factory.',
+        expected: 'Roald Dahl Wrote Charlie and the Chocolate Factory.',
+      },
+      {
+        result:
+          'Brené Brown wrote Daring greatly: How the Courage to Be Vulnerable Transforms the Way We Live, Love, Parent, and Lead.',
+        expected:
+          'Brené Brown Wrote Daring Greatly: How the Courage to Be Vulnerable Transforms the Way We Live, Love, Parent, and Lead.',
+      },
+      {
+        result: 'Norman Maclean wrote A River Runs through It. ',
+        expected: 'Norman Maclean Wrote a River Runs Through It. ',
+      },
+    ];
+    allUppercaseTypes.forEach((type) => {
+      expect(applyApTitleCase(type.result)).toEqual(type.expected);
+    });
+  });
+});

--- a/src/_shared/utils/applyApTitleCase.ts
+++ b/src/_shared/utils/applyApTitleCase.ts
@@ -1,0 +1,47 @@
+export const STOP_WORDS =
+  'a an and at but by for in nor of on or so the to up yet';
+
+export const SEPARATORS = /(\s+|[-‑–—,:;!?()])/;
+
+/**
+ * Capitalize first character for string
+ *
+ * @param {string} value
+ * @returns {string}
+ */
+const capitalize = (value: string) => {
+  if (!value) {
+    return '';
+  }
+  return value.charAt(0).toUpperCase() + value.slice(1);
+};
+
+/**
+ * Helper to convert text to AP title case
+ * adapted from https://github.com/words/ap-style-title-case
+ * text should match https://headlinecapitalization.com/
+ *
+ * @param {string} [value]
+ * @returns {string}
+ */
+export const applyApTitleCase = (value: string): string => {
+  if (!value) {
+    return '';
+  }
+  // split by separators, check if word is first or last
+  // or not blacklisted, then capitalize
+  const stop = STOP_WORDS.split(' ');
+  return value
+    .split(SEPARATORS)
+    .map((word, index, all) => {
+      if (
+        index === 0 ||
+        index === all.length - 1 ||
+        !stop.includes(word.toLowerCase())
+      ) {
+        return capitalize(word);
+      }
+      return word.toLowerCase();
+    })
+    .join('');
+};

--- a/src/_shared/utils/applyApTitleCase.ts
+++ b/src/_shared/utils/applyApTitleCase.ts
@@ -3,6 +3,8 @@ export const STOP_WORDS =
 
 export const SEPARATORS = /(\s+|[-‑–—,:;!?()])/;
 
+export const stop = STOP_WORDS.split(' ');
+
 /**
  * Capitalize first character for string
  *
@@ -30,7 +32,6 @@ export const applyApTitleCase = (value: string): string => {
   }
   // split by separators, check if word is first or last
   // or not blacklisted, then capitalize
-  const stop = STOP_WORDS.split(' ');
   return value
     .split(SEPARATORS)
     .map((word, index, all) => {

--- a/src/_shared/utils/applyCurlyQuotes.test.ts
+++ b/src/_shared/utils/applyCurlyQuotes.test.ts
@@ -1,0 +1,23 @@
+import { applyCurlyQuotes } from './applyCurlyQuotes';
+
+describe('applyCurlyQuotes', () => {
+  it('returns an empty string if no text added', () => {
+    const result = applyCurlyQuotes('');
+    expect(result).toEqual('');
+  });
+
+  it('adds single open curly apostrophe for straight apostrophe', () => {
+    const result = applyCurlyQuotes("Here's to the great ones!");
+    expect(result).toEqual('Here‘s to the great ones!');
+  });
+
+  it('adds double curly apostrophes for straight apostrophe wrapping text', () => {
+    const result = applyCurlyQuotes('Here\'s a quote - "To be or not to be"');
+    expect(result).toEqual('Here‘s a quote - “To be or not to be”');
+  });
+
+  it('adds single curly apostrophes for straight apostrophes wrapping text', () => {
+    const result = applyCurlyQuotes("Here's a quote - 'To be or not to be'");
+    expect(result).toEqual('Here‘s a quote - ‘To be or not to be’');
+  });
+});

--- a/src/_shared/utils/applyCurlyQuotes.test.ts
+++ b/src/_shared/utils/applyCurlyQuotes.test.ts
@@ -8,16 +8,30 @@ describe('applyCurlyQuotes', () => {
 
   it('adds single open curly apostrophe for straight apostrophe', () => {
     const result = applyCurlyQuotes("Here's to the great ones!");
-    expect(result).toEqual('Here‘s to the great ones!');
+    expect(result).toEqual('Here’s to the great ones!');
   });
 
   it('adds double curly apostrophes for straight apostrophe wrapping text', () => {
     const result = applyCurlyQuotes('Here\'s a quote - "To be or not to be"');
-    expect(result).toEqual('Here‘s a quote - “To be or not to be”');
+    expect(result).toEqual('Here’s a quote - “To be or not to be”');
   });
 
   it('adds single curly apostrophes for straight apostrophes wrapping text', () => {
     const result = applyCurlyQuotes("Here's a quote - 'To be or not to be'");
-    expect(result).toEqual('Here‘s a quote - ‘To be or not to be’');
+    expect(result).toEqual('Here’s a quote - ‘To be or not to be’');
+  });
+
+  it('adds single curly apostrophes at the end of quotes', () => {
+    const result = applyCurlyQuotes("Here's a quote - 'To be or not to be.'");
+    expect(result).toEqual('Here’s a quote - ‘To be or not to be.’');
+  });
+
+  it('adds double curly apostrophes at the end of quotes', () => {
+    const result = applyCurlyQuotes(
+      'I tried the workout, and it did more than expected. "Fitness is for Everyone."'
+    );
+    expect(result).toEqual(
+      'I tried the workout, and it did more than expected. “Fitness is for Everyone.”'
+    );
   });
 });

--- a/src/_shared/utils/applyCurlyQuotes.ts
+++ b/src/_shared/utils/applyCurlyQuotes.ts
@@ -1,0 +1,15 @@
+/**
+ * Helper to replace opening and closing curly single and double quotes
+ *
+ * @param text
+ * @returns {string}
+ */
+
+export const applyCurlyQuotes = (text: string): string => {
+  if (!text) return '';
+  return text
+    .replace(/'\b/g, '\u2018') // Opening singles
+    .replace(/\b'/g, '\u2019') // Closing singles
+    .replace(/"\b/g, '\u201c') // Opening doubles
+    .replace(/\b"/g, '\u201d'); // Closing doubles
+};

--- a/src/_shared/utils/applyCurlyQuotes.ts
+++ b/src/_shared/utils/applyCurlyQuotes.ts
@@ -1,15 +1,18 @@
 /**
  * Helper to replace opening and closing curly single and double quotes
+ * adapted from https://gist.github.com/drdrang/705071
  *
  * @param text
  * @returns {string}
  */
 
 export const applyCurlyQuotes = (text: string): string => {
-  if (!text) return '';
+  if (!text) {
+    return '';
+  }
   return text
-    .replace(/'\b/g, '\u2018') // Opening singles
-    .replace(/\b'/g, '\u2019') // Closing singles
-    .replace(/"\b/g, '\u201c') // Opening doubles
-    .replace(/\b"/g, '\u201d'); // Closing doubles
+    .replace(/(^|[-\u2014/([{"\s])'/g, '$1\u2018') // Opening singles
+    .replace(/'/g, '\u2019') // Closing singles & apostrophes
+    .replace(/(^|[-\u2014/([{\u2018\s])"/g, '$1\u201c') // Opening doubles
+    .replace(/"/g, '\u201d'); // Closing doubles
 };

--- a/src/collections/components/StoryForm/StoryForm.tsx
+++ b/src/collections/components/StoryForm/StoryForm.tsx
@@ -27,6 +27,8 @@ import {
   useGetStoryFromParserLazyQuery,
 } from '../../../api/generatedTypes';
 import { flattenAuthors } from '../../../_shared/utils/flattenAuthors';
+import { applyApTitleCase } from '../../../_shared/utils/applyApTitleCase';
+import { applyCurlyQuotes } from '../../../_shared/utils/applyCurlyQuotes';
 
 interface StoryFormProps {
   /**
@@ -214,6 +216,13 @@ export const StoryForm: React.FC<StoryFormProps & SharedFormButtonsProps> = (
     }
   };
 
+  const fixTitle = () => {
+    formik.setFieldValue(
+      'title',
+      applyCurlyQuotes(applyApTitleCase(formik.values.title))
+    );
+  };
+
   return (
     <form name="story-form" onSubmit={formik.handleSubmit}>
       <Grid container spacing={3}>
@@ -250,12 +259,21 @@ export const StoryForm: React.FC<StoryFormProps & SharedFormButtonsProps> = (
         {showOtherFields && (
           <>
             <Grid item xs={12}>
-              <FormikTextField
-                id="title"
-                label="Title"
-                fieldProps={formik.getFieldProps('title')}
-                fieldMeta={formik.getFieldMeta('title')}
-              />
+              <Box display="flex">
+                <Box flexGrow={1} alignSelf="center" textOverflow="ellipsis">
+                  <FormikTextField
+                    id="title"
+                    label="Title"
+                    fieldProps={formik.getFieldProps('title')}
+                    fieldMeta={formik.getFieldMeta('title')}
+                  />
+                </Box>
+                <Box alignSelf="baseline" ml={1}>
+                  <Button buttonType="hollow" onClick={fixTitle}>
+                    Fix title
+                  </Button>
+                </Box>
+              </Box>
             </Grid>
             <Grid item xs={12} sm={3}>
               <CardMedia

--- a/src/collections/components/StoryForm/StoryForm.tsx
+++ b/src/collections/components/StoryForm/StoryForm.tsx
@@ -223,6 +223,10 @@ export const StoryForm: React.FC<StoryFormProps & SharedFormButtonsProps> = (
     );
   };
 
+  const fixExcerpt = () => {
+    formik.setFieldValue('excerpt', applyCurlyQuotes(formik.values.excerpt));
+  };
+
   return (
     <form name="story-form" onSubmit={formik.handleSubmit}>
       <Grid container spacing={3}>
@@ -330,6 +334,11 @@ export const StoryForm: React.FC<StoryFormProps & SharedFormButtonsProps> = (
                   minRows={4}
                 />
               </MarkdownPreview>
+            </Grid>
+            <Grid item xs={12}>
+              <Button buttonType="hollow" onClick={fixExcerpt}>
+                Fix excerpt
+              </Button>
             </Grid>
             {formik.isSubmitting && (
               <Grid item xs={12}>


### PR DESCRIPTION
## Goal
Based on meeting we had with Editorial team, we wanted to add a button that fixes the title and the straight apostrophe's in titles when populating from a url.

Created two helper functions for these two fixes:

Add curly quotes and fix AP style title case for titles in collections (see tests also)

Per request from Editorial team, added a 'fix excerpt' button as well

## Reference

Documentation here:
1. Casing follows AP style here - https://headlinecapitalization.com/
2. Regular single and double quotes replaced by curly ones

Tickets:

[Jira](https://getpocket.atlassian.net/jira/software/projects/TML/boards/123?assignee=637ba9dca593cb822e93c33f)
<img width="1274" alt="Screenshot 2023-06-15 at 12 27 14" src="https://github.com/Pocket/curation-admin-tools/assets/119352705/52167ba6-7f3a-4b22-9de6-1701423699d7">

