### PR TITLE
Replace 'View' button on scheduling page with 'Edit'

### DIFF
--- a/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.test.tsx
+++ b/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.test.tsx
@@ -30,6 +30,7 @@ describe('The ScheduledItemCardWrapper component', () => {
         <ThemeProvider theme={theme}>
           <ScheduledItemCardWrapper
             item={item}
+            onEdit={jest.fn()}
             onMoveToBottom={jest.fn()}
             onReschedule={jest.fn()}
             onRemove={jest.fn()}
@@ -50,6 +51,7 @@ describe('The ScheduledItemCardWrapper component', () => {
         <ThemeProvider theme={theme}>
           <ScheduledItemCardWrapper
             item={item}
+            onEdit={jest.fn()}
             onMoveToBottom={jest.fn()}
             onReschedule={jest.fn()}
             onRemove={jest.fn()}
@@ -58,7 +60,9 @@ describe('The ScheduledItemCardWrapper component', () => {
       </MemoryRouter>
     );
 
-    const viewButton = screen.getByRole('button', { name: /View/i });
+    const editButton = screen.getByRole('button', {
+      name: /Edit/i,
+    });
 
     const removeButton = screen.getByRole('button', {
       name: /Remove/i,
@@ -72,7 +76,7 @@ describe('The ScheduledItemCardWrapper component', () => {
       name: /move to bottom/i,
     });
 
-    expect(viewButton).toBeInTheDocument();
+    expect(editButton).toBeInTheDocument();
     expect(removeButton).toBeInTheDocument();
     expect(rescheduleButton).toBeInTheDocument();
     expect(moveButton).toBeInTheDocument();
@@ -86,6 +90,7 @@ describe('The ScheduledItemCardWrapper component', () => {
         <ThemeProvider theme={theme}>
           <ScheduledItemCardWrapper
             item={item}
+            onEdit={jest.fn()}
             onMoveToBottom={jest.fn()}
             onReschedule={jest.fn()}
             onRemove={onRemove}
@@ -111,6 +116,7 @@ describe('The ScheduledItemCardWrapper component', () => {
         <ThemeProvider theme={theme}>
           <ScheduledItemCardWrapper
             item={item}
+            onEdit={jest.fn()}
             onMoveToBottom={jest.fn()}
             onReschedule={onReschedule}
             onRemove={jest.fn()}
@@ -136,6 +142,7 @@ describe('The ScheduledItemCardWrapper component', () => {
         <ThemeProvider theme={theme}>
           <ScheduledItemCardWrapper
             item={item}
+            onEdit={jest.fn()}
             onMoveToBottom={onMoveToBottom}
             onReschedule={jest.fn()}
             onRemove={jest.fn()}
@@ -153,12 +160,15 @@ describe('The ScheduledItemCardWrapper component', () => {
     expect(onMoveToBottom).toHaveBeenCalled();
   });
 
-  it('should have the correct link to corpus item page', () => {
+  it('should run an action on pressing the "Edit" button', () => {
+    const onEdit = jest.fn();
+
     render(
       <MemoryRouter>
         <ThemeProvider theme={theme}>
           <ScheduledItemCardWrapper
             item={item}
+            onEdit={onEdit}
             onMoveToBottom={jest.fn()}
             onReschedule={jest.fn()}
             onRemove={jest.fn()}
@@ -167,12 +177,12 @@ describe('The ScheduledItemCardWrapper component', () => {
       </MemoryRouter>
     );
 
-    // The link to the corpus item page is present and is well-formed
-    const linkToItemPage = screen.getByText(/view/i) as HTMLAnchorElement;
-    expect(linkToItemPage).toBeInTheDocument();
-    expect(linkToItemPage).toHaveAttribute(
-      'href',
-      expect.stringContaining(item.approvedItem.externalId)
+    userEvent.click(
+      screen.getByRole('button', {
+        name: /Edit/i,
+      })
     );
+
+    expect(onEdit).toHaveBeenCalled();
   });
 });

--- a/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.tsx
+++ b/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import { Grid } from '@mui/material';
-import { Link as RouterLink } from 'react-router-dom';
 import { ScheduledCorpusItem } from '../../../api/generatedTypes';
 import { Button } from '../../../_shared/components';
 import {
   StyledCardActions,
   StyledCorpusItemCard,
-  StyledLinkButton,
 } from '../../../_shared/styled';
 import { ApprovedItemListCard } from '../';
 
@@ -32,6 +30,11 @@ interface ScheduledItemCardWrapperProps {
   onReschedule: VoidFunction;
 
   /**
+   * Callback for the "Edit" button
+   */
+  onEdit: VoidFunction;
+
+  /**
    * Optional boolean prop to show/hide the language icon on the ApprovedItemListCard component
    */
   showLanguageIcon?: boolean;
@@ -50,6 +53,7 @@ export const ScheduledItemCardWrapper: React.FC<
     onMoveToBottom,
     onRemove,
     onReschedule,
+    onEdit,
     showLanguageIcon,
     showRecommendedOverlay,
   } = props;
@@ -64,13 +68,8 @@ export const ScheduledItemCardWrapper: React.FC<
         />
 
         <StyledCardActions>
-          <Button buttonType="positive" variant="text">
-            <StyledLinkButton
-              to={`/curated-corpus/corpus/item/${item.approvedItem.externalId}`}
-              component={RouterLink}
-            >
-              View
-            </StyledLinkButton>
+          <Button buttonType="positive" variant="text" onClick={onEdit}>
+            Edit
           </Button>
           <Button buttonType="positive" variant="text" onClick={onReschedule}>
             Reschedule

--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -19,6 +19,7 @@ import {
   HandleApiResponse,
 } from '../../../_shared/components';
 import {
+  EditCorpusItemAction,
   RemoveItemFromScheduledSurfaceModal,
   ScheduledItemCardWrapper,
   ScheduleItemModal,
@@ -99,6 +100,11 @@ export const SchedulePage: React.FC = (): JSX.Element => {
    * Keep track of whether the "Schedule Item Modal" is open or not
    */
   const [scheduleItemModalOpen, toggleScheduleItemModal] = useToggle(false);
+
+  /**
+   * Keep track of whether the "Edit item modal" is open or not
+   */
+  const [editItemModalOpen, toggleEditModal] = useToggle(false);
 
   // Get the list of Scheduled Surfaces the currently logged-in user has access to.
   const { data: scheduledSurfaceData } = useGetScheduledSurfacesForUserQuery();
@@ -356,6 +362,15 @@ export const SchedulePage: React.FC = (): JSX.Element => {
         />
       )}
 
+      {currentItem && (
+        <EditCorpusItemAction
+          item={currentItem?.approvedItem!}
+          modalOpen={editItemModalOpen}
+          toggleModal={toggleEditModal}
+          refetch={refetch}
+        />
+      )}
+
       {scheduledSurfaceOptions.length > 0 && (
         <Grid container spacing={2}>
           <Grid item>
@@ -484,6 +499,10 @@ export const SchedulePage: React.FC = (): JSX.Element => {
                           <ScheduledItemCardWrapper
                             key={item.externalId}
                             item={item}
+                            onEdit={() => {
+                              setCurrentItem(item);
+                              toggleEditModal();
+                            }}
                             onRemove={() => {
                               setCurrentItem(item);
                               toggleRemoveModal();


### PR DESCRIPTION
## Goal
- Update 'View' button in scheduling page with 'Edit' button
- Edit button will popup modal similar to other pages.
- View button can be re-added if necessary.

Tickets:

- https://getpocket.atlassian.net/browse/TML-95

<img width="998" alt="Screenshot 2023-06-22 at 14 01 45" src="https://github.com/Pocket/curation-admin-tools/assets/119352705/346eabcf-4bec-43d8-a0d8-5327a90b5fc0">

