### PR TITLE
feat(scheduling): [MC-784] 'Add item' button should appear next to each date on Schedule page

### DIFF
--- a/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.tsx
+++ b/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.tsx
@@ -70,6 +70,7 @@ export const ScheduleItemForm: React.FC<
     onSubmit,
   } = props;
 
+  // Default to tomorrow if no selected date is passed through the props.
   const tomorrow = DateTime.local().plus({ days: 1 });
 
   // Run the lookup query for scheduled items on loading the component,
@@ -79,7 +80,7 @@ export const ScheduleItemForm: React.FC<
 
   useEffect(() => {
     setRefreshData(true);
-    handleDateChange(tomorrow);
+    handleDateChange(selectedDate ? selectedDate : tomorrow);
   }, []);
 
   // if a scheduledSurfaceGuid was not supplied (meaning this is a manually

--- a/src/curated-corpus/components/ScheduleItemFormConnector/ScheduleItemFormConnector.tsx
+++ b/src/curated-corpus/components/ScheduleItemFormConnector/ScheduleItemFormConnector.tsx
@@ -16,6 +16,11 @@ interface ScheduleItemFormConnectorProps {
   approvedItemExternalId: string;
 
   /**
+   * Use this date as the default date if it's provided.
+   */
+  date?: DateTime;
+
+  /**
    * The GUID of the Scheduled Surface if one's been sent through.
    */
   scheduledSurfaceGuid?: string;
@@ -40,6 +45,7 @@ export const ScheduleItemFormConnector: React.FC<
 > = (props) => {
   const {
     approvedItemExternalId,
+    date,
     disableScheduledSurface,
     scheduledSurfaceGuid,
     onCancel,
@@ -57,7 +63,11 @@ export const ScheduleItemFormConnector: React.FC<
   // Save the date in a state var as the submitted form will contain
   // a formatted string instead of a luxon object. Would like to work with the luxon
   // object instead of parsing the date from string.
-  const [selectedDate, setSelectedDate] = useState<DateTime | null>(tomorrow);
+  // Use the date provided; otherwise, use tomorrow's date in the curator's time zone
+
+  const [selectedDate, setSelectedDate] = useState<DateTime | null>(
+    date ? date : tomorrow
+  );
 
   // What to do when the user clicks on a date in the calendar.
   const handleDateChange = (date: any, value?: string | null | undefined) => {

--- a/src/curated-corpus/components/ScheduleItemModal/ScheduleItemModal.tsx
+++ b/src/curated-corpus/components/ScheduleItemModal/ScheduleItemModal.tsx
@@ -1,16 +1,22 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 import { FormikValues } from 'formik';
 import { FormikHelpers } from 'formik/dist/types';
 import { Box, Grid, Typography } from '@mui/material';
 import { ApprovedCorpusItem } from '../../../api/generatedTypes';
 import { Modal } from '../../../_shared/components';
 import { ScheduleItemFormConnector } from '../';
+import { DateTime } from 'luxon';
 
 interface ScheduleItemModalProps {
   /**
    * The approved corpus item the impending scheduling action is meant for.
    */
   approvedItem: ApprovedCorpusItem;
+
+  /**
+   * Use this date as the default date if it's provided.
+   */
+  date?: DateTime;
 
   /**
    * The copy that shows up at the top of the schedule item modal. This is different
@@ -59,9 +65,10 @@ interface ScheduleItemModalProps {
  */
 export const ScheduleItemModal: React.FC<ScheduleItemModalProps> = (
   props
-): JSX.Element => {
+): ReactElement => {
   const {
     approvedItem,
+    date,
     disableScheduledSurface,
     headingCopy = 'Schedule this item',
     isOpen,
@@ -89,6 +96,7 @@ export const ScheduleItemModal: React.FC<ScheduleItemModalProps> = (
         <Grid item xs={12}>
           <ScheduleItemFormConnector
             approvedItemExternalId={approvedItem.externalId}
+            date={date}
             scheduledSurfaceGuid={scheduledSurfaceGuid}
             disableScheduledSurface={disableScheduledSurface}
             onSubmit={onSave}

--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -99,6 +99,10 @@ export const SchedulePage: React.FC = (): ReactElement => {
     string | undefined
   >();
 
+  // Track which scheduled date to use by default when a curator
+  // adds a new item manually.
+  const [addItemDate, setAddItemDate] = useState<DateTime>();
+
   /**
    * ##########
    * ########## gql and other useful hooks start here
@@ -606,6 +610,7 @@ export const SchedulePage: React.FC = (): ReactElement => {
       {approvedItem && (
         <ScheduleItemModal
           approvedItem={approvedItem}
+          date={addItemDate}
           headingCopy="Schedule this item"
           isOpen={scheduleItemModalOpen}
           scheduledSurfaceGuid={currentScheduledSurfaceGuid}
@@ -702,22 +707,6 @@ export const SchedulePage: React.FC = (): ReactElement => {
         </Grid>
       )}
 
-      {scheduledSurfaceOptions.length > 0 && (
-        <Grid container spacing={2} mb={2} justifyContent="flex-end">
-          <Grid item>
-            <Button
-              onClick={() => {
-                // toggle the add prospect modal
-                toggleAddProspectModal();
-              }}
-            >
-              <AddIcon />
-              Add Item
-            </Button>
-          </Grid>
-        </Grid>
-      )}
-
       {/** Page Contents Below */}
 
       <Grid container spacing={2}>
@@ -738,13 +727,16 @@ export const SchedulePage: React.FC = (): ReactElement => {
                   justifyContent="flex-start"
                   key={data.scheduledDate}
                 >
-                  <Grid item xs={12}>
+                  <Grid item xs={10}>
                     <Box mt={3}>
                       <Accordion>
-                        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                        <AccordionSummary
+                          expandIcon={<ExpandMoreIcon />}
+                          sx={{ maxHeight: '2.5rem' }}
+                        >
                           <Typography
                             sx={{
-                              fontSize: '1.5rem',
+                              fontSize: '1.25rem',
                               fontWeight: 500,
                               textTransform: 'capitalize',
                               color: curationPalette.primary,
@@ -757,6 +749,28 @@ export const SchedulePage: React.FC = (): ReactElement => {
                           <ScheduleSummaryLayout scheduledItems={data.items} />
                         </AccordionDetails>
                       </Accordion>
+                    </Box>
+                  </Grid>
+                  <Grid item xs={2}>
+                    <Box mt={3}>
+                      <Button
+                        size="large"
+                        onClick={() => {
+                          // toggle the add prospect modal
+                          toggleAddProspectModal();
+                          // set the default date to use when this manual addition
+                          // is scheduled
+                          setAddItemDate(
+                            DateTime.fromFormat(
+                              data.scheduledDate,
+                              'yyyy-MM-dd'
+                            )
+                          );
+                        }}
+                      >
+                        <AddIcon />
+                        Add Item
+                      </Button>
                     </Box>
                   </Grid>
                   <Grid item xs={12}>


### PR DESCRIPTION
## Goal

As currently implemented, the “Add item” button on the Schedule page is a solitary button on top of the page, and the scheduling date it fills in by default is tomorrow in the curator’s time zone. This was actually not the intention of the new UX wireframes - there should be a button next to each scheduled date. 

Functionality changes:

- There is an “Add an item” for manual addition of stories alongside each date displayed on the Schedule page

- When going through the manual addition, the date automatically filled in should be that parent date rather than tomorrow.

## Implementation details

- I have slightly de-emphasised the header for each date and lined up the header/accordion element with the button. Note that the accordion is on the way out - it will be replaced by the new sorting and filtering in the near future.

## Video walkthrough

Shows the multiple "Add item" buttons and the date the screen defaults to when scheduling items (in this case, March 21).


https://github.com/Pocket/curation-admin-tools/assets/22447785/732b87d7-651f-4bd2-98a0-f29728314ebd



## Reference

https://mozilla-hub.atlassian.net/browse/MC-784
