### PR TITLE
feat(prospectType): [MC-319] Add rss_logistic_recent prospect type to new_tab_en_us

### DIFF
--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -1353,6 +1353,7 @@ export enum ProspectType {
   DomainAllowlist = 'DOMAIN_ALLOWLIST',
   Recommended = 'RECOMMENDED',
   RssLogistic = 'RSS_LOGISTIC',
+  RssLogisticRecent = 'RSS_LOGISTIC_RECENT',
   SyndicatedNew = 'SYNDICATED_NEW',
   SyndicatedRerun = 'SYNDICATED_RERUN',
   Timespent = 'TIMESPENT',

--- a/src/curated-corpus/integration-test-mocks/getScheduledSurfacesForUser.ts
+++ b/src/curated-corpus/integration-test-mocks/getScheduledSurfacesForUser.ts
@@ -23,6 +23,7 @@ const allScheduledSurfaces: ScheduledSurface[] = [
       ProspectType.TimespentModeled,
       ProspectType.TitleUrlModeled,
       ProspectType.RssLogistic,
+      ProspectType.RssLogisticRecent,
     ],
   },
   {


### PR DESCRIPTION
Add the new RSS_LOGISTIC_RECENT prospect type to NEW_TAB_EN_US surface for the new tab recent content experiment.

Will be merged before this https://github.com/Pocket/prospect-api/pull/572.

Related to: https://github.com/Pocket/curated-corpus-api/pull/1007

JIRA ticket:

 [MC-319](https://mozilla-hub.atlassian.net/browse/MC-319)

[MC-319]: https://mozilla-hub.atlassian.net/browse/MC-319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ