### PR TITLE
Allow scheduling up to 1 year

### DIFF
--- a/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.tsx
+++ b/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.tsx
@@ -149,7 +149,7 @@ export const ScheduleItemForm: React.FC<
               onChange={handleDateChange}
               disablePast
               openTo="day"
-              maxDate={tomorrow.plus({ days: 59 })}
+              maxDate={tomorrow.plus({ days: 365 })}
               renderInput={(params: any) => (
                 <TextField
                   fullWidth

--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -418,7 +418,7 @@ export const SchedulePage: React.FC = (): JSX.Element => {
                       date && setEndDate(date);
                     }}
                     openTo="day"
-                    maxDate={startDate.plus({ days: 30 })}
+                    maxDate={startDate.plus({ days: 365 })}
                     renderInput={(params: any) => (
                       <TextField
                         fullWidth


### PR DESCRIPTION
## Goal

Allow curators to schedule articles one year in advance, e.g. for Christmas next year

## Reference

Documentation here:
- Following is the doc that was used to add the initial `59` days. Seems like it was chosen so curators don't see to many schedule days.
- New requirement is now for `365` days.
- [Link to docs](https://docs.google.com/document/d/15vDPv7RvQwhz3K4Vl3UinHFcDx6ZdCDxlNMPwlZIhb4/edit)

Tickets:

- Previous ticket for 59 days - https://getpocket.atlassian.net/browse/BACK-1363
- New ticket - https://getpocket.atlassian.net/browse/TML-97

## Implementation Decisions

