### PR TITLE
feat(mlScheduled): [MC-550] Show ML label on ML scheduled items

### DIFF
--- a/src/_shared/components/CorpusItemCardImage/CorpusItemCardImage.tsx
+++ b/src/_shared/components/CorpusItemCardImage/CorpusItemCardImage.tsx
@@ -22,6 +22,11 @@ interface CorpusItemCardImageProps {
   item: ApprovedCorpusItem;
 
   /**
+   * If this Scheduled item was scheduled by ML
+   */
+  isMlScheduled: boolean;
+
+  /**
    * Current date that the schedule is being viewed for
    */
   currentScheduledDate: string;
@@ -66,9 +71,11 @@ const bottomOverlayContainerSxStyles: SxProps = {
   cursor: 'pointer',
 };
 
-const getTopRightLabel = (item: ApprovedCorpusItem): ReactElement | null => {
-  //TODO @Herraj replace the string value being asserted on once MC-550 is complete
-  if (item.createdBy === 'ML') {
+const getTopRightLabel = (
+  item: ApprovedCorpusItem,
+  isMlScheduled: boolean
+): ReactElement | null => {
+  if (isMlScheduled) {
     return (
       <>
         <AutoFixHighOutlinedIcon fontSize="small" />
@@ -131,6 +138,7 @@ export const CorpusItemCardImage: React.FC<CorpusItemCardImageProps> = (
 ): ReactElement => {
   const {
     item,
+    isMlScheduled,
     toggleScheduleHistoryModal,
     currentScheduledDate,
     scheduledSurfaceGuid,
@@ -141,7 +149,7 @@ export const CorpusItemCardImage: React.FC<CorpusItemCardImageProps> = (
 
   const displayTopic = getDisplayTopic(item.topic);
 
-  const topRightLabel = getTopRightLabel(item);
+  const topRightLabel = getTopRightLabel(item, isMlScheduled);
 
   // extract the scheduled history dates into a string array
   const scheduledHistoryDates = item.scheduledSurfaceHistory.map(

--- a/src/api/fragments/scheduledItemData.ts
+++ b/src/api/fragments/scheduledItemData.ts
@@ -16,6 +16,7 @@ export const ScheduledItemData = gql`
     scheduledDate
     updatedAt
     updatedBy
+    source
   }
   ${CuratedItemData}
 `;

--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -446,6 +446,8 @@ export enum CorpusItemSource {
   Backfill = 'BACKFILL',
   /** Manually entered through the curation admin tool */
   Manual = 'MANUAL',
+  /** Created by ML */
+  Ml = 'ML',
   /** Originated as a prospect in the curation admin tool */
   Prospect = 'PROSPECT',
 }
@@ -483,6 +485,10 @@ export type CreateApprovedCorpusItemInput = {
   isTimeSensitive: Scalars['Boolean'];
   /** What language this item is in. This is a two-letter code, for example, 'EN' for English. */
   language: CorpusLanguage;
+  /** Free-text entered by the curator to give further detail to the manual addition reason(s) provided. */
+  manualAdditionReasonComment?: InputMaybe<Scalars['String']>;
+  /** A comma-separated list of reasons for manually adding an item (only supplied when `source` is MANUAL). */
+  manualAdditionReasons?: InputMaybe<Scalars['String']>;
   /** The GUID of the corresponding Prospect ID. Will be empty for manually added items. */
   prospectId?: InputMaybe<Scalars['ID']>;
   /** The name of the online publication that published this story. */
@@ -587,6 +593,8 @@ export type CreateScheduledCorpusItemInput = {
   scheduledDate: Scalars['Date'];
   /** The GUID of the Scheduled Surface the Approved Item is going to appear on. Example: 'NEW_TAB_EN_US'. */
   scheduledSurfaceGuid: Scalars['ID'];
+  /** Source of the Scheduled Item. Could be one of: MANUAL or ML */
+  source?: InputMaybe<ScheduledItemSource>;
 };
 
 /** The outcome of the curators reviewing a prospective story. */
@@ -1700,6 +1708,8 @@ export type ScheduledCorpusItem = {
   scheduledDate: Scalars['Date'];
   /** The GUID of this scheduledSurface to which this item is scheduled. Example: 'NEW_TAB_EN_US'. */
   scheduledSurfaceGuid: Scalars['ID'];
+  /** Source of the Scheduled Item. Could be one of: MANUAL or ML */
+  source?: Maybe<ScheduledItemSource>;
   /** A Unix timestamp of when the entity was last updated. */
   updatedAt: Scalars['Int'];
   /** A single sign-on user identifier of the user who last updated this entity. Null on creation. */
@@ -1730,6 +1740,14 @@ export type ScheduledCorpusItemsResult = {
   /** The total number of items for the scheduled date. */
   totalCount: Scalars['Int'];
 };
+
+/** The source of the Scheduled item */
+export enum ScheduledItemSource {
+  /** Manually entered through the curation admin tool */
+  Manual = 'MANUAL',
+  /** Created by ML */
+  Ml = 'ML',
+}
 
 /** A Scheduled Surface, including its associated Prospect Types. */
 export type ScheduledSurface = {
@@ -2448,6 +2466,7 @@ export type ScheduledItemDataFragment = {
   scheduledDate: any;
   updatedAt: number;
   updatedBy?: string | null;
+  source?: ScheduledItemSource | null;
   approvedItem: {
     __typename?: 'ApprovedCorpusItem';
     externalId: string;
@@ -3019,6 +3038,7 @@ export type RescheduleScheduledCorpusItemMutation = {
     scheduledDate: any;
     updatedAt: number;
     updatedBy?: string | null;
+    source?: ScheduledItemSource | null;
     approvedItem: {
       __typename?: 'ApprovedCorpusItem';
       externalId: string;
@@ -4663,6 +4683,7 @@ export const ScheduledItemDataFragmentDoc = gql`
     scheduledDate
     updatedAt
     updatedBy
+    source
   }
   ${CuratedItemDataFragmentDoc}
 `;

--- a/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.tsx
+++ b/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.tsx
@@ -1,6 +1,9 @@
 import React, { ReactElement } from 'react';
 import { Grid } from '@mui/material';
-import { ScheduledCorpusItem } from '../../../api/generatedTypes';
+import {
+  ScheduledCorpusItem,
+  ScheduledItemSource,
+} from '../../../api/generatedTypes';
 
 import { StyledScheduledItemCard } from '../../../_shared/styled';
 import { SuggestedScheduleItemListCard } from '../SuggestedScheduleItemListCard/SuggestedScheduleItemListCard';
@@ -60,6 +63,7 @@ export const ScheduledItemCardWrapper: React.FC<
       <StyledScheduledItemCard variant="outlined">
         <SuggestedScheduleItemListCard
           item={item.approvedItem}
+          isMlScheduled={item.source === ScheduledItemSource.Ml}
           currentScheduledDate={currentScheduledDate}
           scheduledSurfaceGuid={scheduledSurfaceGuid}
           onEdit={onEdit}

--- a/src/curated-corpus/components/SuggestedScheduleItemListCard/SuggestedScheduleItemListCard.tsx
+++ b/src/curated-corpus/components/SuggestedScheduleItemListCard/SuggestedScheduleItemListCard.tsx
@@ -18,6 +18,11 @@ interface SuggestedScheduleItemListCardProps {
   item: ApprovedCorpusItem;
 
   /**
+   * If this Scheduled item was scheduled by ML
+   */
+  isMlScheduled: boolean;
+
+  /**
    * Current date that the schedule is being viewed for
    */
   currentScheduledDate: string;
@@ -53,6 +58,7 @@ export const SuggestedScheduleItemListCard: React.FC<
 > = (props): ReactElement => {
   const {
     item,
+    isMlScheduled,
     currentScheduledDate,
     scheduledSurfaceGuid,
     onUnschedule,


### PR DESCRIPTION
## Goal

Asserting on the `ScheduledItem` object / type's newly added `source` enum value to determine if it is an ML scheduled item and show the `ML` label on the scheduled item card.

## Todos

- [x] Merge the related backend PR first: https://github.com/Pocket/content-monorepo/pull/63
- [ ] Optional refactor. See Implementation Decisions below

Tickets:

- [MC-550](https://mozilla-hub.atlassian.net/browse/MC-550)

## Implementation Decisions
Ideally, I didn't want to add another prop and drill it down. Due to the lack of time, I've implemented it this way. Although, a more graceful solution would require some refactoring such that `CorpusCardImage` component is able to take an `item` prop of `ScheduledCorpusItem` as well. 

I leave it to the smart people of this team ❤️  

[MC-550]: https://mozilla-hub.atlassian.net/browse/MC-550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ