### PR TITLE
Fix contractions in "Fix Title"

### DIFF
--- a/src/_shared/utils/applyApTitleCase.test.ts
+++ b/src/_shared/utils/applyApTitleCase.test.ts
@@ -82,25 +82,13 @@ describe('applyApTitleCase', () => {
     });
   });
 
-  it('words after curly apostrophes should be uppercase', () => {
+  it('words after double apostrophes should be uppercase', () => {
     const sentencesWithApostrophe = [
       {
         result:
           '“Integrated thriving” can fix unhelpful buzz words like “girlboss” and “snail girl”',
         expected:
           '“Integrated Thriving” Can Fix Unhelpful Buzz Words Like “Girlboss” and “Snail Girl”',
-      },
-      {
-        result:
-          '‘Integrated thriving’ can fix unhelpful buzz words like ‘girlboss’ and ‘snail girl’',
-        expected:
-          '‘Integrated Thriving’ Can Fix Unhelpful Buzz Words Like ‘Girlboss’ and ‘Snail Girl’',
-      },
-      {
-        result:
-          "'Integrated thriving' can fix unhelpful buzz words like 'girlboss' and 'snail girl'",
-        expected:
-          "'Integrated Thriving' Can Fix Unhelpful Buzz Words Like 'Girlboss' and 'Snail Girl'",
       },
       {
         result:
@@ -111,6 +99,18 @@ describe('applyApTitleCase', () => {
     ];
     sentencesWithApostrophe.forEach((swa) => {
       expect(applyApTitleCase(swa.result)).toEqual(swa.expected);
+    });
+  });
+
+  it('contractions should be properly uppercase', () => {
+    const sentencesWithContractions = [
+      {
+        result: "Here's what you haven't noticed",
+        expected: "Here's What You Haven't Noticed",
+      },
+    ];
+    sentencesWithContractions.forEach((swc) => {
+      expect(applyApTitleCase(swc.result)).toEqual(swc.expected);
     });
   });
 });

--- a/src/_shared/utils/applyApTitleCase.ts
+++ b/src/_shared/utils/applyApTitleCase.ts
@@ -1,7 +1,7 @@
 export const STOP_WORDS =
   'a an and at but by for in nor of on or so the to up yet';
 
-export const SEPARATORS = /(\s+|[-‑–—,:;!?()“”‘’'"])/;
+export const SEPARATORS = /(\s+|[-‑–—,:;!?()“”"])/;
 
 export const stop = STOP_WORDS.split(' ');
 


### PR DESCRIPTION
## Goal

Kimi found that contractions stopped working for "Fix Title" and suggested that we only handle double apostrophes for now - https://mozilla.slack.com/archives/C05FLVAF4SK/p1701709206385509

## Todos
- [x] Removed single apostrophes and added test cases that Kimi found

## Implementation Decisions
Small code change to remove the single apostrophes.