### PR TITLE
feat(scheduling): [MC-564] Launch Reject modal from new Schedule view

### DIFF
--- a/src/_shared/components/CardActionButtonRow/CardActionButtonRow.test.tsx
+++ b/src/_shared/components/CardActionButtonRow/CardActionButtonRow.test.tsx
@@ -9,6 +9,7 @@ describe('The CardActionButtonRow component', () => {
   const onEdit = jest.fn();
   const onReschedule = jest.fn();
   const onUnschedule = jest.fn();
+  const onReject = jest.fn();
 
   //TODO update when reject button flow ready
   it('should render all four card action buttons and call their callbacks', () => {
@@ -18,6 +19,7 @@ describe('The CardActionButtonRow component', () => {
         onUnschedule={onUnschedule}
         onReschedule={onReschedule}
         onMoveToBottom={onMoveToBottom}
+        onReject={onReject}
       />
     );
 
@@ -49,6 +51,12 @@ describe('The CardActionButtonRow component', () => {
     userEvent.click(moveToBottomButton);
     expect(onMoveToBottom).toHaveBeenCalled();
 
-    //TODO assert for reject button and onReject callback
+    //assert for reject button and onReject callback
+    const rejectButton = screen.getByRole('button', {
+      name: 'reject',
+    });
+    expect(rejectButton).toBeInTheDocument();
+    userEvent.click(rejectButton);
+    expect(onReject).toHaveBeenCalled();
   });
 });

--- a/src/_shared/components/CardActionButtonRow/CardActionButtonRow.tsx
+++ b/src/_shared/components/CardActionButtonRow/CardActionButtonRow.tsx
@@ -28,12 +28,18 @@ interface CardActionButtonRowProps {
    * Callback for the "Move to bottom" button
    */
   onMoveToBottom: VoidFunction;
+
+  /**
+   * Callback for the "Reject" (trash) button
+   */
+  onReject: VoidFunction;
 }
 
 export const CardActionButtonRow: React.FC<CardActionButtonRowProps> = (
   props
 ): JSX.Element => {
-  const { onEdit, onUnschedule, onReschedule, onMoveToBottom } = props;
+  const { onEdit, onUnschedule, onReschedule, onMoveToBottom, onReject } =
+    props;
 
   return (
     <Stack
@@ -45,10 +51,9 @@ export const CardActionButtonRow: React.FC<CardActionButtonRowProps> = (
     >
       <Stack direction="row" justifyContent="flex-start">
         <Tooltip title="Reject" placement="bottom">
-          {/** TODO: @Herraj -- enable when reject suggested item flow is ready, need to pass in an onClick */}
           <IconButton
             aria-label="reject"
-            disabled
+            onClick={onReject}
             sx={{ color: curationPalette.jetBlack }}
           >
             <DeleteOutlinedIcon />

--- a/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.tsx
+++ b/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.tsx
@@ -35,6 +35,11 @@ interface ScheduledItemCardWrapperProps {
   onEdit: VoidFunction;
 
   /**
+   * Callback for the "Reject" (trash) button
+   */
+  onReject: VoidFunction;
+
+  /**
    * Current date that the schedule is being viewed for
    */
   currentScheduledDate: string;
@@ -54,6 +59,7 @@ export const ScheduledItemCardWrapper: React.FC<
     onUnschedule,
     onReschedule,
     onEdit,
+    onReject,
     currentScheduledDate,
     scheduledSurfaceGuid,
   } = props;
@@ -70,6 +76,7 @@ export const ScheduledItemCardWrapper: React.FC<
           onUnschedule={onUnschedule}
           onReschedule={onReschedule}
           onMoveToBottom={onMoveToBottom}
+          onReject={onReject}
         />
       </StyledScheduledItemCard>
     </Grid>

--- a/src/curated-corpus/components/SuggestedScheduleItemListCard/SuggestedScheduleItemListCard.test.tsx
+++ b/src/curated-corpus/components/SuggestedScheduleItemListCard/SuggestedScheduleItemListCard.test.tsx
@@ -14,6 +14,7 @@ describe('The SuggestedScheduleItemListCard component', () => {
   const onEdit = jest.fn();
   const onReschedule = jest.fn();
   const onUnschedule = jest.fn();
+  const onReject = jest.fn();
 
   it('shows basic scheduled item information', () => {
     render(
@@ -25,6 +26,7 @@ describe('The SuggestedScheduleItemListCard component', () => {
         onUnschedule={onUnschedule}
         onReschedule={onReschedule}
         onMoveToBottom={onMoveToBottom}
+        onReject={onReject}
         scheduledSurfaceGuid="NEW_TAB_EN_US"
       />
     );
@@ -55,6 +57,7 @@ describe('The SuggestedScheduleItemListCard component', () => {
         onUnschedule={onUnschedule}
         onReschedule={onReschedule}
         onMoveToBottom={onMoveToBottom}
+        onReject={onReject}
         scheduledSurfaceGuid="NEW_TAB_EN_US"
       />
     );
@@ -72,6 +75,7 @@ describe('The SuggestedScheduleItemListCard component', () => {
         onUnschedule={onUnschedule}
         onReschedule={onReschedule}
         onMoveToBottom={onMoveToBottom}
+        onReject={onReject}
         scheduledSurfaceGuid="NEW_TAB_EN_US"
       />
     );
@@ -94,6 +98,7 @@ describe('The SuggestedScheduleItemListCard component', () => {
         onUnschedule={onUnschedule}
         onReschedule={onReschedule}
         onMoveToBottom={onMoveToBottom}
+        onReject={onReject}
         scheduledSurfaceGuid="NEW_TAB_EN_US"
       />
     );

--- a/src/curated-corpus/components/SuggestedScheduleItemListCard/SuggestedScheduleItemListCard.tsx
+++ b/src/curated-corpus/components/SuggestedScheduleItemListCard/SuggestedScheduleItemListCard.tsx
@@ -51,6 +51,11 @@ interface SuggestedScheduleItemListCardProps {
    * Callback for the "Move to bottom" button
    */
   onMoveToBottom: VoidFunction;
+
+  /**
+   * Callback for the "Reject" (trash) button
+   */
+  onReject: VoidFunction;
 }
 
 export const SuggestedScheduleItemListCard: React.FC<
@@ -65,6 +70,7 @@ export const SuggestedScheduleItemListCard: React.FC<
     onReschedule,
     onEdit,
     onMoveToBottom,
+    onReject,
   } = props;
 
   const [isScheduleHistoryModalOpen, setScheduleHistoryModalOpen] =
@@ -158,6 +164,7 @@ export const SuggestedScheduleItemListCard: React.FC<
         onUnschedule={onUnschedule}
         onReschedule={onReschedule}
         onMoveToBottom={onMoveToBottom}
+        onReject={onReject}
       />
     </>
   );

--- a/src/curated-corpus/components/actions/RejectAndUnscheduleItemAction/RejectAndUnscheduleItemAction.test.tsx
+++ b/src/curated-corpus/components/actions/RejectAndUnscheduleItemAction/RejectAndUnscheduleItemAction.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
+import { render, screen } from '@testing-library/react';
+import { SnackbarProvider } from 'notistack';
+import { RejectAndUnscheduleItemAction } from './RejectAndUnscheduleItemAction';
+import { getTestScheduledItem } from '../../../helpers/scheduledItem';
+import { successMock as unscheduleItemSuccessMock } from '../../../integration-test-mocks/deleteScheduledCorpusItem';
+import { successMock as rejectItemSuccessMock } from '../../../integration-test-mocks/rejectApprovedItem';
+import userEvent from '@testing-library/user-event';
+import { apolloCache } from '../../../../api/client';
+
+describe('The RejectAndUnscheduleItemAction', () => {
+  let mocks: MockedResponse[] = [];
+
+  it('renders the modal', async () => {
+    mocks = [];
+
+    render(
+      <MockedProvider mocks={mocks} cache={apolloCache}>
+        <SnackbarProvider maxSnack={3}>
+          <RejectAndUnscheduleItemAction
+            item={getTestScheduledItem()}
+            toggleModal={jest.fn()}
+            modalOpen={true}
+          />
+        </SnackbarProvider>
+      </MockedProvider>
+    );
+
+    // Do we have the modal heading
+    expect(screen.getByText(/reject this item/i)).toBeInTheDocument();
+
+    // How about the form?
+    expect(screen.getByRole('form')).toBeInTheDocument();
+  });
+
+  it('completes the action successfully', async () => {
+    mocks = [unscheduleItemSuccessMock, rejectItemSuccessMock];
+
+    render(
+      <MockedProvider mocks={mocks} cache={apolloCache}>
+        <SnackbarProvider maxSnack={3}>
+          <RejectAndUnscheduleItemAction
+            item={getTestScheduledItem()}
+            toggleModal={jest.fn()}
+            modalOpen={true}
+          />
+        </SnackbarProvider>
+      </MockedProvider>
+    );
+
+    const reason = screen.getByLabelText(/time sensitive/i);
+    userEvent.click(reason);
+    userEvent.click(screen.getByText(/save/i));
+
+    expect(
+      await screen.findByText(/item successfully moved to the rejected corpus/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/curated-corpus/components/actions/RejectAndUnscheduleItemAction/RejectAndUnscheduleItemAction.tsx
+++ b/src/curated-corpus/components/actions/RejectAndUnscheduleItemAction/RejectAndUnscheduleItemAction.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { FormikHelpers, FormikValues } from 'formik';
+import {
+  DeleteScheduledCorpusItemInput,
+  RejectApprovedCorpusItemInput,
+  ScheduledCorpusItem,
+  useDeleteScheduledItemMutation,
+  useRejectApprovedItemMutation,
+} from '../../../../api/generatedTypes';
+import { useRunMutation } from '../../../../_shared/hooks';
+import { RejectItemModal } from '../../';
+
+interface RejectAndUnscheduleItemActionProps {
+  /**
+   * The scheduled item that is about to be rejected and unscheduled in one go.
+   */
+  item: ScheduledCorpusItem;
+
+  /**
+   * A state variable that tracks whether the RejectItemModal is visible
+   * on the page or not.
+   * This has to be passed down from the parent component as other components
+   * may need to use it, too.
+   */
+  modalOpen: boolean;
+
+  /**
+   * A function that toggles the RejectItemModal's visibility on and off.
+   * This has to be passed down from the parent component as other components
+   * may need to use it, too.
+   */
+  toggleModal: VoidFunction;
+
+  /**
+   * A function that triggers a new API call to refetch the data for a given
+   * query. Needed on the Corpus page to take the newly rejected curated item
+   * off the page. NOT needed on the CorpusItem page.
+   */
+  refetch?: VoidFunction;
+}
+
+/**
+ * This component encapsulates the logic needed to reject a corpus item -
+ * send through a mutation to the Curated Corpus API to move the corpus item
+ * from the approved to the rejected pile.
+ *
+ * @param props
+ * @constructor
+ */
+export const RejectAndUnscheduleItemAction: React.FC<
+  RejectAndUnscheduleItemActionProps
+> = (props) => {
+  const { item, toggleModal, modalOpen, refetch } = props;
+
+  // Get a helper function that will execute each mutation, show standard notifications
+  // and execute any additional actions in a callback
+  const { runMutation } = useRunMutation();
+
+  // Prepare the "reject curated item" mutation
+  const [rejectCuratedItem] = useRejectApprovedItemMutation();
+
+  // Prepare the "delete scheduled item" mutation
+  const [deleteScheduledItem] = useDeleteScheduledItemMutation();
+
+  // 2. Remove the curated item from the recommendation corpus and place it
+  // into the rejected item list.
+  const onSave = (
+    values: FormikValues,
+    formikHelpers: FormikHelpers<any>
+  ): void => {
+    // Set up all the variables we need to pass to the unschedule mutation
+    const unscheduleInput: DeleteScheduledCorpusItemInput = {
+      externalId: item.externalId as string,
+    };
+
+    // Set out all the variables we need to pass to the reject mutation
+    const rejectInput: RejectApprovedCorpusItemInput = {
+      externalId: item.approvedItem!.externalId,
+      reason: values.reason,
+    };
+
+    // First unschedule the item, otherwise the rejection will fail
+    runMutation(
+      deleteScheduledItem,
+      { variables: { data: unscheduleInput } },
+      `Item unscheduled successfully.`,
+      () => {
+        // On success, move the approved item from the corpus to the rejected pile
+        runMutation(
+          rejectCuratedItem,
+          { variables: { data: rejectInput } },
+          `Item successfully moved to the rejected corpus.`,
+          () => {
+            toggleModal();
+            formikHelpers.setSubmitting(false);
+          },
+          () => {
+            formikHelpers.setSubmitting(false);
+          },
+          // If the data needs to be refreshed (as it does on the Schedule page),
+          // run the `refetch` helper function provided by the parent component.
+          refetch
+        );
+      },
+      () => {
+        formikHelpers.setSubmitting(false);
+      }
+    );
+  };
+
+  return (
+    <RejectItemModal
+      prospect={item.approvedItem}
+      isOpen={modalOpen}
+      onSave={onSave}
+      toggleModal={toggleModal}
+    />
+  );
+};

--- a/src/curated-corpus/components/index.ts
+++ b/src/curated-corpus/components/index.ts
@@ -13,6 +13,7 @@ export { DuplicateProspectModal } from './DuplicateProspectModal/DuplicateProspe
 export { NextPrevPagination } from './NextPrevPagination/NextPrevPagination';
 export { ProspectListCard } from './ProspectListCard/ProspectListCard';
 export { ProspectPublisherFilter } from './ProspectPublisherFilter/ProspectPublisherFilter';
+export { RejectAndUnscheduleItemAction } from './actions/RejectAndUnscheduleItemAction/RejectAndUnscheduleItemAction';
 export { RejectCorpusItemAction } from './actions/RejectCorpusItemAction/RejectCorpusItemAction';
 export { RejectedItemListCard } from './RejectedItemListCard/RejectedItemListCard';
 export { RejectedItemSearchForm } from './RejectedItemSearchForm/RejectedItemSearchForm';

--- a/src/curated-corpus/helpers/scheduledItem.test.ts
+++ b/src/curated-corpus/helpers/scheduledItem.test.ts
@@ -1,0 +1,23 @@
+import { getTestScheduledItem, scheduledItem } from './scheduledItem';
+
+describe('helper functions related to scheduledItem', () => {
+  describe('getTestScheduledItem function', () => {
+    it('should return a scheduled item with default test properties', () => {
+      // Very trivial test. Asserting against the same object the function is returning
+      expect(getTestScheduledItem()).toStrictEqual(scheduledItem);
+    });
+
+    it('should return a scheduled item with the default test properties overwritten', () => {
+      const modifiedProperties = {
+        scheduledDate: '2025-02-02',
+        createdBy: 'mbob',
+        updatedBy: 'rjoe',
+      };
+
+      expect(getTestScheduledItem({ ...modifiedProperties })).toStrictEqual({
+        ...scheduledItem,
+        ...modifiedProperties,
+      });
+    });
+  });
+});

--- a/src/curated-corpus/helpers/scheduledItem.ts
+++ b/src/curated-corpus/helpers/scheduledItem.ts
@@ -1,0 +1,31 @@
+import {
+  ScheduledCorpusItem,
+  ScheduledItemSource,
+} from '../../api/generatedTypes';
+import { getTestApprovedItem } from './approvedItem';
+import { ScheduledSurfaces } from './definitions';
+
+export const scheduledItem: ScheduledCorpusItem = {
+  externalId: '456-qwerty',
+  scheduledDate: '2024-01-01',
+  scheduledSurfaceGuid: ScheduledSurfaces[0].guid, // New Tab EN-US
+  source: ScheduledItemSource.Manual,
+  createdAt: 1635014927,
+  createdBy: 'Amy',
+  updatedAt: 1635014927,
+  updatedBy: 'Amy',
+  approvedItem: getTestApprovedItem(),
+};
+
+/**
+ * @param options to override certain properties and customize the approved corpus item
+ * @returns Returns a test object of type ApprovedCorpusItem
+ */
+export const getTestScheduledItem = (
+  options?: Partial<ScheduledCorpusItem>
+): ScheduledCorpusItem => {
+  return {
+    ...scheduledItem,
+    ...options,
+  };
+};

--- a/src/curated-corpus/integration-test-mocks/deleteScheduledCorpusItem.ts
+++ b/src/curated-corpus/integration-test-mocks/deleteScheduledCorpusItem.ts
@@ -1,0 +1,12 @@
+import { deleteScheduledItem } from '../../api/mutations/deleteScheduledItem';
+import { getTestScheduledItem } from '../helpers/scheduledItem';
+
+const item = getTestScheduledItem();
+
+export const successMock = {
+  request: {
+    query: deleteScheduledItem,
+    variables: { data: { externalId: item.externalId } },
+  },
+  result: { data: { deleteScheduledCorpusItem: item } },
+};

--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -24,6 +24,7 @@ import {
   ApprovedItemModal,
   DuplicateProspectModal,
   EditCorpusItemAction,
+  RejectAndUnscheduleItemAction,
   RemoveItemFromScheduledSurfaceModal,
   ScheduledItemCardWrapper,
   ScheduleItemModal,
@@ -167,6 +168,12 @@ export const SchedulePage: React.FC = (): ReactElement => {
    * Keep track of whether the "Duplicate item" modal is open or not.
    */
   const [duplicateProspectModalOpen, toggleDuplicateProspectModal] =
+    useToggle(false);
+
+  /**
+   * Keep track of whether the "Reject this item" modal is open or not.
+   */
+  const [rejectAndUnscheduleModalOpen, toggleRejectAndUnscheduleModal] =
     useToggle(false);
 
   // state variable to store s3 image url when user uploads a new image
@@ -552,32 +559,34 @@ export const SchedulePage: React.FC = (): ReactElement => {
       <h1>Schedule</h1>
 
       {currentItem && (
-        <RemoveItemFromScheduledSurfaceModal
-          item={currentItem}
-          isOpen={removeModalOpen}
-          onSave={onRemoveSave}
-          toggleModal={toggleRemoveModal}
-        />
-      )}
-
-      {currentItem && (
-        <ScheduleItemModal
-          approvedItem={currentItem.approvedItem}
-          headingCopy={'Reschedule Item'}
-          isOpen={scheduleItemModalOpen}
-          toggleModal={toggleScheduleItemModal}
-          onSave={onRescheduleItem}
-          scheduledSurfaceGuid={currentScheduledSurfaceGuid}
-        />
-      )}
-
-      {currentItem && (
-        <EditCorpusItemAction
-          item={currentItem.approvedItem}
-          modalOpen={editItemModalOpen}
-          toggleModal={toggleEditModal}
-          refetch={refetch}
-        />
+        <>
+          <RemoveItemFromScheduledSurfaceModal
+            item={currentItem}
+            isOpen={removeModalOpen}
+            onSave={onRemoveSave}
+            toggleModal={toggleRemoveModal}
+          />
+          <ScheduleItemModal
+            approvedItem={currentItem.approvedItem}
+            headingCopy={'Reschedule Item'}
+            isOpen={scheduleItemModalOpen}
+            toggleModal={toggleScheduleItemModal}
+            onSave={onRescheduleItem}
+            scheduledSurfaceGuid={currentScheduledSurfaceGuid}
+          />
+          <EditCorpusItemAction
+            item={currentItem.approvedItem}
+            modalOpen={editItemModalOpen}
+            toggleModal={toggleEditModal}
+            refetch={refetch}
+          />
+          <RejectAndUnscheduleItemAction
+            item={currentItem}
+            modalOpen={rejectAndUnscheduleModalOpen}
+            toggleModal={toggleRejectAndUnscheduleModal}
+            refetch={refetch}
+          />
+        </>
       )}
 
       <AddProspectModal
@@ -794,6 +803,24 @@ export const SchedulePage: React.FC = (): ReactElement => {
                             onReschedule={() => {
                               setCurrentItem(item);
                               toggleScheduleItemModal();
+                            }}
+                            onReject={() => {
+                              setCurrentItem(item);
+
+                              // If this item is also scheduled elsewhere, show an error.
+                              if (
+                                item.approvedItem.scheduledSurfaceHistory
+                                  .length > 1
+                              ) {
+                                showNotification(
+                                  'Cannot reject and unschedule this item - multiple scheduled entries exist.',
+                                  'error'
+                                );
+                              }
+                              // Otherwise, proceed with rejecting and unscheduling this item
+                              else {
+                                toggleRejectAndUnscheduleModal();
+                              }
                             }}
                             currentScheduledDate={data.scheduledDate}
                             scheduledSurfaceGuid={currentScheduledSurfaceGuid}


### PR DESCRIPTION
## Goal

When curators press the trash icon on items on the Schedule page, the app now allows them to reject these items and unschedule them in one go as long as that's the only scheduled entry.

If more than one scheduled entry is linked to the same corpus item that the curator is trying to reject, an error message appears instead.

Note: tests test the happy path only in line with existing tests.

## Video Walkthrough

Here I'm trying to reject an item but it's scheduled for another date. Once I remove the second scheduling entry, I can reject the item. 

https://github.com/Pocket/curation-admin-tools/assets/22447785/6bb64a2e-a761-49f5-b83c-75092c03845c


## Reference

https://mozilla-hub.atlassian.net/browse/MC-564
