### PR TITLE
Add schedule context to 'Schedule' and 'Corpus'

### DIFF
--- a/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.test.tsx
+++ b/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.test.tsx
@@ -3,6 +3,7 @@ import { DateTime } from 'luxon';
 import { render, screen } from '@testing-library/react';
 import { ScheduleItemForm } from './ScheduleItemForm';
 import { ProspectType, ScheduledSurface } from '../../../api/generatedTypes';
+import { MockedProvider } from '@apollo/client/testing';
 
 describe('The ScheduleItemForm component', () => {
   const handleSubmit = jest.fn();
@@ -31,7 +32,6 @@ describe('The ScheduleItemForm component', () => {
     render(
       <ScheduleItemForm
         handleDateChange={jest.fn()}
-        lookupCopy=""
         selectedDate={DateTime.local()}
         onSubmit={handleSubmit}
         scheduledSurfaces={scheduledSurfaces}
@@ -48,7 +48,6 @@ describe('The ScheduleItemForm component', () => {
     render(
       <ScheduleItemForm
         handleDateChange={jest.fn()}
-        lookupCopy=""
         selectedDate={DateTime.local()}
         onSubmit={handleSubmit}
         scheduledSurfaces={scheduledSurfaces}
@@ -67,7 +66,6 @@ describe('The ScheduleItemForm component', () => {
       <ScheduleItemForm
         data-testId="surface-selector"
         handleDateChange={jest.fn()}
-        lookupCopy=""
         selectedDate={DateTime.local()}
         onSubmit={handleSubmit}
         scheduledSurfaces={scheduledSurfaces}
@@ -88,16 +86,17 @@ describe('The ScheduleItemForm component', () => {
 
   it('pre-selects the passed in scheduled surface', () => {
     render(
-      <ScheduleItemForm
-        data-testId="surface-selector"
-        handleDateChange={jest.fn()}
-        lookupCopy=""
-        selectedDate={DateTime.local()}
-        onSubmit={handleSubmit}
-        scheduledSurfaces={scheduledSurfaces}
-        scheduledSurfaceGuid="NEW_TAB_EN_US"
-        approvedItemExternalId={'123abc'}
-      />
+      <MockedProvider>
+        <ScheduleItemForm
+          data-testId="surface-selector"
+          handleDateChange={jest.fn()}
+          selectedDate={DateTime.local()}
+          onSubmit={handleSubmit}
+          scheduledSurfaces={scheduledSurfaces}
+          scheduledSurfaceGuid="NEW_TAB_EN_US"
+          approvedItemExternalId={'123abc'}
+        />
+      </MockedProvider>
     );
 
     const select = screen.getByLabelText(
@@ -114,15 +113,16 @@ describe('The ScheduleItemForm component', () => {
 
   it('pre-selects the only available scheduled surface if none was specified and the user only has access to a single one', () => {
     render(
-      <ScheduleItemForm
-        data-testId="surface-selector"
-        handleDateChange={jest.fn()}
-        lookupCopy=""
-        selectedDate={DateTime.local()}
-        onSubmit={handleSubmit}
-        scheduledSurfaces={[scheduledSurfaces[0]]}
-        approvedItemExternalId={'123abc'}
-      />
+      <MockedProvider>
+        <ScheduleItemForm
+          data-testId="surface-selector"
+          handleDateChange={jest.fn()}
+          selectedDate={DateTime.local()}
+          onSubmit={handleSubmit}
+          scheduledSurfaces={[scheduledSurfaces[0]]}
+          approvedItemExternalId={'123abc'}
+        />
+      </MockedProvider>
     );
 
     const select = screen.getByLabelText(

--- a/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.test.tsx
+++ b/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { DateTime } from 'luxon';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from "@testing-library/react";
 import { ScheduleItemForm } from './ScheduleItemForm';
 import { ProspectType, ScheduledSurface } from '../../../api/generatedTypes';
 import { MockedProvider } from '@apollo/client/testing';
@@ -134,5 +134,26 @@ describe('The ScheduleItemForm component', () => {
 
     // the scheduled surface should be selected
     expect(select.options[1].selected).toBeTruthy();
+  });
+
+  it('ensure that the schedule context is rendered when scheduled surface is populated', async () => {
+    render(
+      <MockedProvider>
+        <ScheduleItemForm
+          data-testId="surface-selector"
+          handleDateChange={jest.fn()}
+          selectedDate={DateTime.local()}
+          onSubmit={handleSubmit}
+          scheduledSurfaces={scheduledSurfaces}
+          scheduledSurfaceGuid="NEW_TAB_EN_US"
+          approvedItemExternalId={'123abc'}
+        />
+      </MockedProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/story/i)).toBeInTheDocument();
+      expect(screen.getByText(/syndicated/i)).toBeInTheDocument();
+    });
   });
 });

--- a/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.tsx
+++ b/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Box, Grid, LinearProgress, TextField } from '@mui/material';
 import { FormikHelpers, FormikValues, useFormik } from 'formik';
 import { DatePicker, LocalizationProvider } from '@mui/x-date-pickers';
@@ -11,6 +11,7 @@ import {
 } from '../../../_shared/components';
 import { getValidationSchema } from './ScheduleItemForm.validation';
 import { ScheduledSurface } from '../../../api/generatedTypes';
+import { ScheduleSummaryConnector } from '../ScheduleSummaryConnector/ScheduleSummaryConnector';
 
 interface ScheduleItemFormProps {
   /**
@@ -22,13 +23,6 @@ interface ScheduleItemFormProps {
    * What to do when the user picks a date.
    */
   handleDateChange: (date: any, value?: string | null | undefined) => void;
-
-  /**
-   * The copy/JSX to show underneath the form when the user picks a date
-   * and a call to the API is triggered to look up whether any other
-   * items have been scheduled for this date.
-   */
-  lookupCopy: JSX.Element | string;
 
   /**
    * The list of Scheduled Surfaces the logged-in user has access to.
@@ -68,7 +62,6 @@ export const ScheduleItemForm: React.FC<
   const {
     approvedItemExternalId,
     handleDateChange,
-    lookupCopy,
     scheduledSurfaces,
     scheduledSurfaceGuid,
     disableScheduledSurface = false,
@@ -82,7 +75,10 @@ export const ScheduleItemForm: React.FC<
   // Run the lookup query for scheduled items on loading the component,
   // so that users can see straight away how many stories have already
   // been scheduled for the default date (tomorrow).
+  const [refreshData, setRefreshData] = useState(false);
+
   useEffect(() => {
+    setRefreshData(true);
     handleDateChange(tomorrow);
   }, []);
 
@@ -161,7 +157,17 @@ export const ScheduleItemForm: React.FC<
               )}
             />
           </Grid>
-
+          {formik.values.scheduledSurfaceGuid &&
+            formik.values.scheduledSurfaceGuid.length > 0 && (
+              <Grid item xs={12}>
+                <ScheduleSummaryConnector
+                  date={selectedDate!}
+                  scheduledSurfaceGuid={formik.values.scheduledSurfaceGuid}
+                  refreshData={refreshData}
+                  setRefreshData={setRefreshData}
+                />
+              </Grid>
+            )}
           {formik.isSubmitting && (
             <Grid item xs={12}>
               <Box mb={3}>
@@ -181,13 +187,6 @@ export const ScheduleItemForm: React.FC<
 
         <SharedFormButtons onCancel={onCancel} />
       </form>
-      <Grid container spacing={3}>
-        <Grid item xs={12}>
-          <Box display="flex" justifyContent="center" mt={2} mb={1}>
-            <h3>{lookupCopy}</h3>
-          </Box>
-        </Grid>
-      </Grid>
     </LocalizationProvider>
   );
 };

--- a/src/curated-corpus/components/ScheduleItemFormConnector/ScheduleItemFormConnector.tsx
+++ b/src/curated-corpus/components/ScheduleItemFormConnector/ScheduleItemFormConnector.tsx
@@ -1,19 +1,12 @@
-import React, { useEffect, useState } from 'react';
-import { ApolloError } from '@apollo/client';
+import React, { useState } from 'react';
 import { FormikHelpers, FormikValues } from 'formik';
 import { DateTime } from 'luxon';
-import { CircularProgress } from '@mui/material';
 import {
   HandleApiResponse,
   SharedFormButtonsProps,
 } from '../../../_shared/components';
-import {
-  ScheduledCorpusItemsFilterInput,
-  useGetScheduledItemCountsLazyQuery,
-  useGetScheduledSurfacesForUserQuery,
-} from '../../../api/generatedTypes';
+import { useGetScheduledSurfacesForUserQuery } from '../../../api/generatedTypes';
 
-import { useNotifications } from '../../../_shared/hooks';
 import { ScheduleItemForm } from '../';
 
 interface ScheduleItemFormConnectorProps {
@@ -66,74 +59,11 @@ export const ScheduleItemFormConnector: React.FC<
   // object instead of parsing the date from string.
   const [selectedDate, setSelectedDate] = useState<DateTime | null>(tomorrow);
 
-  // Start with no copy underneath the form that shows if there are any other
-  // scheduled items for the chosen date.
-  const [lookupCopy, setLookupCopy] = useState<JSX.Element | string>('');
-
-  // get a helper function to show an error in case scheduled item lookup fails.
-  const { showNotification } = useNotifications();
-
-  // Get the usual API response vars and a helper method to retrieve data
-  // that can be used inside hooks.
-  const [getScheduledItemCounts, { loading: loadingCounts }] =
-    useGetScheduledItemCountsLazyQuery({
-      fetchPolicy: 'no-cache',
-      notifyOnNetworkStatusChange: true,
-      onCompleted: (data) => {
-        // If there's something already scheduled for the chosen date,
-        // let the user know.
-        if (data.getScheduledCorpusItems.length > 0) {
-          const totalCount = data.getScheduledCorpusItems[0].totalCount;
-
-          setLookupCopy(
-            <>
-              Already scheduled: {totalCount}{' '}
-              {totalCount === 1 ? 'story' : 'stories'} (
-              {data.getScheduledCorpusItems[0].syndicatedCount} syndicated).
-            </>
-          );
-        } else {
-          setLookupCopy('Nothing has been scheduled for this date yet.');
-        }
-      },
-      onError: (error: ApolloError) => {
-        showNotification(error.message, 'error');
-      },
-    });
-
   // What to do when the user clicks on a date in the calendar.
   const handleDateChange = (date: any, value?: string | null | undefined) => {
     // Keep track of the chosen date.
     setSelectedDate(date);
-
-    // If the Scheduled Surface has been specified, run a lookup query.
-    // Realistically, this means that the lookup will be available on the Prospecting
-    // page but not on the Corpus page.
-    if (scheduledSurfaceGuid) {
-      // Look up any other scheduled items for this date + scheduled surface combination.
-      // Start with the filters. Note `startDate` and `endDate` is the same as we're
-      // interested in single day data only.
-      const filters: ScheduledCorpusItemsFilterInput = {
-        scheduledSurfaceGuid,
-        startDate: date?.toFormat('yyyy-MM-dd'),
-        endDate: date?.toFormat('yyyy-MM-dd'),
-      };
-
-      getScheduledItemCounts({ variables: { filters } });
-    }
   };
-
-  // There seems to be no better way of tracking this and passing it
-  // to the child form component ¯\_(ツ)_/¯.
-  useEffect(() => {
-    if (loadingCounts) {
-      setLookupCopy(
-        <>
-          <CircularProgress /> Checking...
-        </>
-      );
-    }
-  }, [loadingCounts]);
 
   return (
     <>
@@ -142,7 +72,6 @@ export const ScheduleItemFormConnector: React.FC<
         <ScheduleItemForm
           approvedItemExternalId={approvedItemExternalId}
           handleDateChange={handleDateChange}
-          lookupCopy={lookupCopy}
           scheduledSurfaces={data?.getScheduledSurfacesForUser}
           scheduledSurfaceGuid={scheduledSurfaceGuid}
           disableScheduledSurface={disableScheduledSurface}

--- a/src/curated-corpus/components/ScheduleSummaryConnector/ScheduleSummaryConnector.tsx
+++ b/src/curated-corpus/components/ScheduleSummaryConnector/ScheduleSummaryConnector.tsx
@@ -116,7 +116,11 @@ export const ScheduleSummaryConnector: React.FC<
         <>
           <Typography
             variant="h4"
-            sx={{ fontSize: '1rem', fontWeight: 500, padding: '0.75rem 0' }}
+            sx={{
+              fontSize: '1rem',
+              fontWeight: 500,
+              padding: '0.75rem 0',
+            }}
           >
             {data.getScheduledCorpusItems[0]?.totalCount}{' '}
             {data.getScheduledCorpusItems[0]?.totalCount === 1

--- a/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.tsx
+++ b/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.tsx
@@ -59,7 +59,7 @@ export const ScheduledItemCardWrapper: React.FC<
   } = props;
 
   return (
-    <Grid item xs={12} sm={6} md={3}>
+    <Grid item xs={12} sm={6} md={4}>
       <StyledCorpusItemCard>
         <ApprovedItemListCard
           item={item.approvedItem}

--- a/src/curated-corpus/pages/CorpusItemPage/CorpusItemPage.tsx
+++ b/src/curated-corpus/pages/CorpusItemPage/CorpusItemPage.tsx
@@ -50,7 +50,6 @@ export const CorpusItemPage: React.FC = (): JSX.Element => {
    * Keep track of whether the "Edit this item" modal is open or not.
    */
   const [editModalOpen, toggleEditModal] = useToggle(false);
-
   return (
     <>
       {!data && <HandleApiResponse loading={loading} error={error} />}

--- a/src/curated-corpus/pages/CorpusPage/CorpusPage.tsx
+++ b/src/curated-corpus/pages/CorpusPage/CorpusPage.tsx
@@ -7,6 +7,7 @@ import {
   ApprovedCorpusItemEdge,
   ApprovedCorpusItemFilter,
   useGetApprovedItemsLazyQuery,
+  useGetScheduledSurfacesForUserQuery,
 } from '../../../api/generatedTypes';
 import { HandleApiResponse } from '../../../_shared/components';
 import {
@@ -16,8 +17,10 @@ import {
   NextPrevPagination,
   RejectCorpusItemAction,
   ScheduleCorpusItemAction,
+  SidebarWrapper,
 } from '../../components';
 import { useToggle } from '../../../_shared/hooks';
+import { DateTime } from 'luxon';
 
 export const CorpusPage: React.FC = (): JSX.Element => {
   // Get the usual API response vars and a helper method to retrieve data
@@ -36,6 +39,38 @@ export const CorpusPage: React.FC = (): JSX.Element => {
   // paginating through results.
   const [before, setBefore] = useState<string | null | undefined>(undefined);
   const [after, setAfter] = useState<string | null | undefined>(undefined);
+
+  // set up the initial scheduled surface guid value (nothing at this point)
+  const [currentScheduledSurfaceGuid, setCurrentScheduledSurfaceGuid] =
+    useState('');
+
+  // This is the date used in the sidebar. Defaults to tomorrow
+  const [sidebarDate, setSidebarDate] = useState<DateTime | null>(
+    DateTime.local().plus({ days: 1 })
+  );
+
+  // Whether the data in the sidebar needs to be refreshed.
+  // Is needed when the user switches from surface to surface or
+  // when they schedule something for the date chosen in the sidebar.
+  const [refreshSidebarData, setRefreshSidebarData] = useState(false);
+
+  // Get the list of Scheduled Surfaces the currently logged-in user has access to.
+  const {
+    data: scheduledSurfaceData,
+    loading: scheduledSurfaceLoading,
+    error: scheduledSurfaceError,
+  } = useGetScheduledSurfacesForUserQuery({
+    onCompleted: (data) => {
+      const options = data.getScheduledSurfacesForUser.map(
+        (scheduledSurface) => {
+          return { code: scheduledSurface.guid, name: scheduledSurface.name };
+        }
+      );
+      if (options.length > 0) {
+        setCurrentScheduledSurfaceGuid(options[0].code);
+      }
+    },
+  });
 
   // On the initial page load, load most recently added Curated Items -
   // the first page of results, no filters applied.
@@ -139,80 +174,100 @@ export const CorpusPage: React.FC = (): JSX.Element => {
   return (
     <>
       <h1>Corpus</h1>
-      <ApprovedItemSearchForm onSubmit={handleSubmit} />
+      <Grid container spacing={2}>
+        <Grid item xs={8}>
+          <ApprovedItemSearchForm onSubmit={handleSubmit} />
 
-      {!data && <HandleApiResponse loading={loading} error={error} />}
+          {!data && <HandleApiResponse loading={loading} error={error} />}
 
-      {currentItem && (
-        <>
-          <ScheduleCorpusItemAction
-            item={currentItem}
-            modalOpen={scheduleModalOpen}
-            toggleModal={toggleScheduleModal}
-            refetch={refetch}
-          />
-          <EditCorpusItemAction
-            item={currentItem}
-            modalOpen={editModalOpen}
-            toggleModal={toggleEditModal}
-            refetch={refetch}
-          />
-          <RejectCorpusItemAction
-            item={currentItem}
-            modalOpen={rejectModalOpen}
-            toggleModal={toggleRejectModal}
-            refetch={refetch}
-          />
-        </>
-      )}
-
-      <Grid
-        container
-        direction="row"
-        alignItems="stretch"
-        justifyContent="flex-start"
-        spacing={3}
-      >
-        {data && (
-          <Grid item xs={12}>
-            <Typography>
-              Found {data.getApprovedCorpusItems.totalCount} result(s).
-            </Typography>
-          </Grid>
-        )}
-        {data &&
-          data.getApprovedCorpusItems.edges.map(
-            (edge: ApprovedCorpusItemEdge) => {
-              return (
-                <Grid
-                  item
-                  xs={12}
-                  sm={6}
-                  md={3}
-                  key={`grid-${edge.node.externalId}`}
-                >
-                  <ApprovedItemCardWrapper
-                    key={edge.node.externalId}
-                    item={edge.node}
-                    onSchedule={() => {
-                      setCurrentItem(edge.node);
-                      toggleScheduleModal();
-                    }}
-                    onEdit={() => {
-                      setCurrentItem(edge.node);
-                      toggleEditModal();
-                    }}
-                    onReject={() => {
-                      setCurrentItem(edge.node);
-                      toggleRejectModal();
-                    }}
-                  />
-                </Grid>
-              );
-            }
+          {currentItem && (
+            <>
+              <ScheduleCorpusItemAction
+                item={currentItem}
+                modalOpen={scheduleModalOpen}
+                toggleModal={toggleScheduleModal}
+                refetch={refetch}
+              />
+              <EditCorpusItemAction
+                item={currentItem}
+                modalOpen={editModalOpen}
+                toggleModal={toggleEditModal}
+                refetch={refetch}
+              />
+              <RejectCorpusItemAction
+                item={currentItem}
+                modalOpen={rejectModalOpen}
+                toggleModal={toggleRejectModal}
+                refetch={refetch}
+              />
+            </>
           )}
-      </Grid>
 
+          <Grid
+            container
+            direction="row"
+            alignItems="stretch"
+            justifyContent="flex-start"
+            spacing={3}
+          >
+            {data && (
+              <Grid item xs={12}>
+                <Typography>
+                  Found {data.getApprovedCorpusItems.totalCount} result(s).
+                </Typography>
+              </Grid>
+            )}
+            {data &&
+              data.getApprovedCorpusItems.edges.map(
+                (edge: ApprovedCorpusItemEdge) => {
+                  return (
+                    <Grid
+                      item
+                      xs={12}
+                      sm={6}
+                      md={4}
+                      key={`grid-${edge.node.externalId}`}
+                    >
+                      <ApprovedItemCardWrapper
+                        key={edge.node.externalId}
+                        item={edge.node}
+                        onSchedule={() => {
+                          setCurrentItem(edge.node);
+                          toggleScheduleModal();
+                        }}
+                        onEdit={() => {
+                          setCurrentItem(edge.node);
+                          toggleEditModal();
+                        }}
+                        onReject={() => {
+                          setCurrentItem(edge.node);
+                          toggleRejectModal();
+                        }}
+                      />
+                    </Grid>
+                  );
+                }
+              )}
+          </Grid>
+        </Grid>
+        {!scheduledSurfaceData && (
+          <HandleApiResponse
+            loading={scheduledSurfaceLoading}
+            error={scheduledSurfaceError}
+          />
+        )}
+        <Grid item sm={4}>
+          {currentScheduledSurfaceGuid.length > 0 && (
+            <SidebarWrapper
+              date={sidebarDate!}
+              setSidebarDate={setSidebarDate}
+              scheduledSurfaceGuid={currentScheduledSurfaceGuid}
+              refreshData={refreshSidebarData}
+              setRefreshData={setRefreshSidebarData}
+            />
+          )}
+        </Grid>
+      </Grid>
       {data && (
         <NextPrevPagination
           hasNextPage={data.getApprovedCorpusItems.pageInfo.hasNextPage}

--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -488,7 +488,7 @@ export const SchedulePage: React.FC = (): JSX.Element => {
           </Grid>
         )}
 
-        <Grid item xs={8.7}>
+        <Grid item xs={8.8}>
           {data &&
             data.getScheduledCorpusItems.map(
               (data: ScheduledCorpusItemsResult) => (
@@ -560,7 +560,7 @@ export const SchedulePage: React.FC = (): JSX.Element => {
           />
         )}
         {/* need weird spacing below so all buttons are visible */}
-        <Grid item sm={3.3}>
+        <Grid item sm={3.2}>
           {currentScheduledSurfaceGuid.length > 0 && (
             <SidebarWrapper
               date={sidebarDate!}


### PR DESCRIPTION
## Goal

Adds the schedule context to the schedule and corpus tools (similar to the prospect tool)

The editors also asked to add the scheduled context in 3 new spots:
1. Corpus schedule on corpus page
2. Reschedule on the schedule page
3. After scheduling from prospecting page

☑️ Fixed tests
☑️ Added new test for new scheduled context

Tickets:

- [Jira](https://getpocket.atlassian.net/browse/TML-96)

<img width="1378" alt="Screenshot 2023-07-17 at 13 04 49" src="https://github.com/Pocket/curation-admin-tools/assets/119352705/0a75316b-6aa0-4713-a4c3-1300ea9ec5a3">
<img width="1378" alt="Screenshot 2023-07-17 at 13 04 39" src="https://github.com/Pocket/curation-admin-tools/assets/119352705/73445cd2-af70-4c9c-ab6f-e04cbd98036d">)
