### PR TITLE
fix(prospects): [MC-96] Use correct language when adding prospect

### DIFF
--- a/src/curated-corpus/helpers/prospects.test.ts
+++ b/src/curated-corpus/helpers/prospects.test.ts
@@ -142,26 +142,27 @@ describe('helper functions related to prospects', () => {
 
   describe('transformUrlMetaDataToProspect function', () => {
     const urlMetadata: UrlMetadata = { url: 'www.test-url.com' };
+    const defaultExpectedProspect: Prospect = {
+      id: '',
+      prospectId: '',
+      url: urlMetadata.url,
+      title: '',
+      imageUrl: '',
+      authors: '',
+      publisher: '',
+      language: undefined,
+      isSyndicated: false,
+      isCollection: false,
+      excerpt: '',
+      topic: '',
+      prospectType: '',
+      scheduledSurfaceGuid: '',
+    };
 
     it('should return the default values when metadata is lacking most of the fields', () => {
       const prospect = transformUrlMetaDataToProspect(urlMetadata);
 
-      expect(prospect).to.deep.equal({
-        id: '',
-        prospectId: '',
-        url: urlMetadata.url,
-        title: '',
-        imageUrl: '',
-        authors: '',
-        publisher: '',
-        language: undefined,
-        isSyndicated: false,
-        isCollection: false,
-        excerpt: '',
-        topic: '',
-        prospectType: '',
-        scheduledSurfaceGuid: '',
-      });
+      expect(prospect).to.deep.equal(defaultExpectedProspect);
     });
 
     it('should return correctly formatted prospect with values derived from the metadata', () => {
@@ -182,8 +183,7 @@ describe('helper functions related to prospects', () => {
       );
 
       expect(prospect).to.deep.equal({
-        id: '',
-        prospectId: '',
+        ...defaultExpectedProspect,
         url: metaDataWithPopulatedFields.url,
         title: metaDataWithPopulatedFields.title,
         imageUrl: metaDataWithPopulatedFields.imageUrl,
@@ -193,10 +193,31 @@ describe('helper functions related to prospects', () => {
         isSyndicated: true,
         isCollection: true,
         excerpt: metaDataWithPopulatedFields.excerpt,
-        topic: '',
-        prospectType: '',
-        scheduledSurfaceGuid: '',
       });
     });
+
+    it.each`
+      languageCode | expectedLanguage
+      ${'de'}      | ${CorpusLanguage.De}
+      ${'en'}      | ${CorpusLanguage.En}
+      ${'es'}      | ${CorpusLanguage.Es}
+      ${'fr'}      | ${CorpusLanguage.Fr}
+      ${'it'}      | ${CorpusLanguage.It}
+    `(
+      'should transform $languageCode from the metadata as $expectedLanguage',
+      ({ languageCode, expectedLanguage }) => {
+        const metaDataWithLanguage = {
+          ...urlMetadata,
+          language: languageCode,
+        };
+
+        const prospect = transformUrlMetaDataToProspect(metaDataWithLanguage);
+
+        expect(prospect).to.deep.equal({
+          ...defaultExpectedProspect,
+          language: expectedLanguage,
+        });
+      }
+    );
   });
 });

--- a/src/curated-corpus/helpers/prospects.ts
+++ b/src/curated-corpus/helpers/prospects.ts
@@ -117,11 +117,15 @@ export const transformUrlMetaDataToProspect = (
 ): Prospect => {
   // set language to undefined if metadata.language is an empty string or undefined.
   // if not, then map it from string to its corresponding CorpusLanguage enum value
-  const language = !metadata.language
-    ? undefined
-    : metadata.language === 'en'
-    ? CorpusLanguage.En
-    : CorpusLanguage.De;
+  let language: CorpusLanguage | undefined = undefined;
+
+  if (metadata.language) {
+    // CorpusLanguage values are upper-case. metadata.language is lower-case.
+    const upperCaseLanguage = metadata.language.toUpperCase() as CorpusLanguage;
+    if (Object.values(CorpusLanguage).includes(upperCaseLanguage)) {
+      language = upperCaseLanguage;
+    }
+  }
 
   return {
     // manually added items don't have a prospect id!


### PR DESCRIPTION
## Goal
Use the right language when manually adding a French, Spanish, or Italian prospect.

## How to check that this works

1. [Run the admin tool locally](https://mozilla-hub.atlassian.net/browse/MC-96) with `REACT_APP_ADMIN_API_ENDPOINT=https://admin-api.getpocket.dev`
2. Manually add a prospect with url https://www.revistavanityfair.es/articulos/centro-de-arte-hortensia-herrero-juan-roig-mercadona-valencia-obras-valencia

Before, the language would default to German. Now, the language is correctly identified as Spanish:

![image](https://github.com/Pocket/curation-admin-tools/assets/1547251/23cfa8f3-0c76-4371-9647-e038e771372e)

## Reference

Tickets:

- https://mozilla-hub.atlassian.net/browse/MC-96

## Implementation Decisions
