### PR TITLE
fix bug: source on scheduled item should not change upon edit action

### DIFF
--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -489,10 +489,6 @@ export type CreateApprovedCorpusItemInput = {
   isTimeSensitive: Scalars['Boolean'];
   /** What language this item is in. This is a two-letter code, for example, 'EN' for English. */
   language: CorpusLanguage;
-  /** Free-text entered by the curator to give further detail to the manual addition reason(s) provided. */
-  manualAdditionReasonComment?: InputMaybe<Scalars['String']>;
-  /** A comma-separated list of reasons for manually adding an item (only supplied when `source` is MANUAL). */
-  manualAdditionReasons?: InputMaybe<Scalars['String']>;
   /** The GUID of the corresponding Prospect ID. Will be empty for manually added items. */
   prospectId?: InputMaybe<Scalars['ID']>;
   /** The name of the online publication that published this story. */
@@ -595,6 +591,10 @@ export type CreateRejectedCorpusItemInput = {
 export type CreateScheduledCorpusItemInput = {
   /** The ID of the Approved Item that needs to be scheduled. */
   approvedItemExternalId: Scalars['ID'];
+  /** Free-text entered by the curator to give further detail to the manual schedule reason(s) provided. */
+  manualScheduleReasonComment?: InputMaybe<Scalars['String']>;
+  /** A comma-separated list of reasons for manually scheduling an item. Helps ML improve models for sets of scheduled items. */
+  manualScheduleReasons?: InputMaybe<Scalars['String']>;
   /** The date the associated Approved Item is scheduled to appear on a Scheduled Surface. Format: YYYY-MM-DD. */
   scheduledDate: Scalars['Date'];
   /** The GUID of the Scheduled Surface the Approved Item is going to appear on. Example: 'NEW_TAB_EN_US'. */
@@ -830,6 +830,8 @@ export type Item = {
   hasOldDupes?: Maybe<Scalars['Boolean']>;
   /** 0=no videos, 1=contains video, 2=is a video */
   hasVideo?: Maybe<Videoness>;
+  /** A server generated unique id for this item based on itemId */
+  id: Scalars['ID'];
   /** Array of images within an article */
   images?: Maybe<Array<Maybe<Image>>>;
   /**
@@ -949,6 +951,22 @@ export type ListItemEdge = {
   /** The ListItem at the end of the edge. */
   node: ShareableListItem;
 };
+
+/**
+ * Reasons for manually scheduling a corpus item.
+ *
+ * This is used by ML downstream to improve their modeling.
+ */
+export enum ManualScheduleReason {
+  Evergreen = 'EVERGREEN',
+  FormatDiversity = 'FORMAT_DIVERSITY',
+  PublisherDiversity = 'PUBLISHER_DIVERSITY',
+  TimeSensitiveExplainer = 'TIME_SENSITIVE_EXPLAINER',
+  TimeSensitiveNews = 'TIME_SENSITIVE_NEWS',
+  TopicDiversity = 'TOPIC_DIVERSITY',
+  Trending = 'TRENDING',
+  UnderTheRadar = 'UNDER_THE_RADAR',
+}
 
 export type MarkdownImagePosition = {
   __typename?: 'MarkdownImagePosition';
@@ -2068,6 +2086,7 @@ export type UpdateLabelInput = {
 export type UrlMetadata = {
   __typename?: 'UrlMetadata';
   authors?: Maybe<Scalars['String']>;
+  datePublished?: Maybe<Scalars['String']>;
   domain?: Maybe<Scalars['String']>;
   excerpt?: Maybe<Scalars['String']>;
   imageUrl?: Maybe<Scalars['String']>;

--- a/src/curated-corpus/components/actions/ScheduleCorpusItemAction/ScheduleCorpusItemAction.tsx
+++ b/src/curated-corpus/components/actions/ScheduleCorpusItemAction/ScheduleCorpusItemAction.tsx
@@ -3,6 +3,7 @@ import { FormikHelpers, FormikValues } from 'formik';
 import { DateTime } from 'luxon';
 import {
   ApprovedCorpusItem,
+  CorpusItemSource,
   CreateScheduledCorpusItemInput,
   ScheduledItemSource,
   useCreateScheduledCorpusItemMutation,
@@ -72,13 +73,18 @@ export const ScheduleCorpusItemAction: React.FC<
       showNotification('Cannot schedule item without topic', 'error');
       return;
     }
-
+    let scheduledSource;
+    if (item.source === CorpusItemSource.Ml) {
+      scheduledSource = ScheduledItemSource.Ml;
+    } else {
+      scheduledSource = ScheduledItemSource.Manual;
+    }
     // Set out all the variables we need to pass to the mutation
     const variables: CreateScheduledCorpusItemInput = {
       approvedItemExternalId: item.externalId,
       scheduledSurfaceGuid: values.scheduledSurfaceGuid,
       scheduledDate: values.scheduledDate.toISODate(),
-      source: ScheduledItemSource.Manual,
+      source: scheduledSource,
     };
     // Run the mutation
     runMutation(

--- a/src/curated-corpus/components/actions/ScheduleCorpusItemAction/ScheduleCorpusItemAction.tsx
+++ b/src/curated-corpus/components/actions/ScheduleCorpusItemAction/ScheduleCorpusItemAction.tsx
@@ -3,7 +3,6 @@ import { FormikHelpers, FormikValues } from 'formik';
 import { DateTime } from 'luxon';
 import {
   ApprovedCorpusItem,
-  CorpusItemSource,
   CreateScheduledCorpusItemInput,
   ScheduledItemSource,
   useCreateScheduledCorpusItemMutation,
@@ -73,16 +72,12 @@ export const ScheduleCorpusItemAction: React.FC<
       showNotification('Cannot schedule item without topic', 'error');
       return;
     }
-    const scheduledSource =
-      item.source === CorpusItemSource.Ml
-        ? ScheduledItemSource.Ml
-        : ScheduledItemSource.Manual;
     // Set out all the variables we need to pass to the mutation
     const variables: CreateScheduledCorpusItemInput = {
       approvedItemExternalId: item.externalId,
       scheduledSurfaceGuid: values.scheduledSurfaceGuid,
       scheduledDate: values.scheduledDate.toISODate(),
-      source: scheduledSource,
+      source: ScheduledItemSource.Manual,
     };
     // Run the mutation
     runMutation(

--- a/src/curated-corpus/components/actions/ScheduleCorpusItemAction/ScheduleCorpusItemAction.tsx
+++ b/src/curated-corpus/components/actions/ScheduleCorpusItemAction/ScheduleCorpusItemAction.tsx
@@ -73,12 +73,10 @@ export const ScheduleCorpusItemAction: React.FC<
       showNotification('Cannot schedule item without topic', 'error');
       return;
     }
-    let scheduledSource;
-    if (item.source === CorpusItemSource.Ml) {
-      scheduledSource = ScheduledItemSource.Ml;
-    } else {
-      scheduledSource = ScheduledItemSource.Manual;
-    }
+    const scheduledSource =
+      item.source === CorpusItemSource.Ml
+        ? ScheduledItemSource.Ml
+        : ScheduledItemSource.Manual;
     // Set out all the variables we need to pass to the mutation
     const variables: CreateScheduledCorpusItemInput = {
       approvedItemExternalId: item.externalId,

--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -518,12 +518,10 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
       return;
     }
 
-    let scheduledSource;
-    if (approvedItem.source === CorpusItemSource.Ml) {
-      scheduledSource = ScheduledItemSource.Ml;
-    } else {
-      scheduledSource = ScheduledItemSource.Manual;
-    }
+    const scheduledSource =
+      approvedItem.source === CorpusItemSource.Ml
+        ? ScheduledItemSource.Ml
+        : ScheduledItemSource.Manual;
     // Set out all the variables we need to pass to the mutation
     const variables = {
       approvedItemExternalId: approvedItem?.externalId,

--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -22,7 +22,6 @@ import {
 } from '../../components';
 import {
   ApprovedCorpusItem,
-  CorpusItemSource,
   CreateApprovedCorpusItemMutation,
   CuratedStatus,
   Prospect,
@@ -518,16 +517,12 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
       return;
     }
 
-    const scheduledSource =
-      approvedItem.source === CorpusItemSource.Ml
-        ? ScheduledItemSource.Ml
-        : ScheduledItemSource.Manual;
     // Set out all the variables we need to pass to the mutation
     const variables = {
       approvedItemExternalId: approvedItem?.externalId,
       scheduledSurfaceGuid: values.scheduledSurfaceGuid,
       scheduledDate: values.scheduledDate.toISODate(),
-      source: scheduledSource,
+      source: ScheduledItemSource.Manual,
     };
 
     // Run the mutation

--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -22,6 +22,7 @@ import {
 } from '../../components';
 import {
   ApprovedCorpusItem,
+  CorpusItemSource,
   CreateApprovedCorpusItemMutation,
   CuratedStatus,
   Prospect,
@@ -517,12 +518,18 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
       return;
     }
 
+    let scheduledSource;
+    if (approvedItem.source === CorpusItemSource.Ml) {
+      scheduledSource = ScheduledItemSource.Ml;
+    } else {
+      scheduledSource = ScheduledItemSource.Manual;
+    }
     // Set out all the variables we need to pass to the mutation
     const variables = {
       approvedItemExternalId: approvedItem?.externalId,
       scheduledSurfaceGuid: values.scheduledSurfaceGuid,
       scheduledDate: values.scheduledDate.toISODate(),
-      source: ScheduledItemSource.Manual,
+      source: scheduledSource,
     };
 
     // Run the mutation

--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -33,6 +33,7 @@ import {
 } from '../../components';
 import {
   ApprovedCorpusItem,
+  CorpusItemSource,
   CreateApprovedCorpusItemMutation,
   DeleteScheduledCorpusItemInput,
   Prospect,
@@ -523,13 +524,18 @@ export const SchedulePage: React.FC = (): ReactElement => {
       showNotification('Cannot schedule item without topic', 'error');
       return;
     }
-
+    let scheduledSource;
+    if (approvedItem.source === CorpusItemSource.Ml) {
+      scheduledSource = ScheduledItemSource.Ml;
+    } else {
+      scheduledSource = ScheduledItemSource.Manual;
+    }
     // Set out all the variables we need to pass to the mutation
     const variables = {
       approvedItemExternalId: approvedItem?.externalId,
       scheduledSurfaceGuid: values.scheduledSurfaceGuid,
       scheduledDate: values.scheduledDate.toISODate(),
-      source: ScheduledItemSource.Manual,
+      source: scheduledSource,
     };
 
     // Run the mutation

--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -312,7 +312,7 @@ export const SchedulePage: React.FC = (): ReactElement => {
     const variables = {
       externalId: currentItem?.externalId,
       scheduledDate: values.scheduledDate.toISODate(),
-      source: ScheduledItemSource.Manual,
+      source: currentItem.source,
     };
 
     // Run the mutation
@@ -347,7 +347,7 @@ export const SchedulePage: React.FC = (): ReactElement => {
     const variables = {
       externalId: item.externalId,
       scheduledDate: item.scheduledDate,
-      source: ScheduledItemSource.Manual,
+      source: item.source,
     };
 
     // Run the mutation

--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -33,7 +33,6 @@ import {
 } from '../../components';
 import {
   ApprovedCorpusItem,
-  CorpusItemSource,
   CreateApprovedCorpusItemMutation,
   DeleteScheduledCorpusItemInput,
   Prospect,
@@ -524,16 +523,13 @@ export const SchedulePage: React.FC = (): ReactElement => {
       showNotification('Cannot schedule item without topic', 'error');
       return;
     }
-    const scheduledSource =
-      approvedItem.source === CorpusItemSource.Ml
-        ? ScheduledItemSource.Ml
-        : ScheduledItemSource.Manual;
+
     // Set out all the variables we need to pass to the mutation
     const variables = {
       approvedItemExternalId: approvedItem?.externalId,
       scheduledSurfaceGuid: values.scheduledSurfaceGuid,
       scheduledDate: values.scheduledDate.toISODate(),
-      source: scheduledSource,
+      source: ScheduledItemSource.Manual,
     };
 
     // Run the mutation

--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -524,12 +524,10 @@ export const SchedulePage: React.FC = (): ReactElement => {
       showNotification('Cannot schedule item without topic', 'error');
       return;
     }
-    let scheduledSource;
-    if (approvedItem.source === CorpusItemSource.Ml) {
-      scheduledSource = ScheduledItemSource.Ml;
-    } else {
-      scheduledSource = ScheduledItemSource.Manual;
-    }
+    const scheduledSource =
+      approvedItem.source === CorpusItemSource.Ml
+        ? ScheduledItemSource.Ml
+        : ScheduledItemSource.Manual;
     // Set out all the variables we need to pass to the mutation
     const variables = {
       approvedItemExternalId: approvedItem?.externalId,


### PR DESCRIPTION
## Goal

The `source` on a scheduled item was set to `Manual` upon an edit action. This was setting some of the `ML` source items to `Manual` source items. This PR fixes this.

## Reference

Tickets:

- [https://mozilla-hub.atlassian.net/browse/MC-840](https://mozilla-hub.atlassian.net/browse/MC-840)
