### PR TITLE
Fix casing after apostrophe

### DIFF
--- a/src/_shared/utils/applyApTitleCase.test.ts
+++ b/src/_shared/utils/applyApTitleCase.test.ts
@@ -81,4 +81,36 @@ describe('applyApTitleCase', () => {
       expect(applyApTitleCase(type.result)).toEqual(type.expected);
     });
   });
+
+  it('words after curly apostrophes should be uppercase', () => {
+    const sentencesWithApostrophe = [
+      {
+        result:
+          '“Integrated thriving” can fix unhelpful buzz words like “girlboss” and “snail girl”',
+        expected:
+          '“Integrated Thriving” Can Fix Unhelpful Buzz Words Like “Girlboss” and “Snail Girl”',
+      },
+      {
+        result:
+          '‘Integrated thriving’ can fix unhelpful buzz words like ‘girlboss’ and ‘snail girl’',
+        expected:
+          '‘Integrated Thriving’ Can Fix Unhelpful Buzz Words Like ‘Girlboss’ and ‘Snail Girl’',
+      },
+      {
+        result:
+          "'Integrated thriving' can fix unhelpful buzz words like 'girlboss' and 'snail girl'",
+        expected:
+          "'Integrated Thriving' Can Fix Unhelpful Buzz Words Like 'Girlboss' and 'Snail Girl'",
+      },
+      {
+        result:
+          '"Integrated thriving" can fix unhelpful buzz words like "girlboss" and "snail girl"',
+        expected:
+          '"Integrated Thriving" Can Fix Unhelpful Buzz Words Like "Girlboss" and "Snail Girl"',
+      },
+    ];
+    sentencesWithApostrophe.forEach((swa) => {
+      expect(applyApTitleCase(swa.result)).toEqual(swa.expected);
+    });
+  });
 });

--- a/src/_shared/utils/applyApTitleCase.ts
+++ b/src/_shared/utils/applyApTitleCase.ts
@@ -1,7 +1,7 @@
 export const STOP_WORDS =
   'a an and at but by for in nor of on or so the to up yet';
 
-export const SEPARATORS = /(\s+|[-‑–—,:;!?()])/;
+export const SEPARATORS = /(\s+|[-‑–—,:;!?()“”‘’'"])/;
 
 export const stop = STOP_WORDS.split(' ');
 


### PR DESCRIPTION
## Goal

Corrie raised [the issue](https://mozilla.slack.com/archives/C05FLVAF4SK/p1701709206385509) that `Fix Title` wasn't working properly when there are apostrophes.

This can now be tested on [dev](https://curation-admin-tools.getpocket.dev/) from `Private Mode or Incognito` by going to `/curated-corpus/corpus`, selecting `Edit` on a tile. Try the following text in the title and click `Fix Title`

```
“Integrated thriving” can fix unhelpful buzz words like “girlboss” and “snail girl”
```
The result should be
```
“Integrated Thriving” Can Fix Unhelpful Buzz Words Like “Girlboss” and “Snail Girl”
``` 

## Todos
- [x] Fixed bug, added new tests and previous tests are working.

Tickets:

-  [Slack issue](https://mozilla.slack.com/archives/C05FLVAF4SK/p1701709206385509)

## Implementation Decisions
Added the missing separators so that we capture the missing apostrophes
