### PR TITLE
Show Article Publish Date in Prospecting tool

### DIFF
--- a/src/api/fragments/BasicParserItemData.ts
+++ b/src/api/fragments/BasicParserItemData.ts
@@ -1,0 +1,13 @@
+import { gql } from '@apollo/client';
+
+/**
+ * Everything we need to fetch for a Curated Item
+ */
+export const BasicParserItemData = gql`
+  fragment BasicParserItemData on Item {
+    givenUrl
+    itemId
+    normalUrl
+    datePublished
+  }
+`;

--- a/src/api/fragments/prospect.ts
+++ b/src/api/fragments/prospect.ts
@@ -22,5 +22,8 @@ export const ProspectData = gql`
     saveCount
     isSyndicated
     isCollection
+    item {
+      ...BasicParserItemData
+    }
   }
 `;

--- a/src/api/fragments/prospectWithCorpusItems.ts
+++ b/src/api/fragments/prospectWithCorpusItems.ts
@@ -1,6 +1,7 @@
 import { gql } from '@apollo/client';
 import { CuratedItemDataWithHistory } from './CuratedItemWithHistory';
 import { RejectedItemData } from './rejectedItemData';
+import {BasicParserItemData} from './BasicParserItemData'
 
 /**
  * Everything we need to fetch for a Prospect, including optional
@@ -31,7 +32,11 @@ export const ProspectDataWithCorpusItems = gql`
     rejectedCorpusItem {
       ...RejectedItemData
     }
+    item {
+      ...BasicParserItemData
+    }
   }
   ${CuratedItemDataWithHistory}
   ${RejectedItemData}
+  ${BasicParserItemData}
 `;

--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -862,6 +862,8 @@ export type Item = {
    * marked as beta because it's not ready yet for large client request.
    */
   shortUrl?: Maybe<Scalars['Url']>;
+  /** If the url is an Article, the text in SSML format for speaking, i.e. Listen */
+  ssml?: Maybe<Scalars['String']>;
   /**
    * Date this item was first parsed in Pocket
    * @deprecated Clients should not use this
@@ -1320,6 +1322,7 @@ export type Prospect = {
   imageUrl?: Maybe<Scalars['String']>;
   isCollection?: Maybe<Scalars['Boolean']>;
   isSyndicated?: Maybe<Scalars['Boolean']>;
+  item?: Maybe<Item>;
   language?: Maybe<CorpusLanguage>;
   prospectId: Scalars['ID'];
   prospectType: Scalars['String'];
@@ -1330,7 +1333,6 @@ export type Prospect = {
   title?: Maybe<Scalars['String']>;
   topic?: Maybe<Scalars['String']>;
   url: Scalars['String'];
-  item?: Maybe<Item>;
 };
 
 /**
@@ -3948,13 +3950,6 @@ export type GetProspectsQuery = {
     saveCount?: number | null;
     isSyndicated?: boolean | null;
     isCollection?: boolean | null;
-    item?: {
-        __typename?: 'Item';
-        givenUrl: string;
-        itemId: string;
-        normalUrl: string;
-        datePublished?: Maybe<Scalars['DateString']>;
-    }
     approvedCorpusItem?: {
       __typename?: 'ApprovedCorpusItem';
       externalId: string;
@@ -4520,11 +4515,6 @@ export const ProspectDataWithCorpusItemsFragmentDoc = gql`
     }
     rejectedCorpusItem {
       ...RejectedItemData
-    }
-    item {
-        givenUrl,
-        normalUrl,
-        datePublished
     }
   }
   ${CuratedItemDataWithHistoryFragmentDoc}

--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -1330,6 +1330,7 @@ export type Prospect = {
   title?: Maybe<Scalars['String']>;
   topic?: Maybe<Scalars['String']>;
   url: Scalars['String'];
+  item?: Maybe<Item>;
 };
 
 /**
@@ -3947,6 +3948,13 @@ export type GetProspectsQuery = {
     saveCount?: number | null;
     isSyndicated?: boolean | null;
     isCollection?: boolean | null;
+    item?: {
+        __typename?: 'Item';
+        givenUrl: string;
+        itemId: string;
+        normalUrl: string;
+        datePublished?: Maybe<Scalars['DateString']>;
+    }
     approvedCorpusItem?: {
       __typename?: 'ApprovedCorpusItem';
       externalId: string;
@@ -4512,6 +4520,11 @@ export const ProspectDataWithCorpusItemsFragmentDoc = gql`
     }
     rejectedCorpusItem {
       ...RejectedItemData
+    }
+    item {
+        givenUrl,
+        normalUrl,
+        datePublished
     }
   }
   ${CuratedItemDataWithHistoryFragmentDoc}

--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -2055,6 +2055,14 @@ export enum Videoness {
   NoVideos = 'NO_VIDEOS',
 }
 
+export type BasicParserItemDataFragment = {
+  __typename?: 'Item';
+  givenUrl: any;
+  itemId: string;
+  normalUrl: string;
+  datePublished?: any | null;
+};
+
 export type CollectionAuthorDataFragment = {
   __typename?: 'CollectionAuthor';
   externalId: string;
@@ -2298,6 +2306,13 @@ export type ProspectDataFragment = {
   saveCount?: number | null;
   isSyndicated?: boolean | null;
   isCollection?: boolean | null;
+  item?: {
+    __typename?: 'Item';
+    givenUrl: any;
+    itemId: string;
+    normalUrl: string;
+    datePublished?: any | null;
+  } | null;
 };
 
 export type ProspectDataWithCorpusItemsFragment = {
@@ -2364,6 +2379,13 @@ export type ProspectDataWithCorpusItemsFragment = {
     reason: string;
     createdBy: string;
     createdAt: number;
+  } | null;
+  item?: {
+    __typename?: 'Item';
+    givenUrl: any;
+    itemId: string;
+    normalUrl: string;
+    datePublished?: any | null;
   } | null;
 };
 
@@ -2828,6 +2850,13 @@ export type DismissProspectMutation = {
     saveCount?: number | null;
     isSyndicated?: boolean | null;
     isCollection?: boolean | null;
+    item?: {
+      __typename?: 'Item';
+      givenUrl: any;
+      itemId: string;
+      normalUrl: string;
+      datePublished?: any | null;
+    } | null;
   } | null;
 };
 
@@ -3457,6 +3486,13 @@ export type UpdateProspectAsCuratedMutation = {
       createdBy: string;
       createdAt: number;
     } | null;
+    item?: {
+      __typename?: 'Item';
+      givenUrl: any;
+      itemId: string;
+      normalUrl: string;
+      datePublished?: any | null;
+    } | null;
   } | null;
 };
 
@@ -3996,6 +4032,13 @@ export type GetProspectsQuery = {
       createdBy: string;
       createdAt: number;
     } | null;
+    item?: {
+      __typename?: 'Item';
+      givenUrl: any;
+      itemId: string;
+      normalUrl: string;
+      datePublished?: any | null;
+    } | null;
   }>;
 };
 
@@ -4424,6 +4467,14 @@ export const ShareableListCompletePropsFragmentDoc = gql`
   }
   ${ShareableListItemPropsFragmentDoc}
 `;
+export const BasicParserItemDataFragmentDoc = gql`
+  fragment BasicParserItemData on Item {
+    givenUrl
+    itemId
+    normalUrl
+    datePublished
+  }
+`;
 export const ProspectDataFragmentDoc = gql`
   fragment ProspectData on Prospect {
     id
@@ -4443,7 +4494,11 @@ export const ProspectDataFragmentDoc = gql`
     saveCount
     isSyndicated
     isCollection
+    item {
+      ...BasicParserItemData
+    }
   }
+  ${BasicParserItemDataFragmentDoc}
 `;
 export const CuratedItemDataWithHistoryFragmentDoc = gql`
   fragment CuratedItemDataWithHistory on ApprovedCorpusItem {
@@ -4516,9 +4571,13 @@ export const ProspectDataWithCorpusItemsFragmentDoc = gql`
     rejectedCorpusItem {
       ...RejectedItemData
     }
+    item {
+      ...BasicParserItemData
+    }
   }
   ${CuratedItemDataWithHistoryFragmentDoc}
   ${RejectedItemDataFragmentDoc}
+  ${BasicParserItemDataFragmentDoc}
 `;
 export const CuratedItemDataFragmentDoc = gql`
   fragment CuratedItemData on ApprovedCorpusItem {

--- a/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.tsx
+++ b/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.tsx
@@ -34,7 +34,7 @@ interface ExistingProspectCardProps {
    */
   item: ApprovedCorpusItem;
 
-  realItem: Item;
+  parserItem: Item;
   /**
    * This is the prospect.id and NOT prospect.prospectId
    */
@@ -61,7 +61,7 @@ interface ExistingProspectCardProps {
 export const ExistingProspectCard: React.FC<ExistingProspectCardProps> = (
   props
 ): JSX.Element => {
-  const { item, realItem, onSchedule, onDismissProspect, prospectId } = props;
+  const { item, parserItem, onSchedule, onDismissProspect, prospectId } = props;
   const showScheduleHistory = item.scheduledSurfaceHistory.length != 0;
 
   return (
@@ -96,9 +96,9 @@ export const ExistingProspectCard: React.FC<ExistingProspectCardProps> = (
             <ListItem disableGutters>
               <ListItemText
                 secondary={
-                  realItem?.datePublished &&
+                  parserItem?.datePublished &&
                   `Published ${DateTime.fromJSDate(
-                    new Date(realItem?.datePublished)
+                    new Date(parserItem?.datePublished)
                   ).toFormat('MMMM dd, yyyy')}`
                 }
               />

--- a/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.tsx
+++ b/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.tsx
@@ -20,7 +20,7 @@ import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import { DateTime } from 'luxon';
 
 import { curationPalette } from '../../../theme';
-import { ApprovedCorpusItem } from '../../../api/generatedTypes';
+import { ApprovedCorpusItem, Item } from '../../../api/generatedTypes';
 import { Button } from '../../../_shared/components';
 import { getCuratorNameFromLdap } from '../../helpers/helperFunctions';
 import { ScheduleHistory } from '../ScheduleHistory/ScheduleHistory';
@@ -34,6 +34,7 @@ interface ExistingProspectCardProps {
    */
   item: ApprovedCorpusItem;
 
+  realItem: Item;
   /**
    * This is the prospect.id and NOT prospect.prospectId
    */
@@ -60,7 +61,7 @@ interface ExistingProspectCardProps {
 export const ExistingProspectCard: React.FC<ExistingProspectCardProps> = (
   props
 ): JSX.Element => {
-  const { item, onSchedule, onDismissProspect, prospectId } = props;
+  const { item, realItem, onSchedule, onDismissProspect, prospectId } = props;
   const showScheduleHistory = item.scheduledSurfaceHistory.length != 0;
 
   return (
@@ -91,6 +92,16 @@ export const ExistingProspectCard: React.FC<ExistingProspectCardProps> = (
                 <LanguageIcon fontSize="small" />
               </ListItemIcon>
               <ListItemText secondary={item.language} />
+            </ListItem>
+            <ListItem disableGutters>
+              <ListItemText
+                secondary={
+                  realItem?.datePublished &&
+                  `Published ${DateTime.fromJSDate(
+                    new Date(realItem?.datePublished)
+                  ).toFormat('MMMM dd, yyyy')}`
+                }
+              />
             </ListItem>
             <ListItem disableGutters>
               <ListItemIcon sx={{ minWidth: '1.5rem' }}>

--- a/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
+++ b/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
@@ -172,7 +172,10 @@ export const ProspectListCard: React.FC<ProspectListCardProps> = (
               )}
             </Grid>
           </Grid>
-          <Typography component="div">{prospect.excerpt}</Typography>
+          <Typography component="div">
+            {prospect?.item?.datePublished}
+            {prospect.excerpt}
+          </Typography>
         </Grid>
       </Grid>
       <CardActions sx={{ margin: 'auto' }}>

--- a/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
+++ b/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Prospect } from '../../../api/generatedTypes';
+import { Item, Prospect } from '../../../api/generatedTypes';
 import {
   Card,
   CardActions,
@@ -22,6 +22,7 @@ import { curationPalette } from '../../../theme';
 import { Button } from '../../../_shared/components';
 import { getDisplayTopic } from '../../helpers/topics';
 import { DismissProspectAction } from '../actions/DismissProspectAction/DismissProspectAction';
+import { DateTime } from 'luxon';
 
 interface ProspectListCardProps {
   /**
@@ -29,6 +30,7 @@ interface ProspectListCardProps {
    */
   prospect: Prospect;
 
+  parserItem: Item;
   /**
    * Function called when "Add to Corpus" button is clicked
    */
@@ -52,8 +54,14 @@ interface ProspectListCardProps {
 export const ProspectListCard: React.FC<ProspectListCardProps> = (
   props
 ): JSX.Element => {
-  const { prospect, onAddToCorpus, onDismissProspect, onRecommend, onReject } =
-    props;
+  const {
+    prospect,
+    parserItem,
+    onAddToCorpus,
+    onDismissProspect,
+    onRecommend,
+    onReject,
+  } = props;
 
   return (
     <Card
@@ -102,6 +110,17 @@ export const ProspectListCard: React.FC<ProspectListCardProps> = (
                 <MyLocationIcon fontSize="small" />
               </ListItemIcon>
               <ListItemText secondary={prospect.prospectType.toLowerCase()} />
+            </ListItem>
+
+            <ListItem disableGutters>
+              <ListItemText
+                secondary={
+                  parserItem?.datePublished &&
+                  `Published ${DateTime.fromJSDate(
+                    new Date(parserItem?.datePublished)
+                  ).toFormat('MMMM dd, yyyy')}`
+                }
+              />
             </ListItem>
           </List>
         </Grid>

--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -772,7 +772,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
                   <ExistingProspectCard
                     key={prospect.id}
                     item={prospect.approvedCorpusItem}
-                    realItem={prospect.item!}
+                    parserItem={prospect.item!}
                     prospectId={prospect.id}
                     onSchedule={() => {
                       setCurrentProspect(prospect);
@@ -786,6 +786,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
               return (
                 <ProspectListCard
                   key={prospect.id}
+                  parserItem={prospect.item}
                   prospect={prospect}
                   onAddToCorpus={() => {
                     setCurrentProspect(prospect);

--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -772,6 +772,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
                   <ExistingProspectCard
                     key={prospect.id}
                     item={prospect.approvedCorpusItem}
+                    realItem={prospect.item!}
                     prospectId={prospect.id}
                     onSchedule={() => {
                       setCurrentProspect(prospect);

--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -786,7 +786,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
               return (
                 <ProspectListCard
                   key={prospect.id}
-                  parserItem={prospect.item}
+                  parserItem={prospect.item!}
                   prospect={prospect}
                   onAddToCorpus={() => {
                     setCurrentProspect(prospect);


### PR DESCRIPTION
## Goal

Insert purpose of pull request

https://getpocket.atlassian.net/browse/TML-98
For TML-98 we're now getting the parser wrapper Item information to augment the UI and provide sorting features.
This is part 1, which shows the publisher date. Part 2 will be a separate PR as this work is being handed off to Vasish.

This relies on PR on prospect-api https://github.com/Pocket/prospect-api/pull/555 which is currently deployed to dev.

## Implementation Decisions
None
