### PR TITLE
feat: Adding removal modal for prospects already in corpus

### DIFF
--- a/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.tsx
+++ b/src/curated-corpus/components/ExistingProspectCard/ExistingProspectCard.tsx
@@ -27,6 +27,7 @@ import { ScheduleHistory } from '../ScheduleHistory/ScheduleHistory';
 import { getDisplayTopic } from '../../helpers/topics';
 import { RemoveProspectAction } from '../actions/RemoveProspectAction/RemoveProspectAction';
 import { flattenAuthors } from '../../../_shared/utils/flattenAuthors';
+import { useToggle } from '../../../_shared/hooks';
 
 interface ExistingProspectCardProps {
   /**
@@ -42,6 +43,12 @@ interface ExistingProspectCardProps {
    * This is the prospect.id and NOT prospect.prospectId
    */
   prospectId: string;
+
+  // sent by prospecting page
+  prospectType?: string;
+
+  // sent by prospecting page
+  prospectTitle?: string;
 
   /**
    * Function called when the scheduled button is clicked.
@@ -64,8 +71,20 @@ interface ExistingProspectCardProps {
 export const ExistingProspectCard: React.FC<ExistingProspectCardProps> = (
   props
 ): JSX.Element => {
-  const { item, parserItem, onSchedule, onRemoveProspect, prospectId } = props;
+  const {
+    item,
+    parserItem,
+    onSchedule,
+    onRemoveProspect,
+    prospectId,
+    prospectType,
+    prospectTitle,
+  } = props;
   const showScheduleHistory = item.scheduledSurfaceHistory.length != 0;
+  /**
+   * Keep track of whether the RemoveItemModal is open or not.
+   */
+  const [removeProspectModalOpen, toggleRemoveProspectModal] = useToggle(false);
 
   return (
     <Card
@@ -151,6 +170,10 @@ export const ExistingProspectCard: React.FC<ExistingProspectCardProps> = (
               <RemoveProspectAction
                 onRemoveProspect={onRemoveProspect}
                 prospectId={prospectId}
+                prospectType={prospectType}
+                prospectTitle={prospectTitle}
+                modalOpen={removeProspectModalOpen}
+                toggleModal={toggleRemoveProspectModal}
               />
             </Grid>
           </Grid>

--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -873,6 +873,8 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
                     item={prospect.approvedCorpusItem}
                     parserItem={prospect.item!}
                     prospectId={prospect.id}
+                    prospectType={prospect.prospectType}
+                    prospectTitle={prospect.title as string}
                     onSchedule={() => {
                       setCurrentProspect(prospect);
                       setApprovedItem(prospect.approvedCorpusItem!);

--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -333,9 +333,11 @@ export const SchedulePage: React.FC = (): ReactElement => {
   const moveItemToBottom = (item: ScheduledCorpusItem): void => {
     // Run the "reschedule" mutation with the same variables
     // it already has. All we want from it is to update `updatedAt` timestamp.
+    console.log('move to bottom');
     const variables = {
       externalId: item.externalId,
       scheduledDate: item.scheduledDate,
+      source: ScheduledItemSource.Ml,
     };
 
     // Run the mutation

--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -333,7 +333,6 @@ export const SchedulePage: React.FC = (): ReactElement => {
   const moveItemToBottom = (item: ScheduledCorpusItem): void => {
     // Run the "reschedule" mutation with the same variables
     // it already has. All we want from it is to update `updatedAt` timestamp.
-    console.log('move to bottom');
     const variables = {
       externalId: item.externalId,
       scheduledDate: item.scheduledDate,

--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -337,7 +337,7 @@ export const SchedulePage: React.FC = (): ReactElement => {
     const variables = {
       externalId: item.externalId,
       scheduledDate: item.scheduledDate,
-      source: ScheduledItemSource.Ml,
+      source: ScheduledItemSource.Manual,
     };
 
     // Run the mutation


### PR DESCRIPTION
## Goal

Making sure the removal modal is triggered for `slate_scheduler_v2` prospects. 

## DEMO


https://github.com/Pocket/curation-admin-tools/assets/16909783/c828a254-6fc2-4d7f-bd54-b86c0e857cf7


## Todos

- [x] deployed & tested in dev



## Reference

Tickets:

- [https://mozilla-hub.atlassian.net/browse/MC-772](https://mozilla-hub.atlassian.net/browse/MC-772)
