### PR TITLE
refactor: only show prospect removal reasons on SlateSchedulerV2 prospect type

### DIFF
--- a/src/curated-corpus/components/actions/RemoveProspectAction/RemoveProspectAction.tsx
+++ b/src/curated-corpus/components/actions/RemoveProspectAction/RemoveProspectAction.tsx
@@ -55,7 +55,7 @@ export const RemoveProspectAction: React.FC<RemoveProspectActionProps> = (
     toggleModal,
     onRemoveProspect,
   } = props;
-  if (prospectType === ProspectType.SlateScheduler) {
+  if (prospectType === ProspectType.SlateSchedulerV2) {
     isProspectSlateScheduler = true;
   }
 


### PR DESCRIPTION
## Goal

only show prospect removal reasons on SlateSchedulerV2 prospect type

- remove showing the modal on the old SlateScheduler prospect type

## Reference

Tickets:

- https://mozilla-hub.atlassian.net/browse/MC-718
