### PR TITLE
feat(prospectType): [MC-403] Add CONSTRAINT_SCHEDULE

### DIFF
--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -1344,6 +1344,7 @@ export type Prospect = {
  * by the Curation Admin Tools frontend to filter prospects.
  */
 export enum ProspectType {
+  ConstraintSchedule = 'CONSTRAINT_SCHEDULE',
   Counts = 'COUNTS',
   CountsModeled = 'COUNTS_MODELED',
   Dismissed = 'DISMISSED',

--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -96,7 +96,7 @@ export type ApprovedCorpusItem = {
   updatedAt: Scalars['Int'];
   /** A single sign-on user identifier of the user who last updated this entity. Null on creation. */
   updatedBy?: Maybe<Scalars['String']>;
-  /** The URL of the story. */
+  /** key field to identify the Approved Corpus Item entity in the Curated Corpus service */
   url: Scalars['Url'];
 };
 
@@ -755,10 +755,7 @@ export type ImportApprovedCorpusItemPayload = {
   scheduledItem: ScheduledCorpusItem;
 };
 
-/**
- * The heart of Pocket
- * A url and meta data related to it.
- */
+/** Resolve by reference the Item entity to connect Prospect to Items. */
 export type Item = {
   __typename?: 'Item';
   /** If available, the url to an AMP version of this article */
@@ -1394,11 +1391,6 @@ export type Query = {
   /** Retrieves the nested list of IAB top/sub categories. */
   getIABCategories: Array<IabParentCategory>;
   /**
-   * Look up Item info by ID.
-   * @deprecated Use itemById instead
-   */
-  getItemByItemId?: Maybe<Item>;
-  /**
    * Look up Item info by a url.
    * @deprecated Use itemByUrl instead
    */
@@ -1417,8 +1409,6 @@ export type Query = {
   getScheduledSurfacesForUser: Array<ScheduledSurface>;
   /** returns parser meta data for a given url */
   getUrlMetadata: UrlMetadata;
-  /** Look up Item info by ID. */
-  itemByItemId?: Maybe<Item>;
   /** Look up Item info by a url. */
   itemByUrl?: Maybe<Item>;
   /** Retrieves all available Labels */
@@ -1475,10 +1465,6 @@ export type QueryGetCollectionStoryArgs = {
   externalId: Scalars['String'];
 };
 
-export type QueryGetItemByItemIdArgs = {
-  id: Scalars['ID'];
-};
-
 export type QueryGetItemByUrlArgs = {
   url: Scalars['String'];
 };
@@ -1502,10 +1488,6 @@ export type QueryGetScheduledCorpusItemsArgs = {
 
 export type QueryGetUrlMetadataArgs = {
   url: Scalars['String'];
-};
-
-export type QueryItemByItemIdArgs = {
-  id: Scalars['ID'];
 };
 
 export type QueryItemByUrlArgs = {
@@ -1554,7 +1536,7 @@ export type RejectedCorpusItem = {
    * Temporarily a string value that will be provided by Prospect API, possibly an enum in the future.
    */
   topic?: Maybe<Scalars['String']>;
-  /** The URL of the story. */
+  /** key field to identify the Rejected Corpus Item entity in the Curated Corpus service */
   url: Scalars['Url'];
 };
 

--- a/src/curated-corpus/integration-test-mocks/getScheduledSurfacesForUser.ts
+++ b/src/curated-corpus/integration-test-mocks/getScheduledSurfacesForUser.ts
@@ -11,6 +11,7 @@ const allScheduledSurfaces: ScheduledSurface[] = [
     guid: 'NEW_TAB_EN_US',
     ianaTimezone: 'America/New_York',
     prospectTypes: [
+      ProspectType.ConstraintSchedule,
       ProspectType.Counts,
       ProspectType.Timespent,
       ProspectType.Recommended,


### PR DESCRIPTION
## Goal
Add new prospect type CONSTRAINT_SCHEDULE, which is a set of prospects without using the same topics and publishers too many times.

## Implementation Decisions
I looked at https://github.com/Pocket/curation-admin-tools/pull/1146/commits/cbf90bfed5242ae906db10821b4fca02eab8f446 to see which changes need to be made.

## Deployment steps
- [x] Deployed https://github.com/Pocket/curated-corpus-api/pull/1009

## References

JIRA ticket:
- [MC-403](https://mozilla-hub.atlassian.net/browse/MC-403)

I created a Confluence doc with steps on how to create a new Prospect Type:
- https://mozilla-hub.atlassian.net/wiki/spaces/PE/pages/516817186/How+to+add+a+new+Prospect+Type

Related PRs:
- https://github.com/Pocket/prospect-api/pull/574
- https://github.com/Pocket/dl-metaflow-jobs/pull/250
- https://github.com/Pocket/curated-corpus-api/pull/1009

[MC-403]: https://mozilla-hub.atlassian.net/browse/MC-403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ