### PR TITLE
chore(types): Update to Github Action CI lib

### DIFF
--- a/.github/workflows/ci-collections.yml
+++ b/.github/workflows/ci-collections.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        uses: actions/checkout@v3.6.0
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2.5.2
+        uses: actions/setup-node@v3.8.2
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -421,6 +421,8 @@ export type CorpusItem = {
    * marked as beta because it's not ready yet for large client request.
    */
   shortUrl?: Maybe<Scalars['Url']>;
+  /** Time to read in minutes. Is nullable. */
+  timeToRead?: Maybe<Scalars['Int']>;
   /** The URL of the Approved Item. */
   url: Scalars['Url'];
 };
@@ -1350,6 +1352,7 @@ export enum ProspectType {
   Dismissed = 'DISMISSED',
   DomainAllowlist = 'DOMAIN_ALLOWLIST',
   Recommended = 'RECOMMENDED',
+  RssLogistic = 'RSS_LOGISTIC',
   SyndicatedNew = 'SYNDICATED_NEW',
   SyndicatedRerun = 'SYNDICATED_RERUN',
   Timespent = 'TIMESPENT',


### PR DESCRIPTION
## Goal

Let the new prospect type be used on the frontend.

Note: failing test is flaky and is irrelevant to the changes in this PR: https://github.com/Pocket/curation-admin-tools/blob/6b990ade40f4815f370eda2b0409e4b225d2b85d/src/curated-corpus/components/actions/ScheduleCorpusItemAction/ScheduleCorpusItemAction.test.tsx#L45

## Reference

https://mozilla-hub.atlassian.net/browse/MC-224