### PR TITLE
fix: adding source to mutation when moving item to bottom

### DIFF
--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -333,9 +333,11 @@ export const SchedulePage: React.FC = (): ReactElement => {
   const moveItemToBottom = (item: ScheduledCorpusItem): void => {
     // Run the "reschedule" mutation with the same variables
     // it already has. All we want from it is to update `updatedAt` timestamp.
+    console.log('move to bottom');
     const variables = {
       externalId: item.externalId,
       scheduledDate: item.scheduledDate,
+      source: ScheduledItemSource.Ml,
     };
 
     // Run the mutation

--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -333,7 +333,6 @@ export const SchedulePage: React.FC = (): ReactElement => {
   const moveItemToBottom = (item: ScheduledCorpusItem): void => {
     // Run the "reschedule" mutation with the same variables
     // it already has. All we want from it is to update `updatedAt` timestamp.
-    console.log('move to bottom');
     const variables = {
       externalId: item.externalId,
       scheduledDate: item.scheduledDate,

--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -337,7 +337,7 @@ export const SchedulePage: React.FC = (): ReactElement => {
     const variables = {
       externalId: item.externalId,
       scheduledDate: item.scheduledDate,
-      source: ScheduledItemSource.Ml,
+      source: ScheduledItemSource.Manual,
     };
 
     // Run the mutation


### PR DESCRIPTION
## Goal
adding `source` to reschedule mutation when moving item to bottom.