### PR TITLE
feat(scheduling): [MC-781] Add publication date to cards in Schedule View

### DIFF
--- a/src/api/fragments/curatedItemData.ts
+++ b/src/api/fragments/curatedItemData.ts
@@ -10,6 +10,7 @@ export const CuratedItemData = gql`
     title
     language
     publisher
+    datePublished
     authors {
       name
       sortOrder

--- a/src/api/fragments/urlMetadata.ts
+++ b/src/api/fragments/urlMetadata.ts
@@ -8,6 +8,7 @@ export const urlMetadata = gql`
     url
     imageUrl
     publisher
+    datePublished
     domain
     title
     excerpt

--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -1,5 +1,6 @@
-import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+import { gql } from '@apollo/client';
+
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = {
@@ -489,10 +490,6 @@ export type CreateApprovedCorpusItemInput = {
   isTimeSensitive: Scalars['Boolean'];
   /** What language this item is in. This is a two-letter code, for example, 'EN' for English. */
   language: CorpusLanguage;
-  /** Free-text entered by the curator to give further detail to the manual addition reason(s) provided. */
-  manualAdditionReasonComment?: InputMaybe<Scalars['String']>;
-  /** A comma-separated list of reasons for manually adding an item (only supplied when `source` is MANUAL). */
-  manualAdditionReasons?: InputMaybe<Scalars['String']>;
   /** The GUID of the corresponding Prospect ID. Will be empty for manually added items. */
   prospectId?: InputMaybe<Scalars['ID']>;
   /** The name of the online publication that published this story. */
@@ -595,6 +592,10 @@ export type CreateRejectedCorpusItemInput = {
 export type CreateScheduledCorpusItemInput = {
   /** The ID of the Approved Item that needs to be scheduled. */
   approvedItemExternalId: Scalars['ID'];
+  /** Free-text entered by the curator to give further detail to the manual schedule reason(s) provided. */
+  manualScheduleReasonComment?: InputMaybe<Scalars['String']>;
+  /** A comma-separated list of reasons for manually scheduling an item. Helps ML improve models for sets of scheduled items. */
+  manualScheduleReasons?: InputMaybe<Scalars['String']>;
   /** The date the associated Approved Item is scheduled to appear on a Scheduled Surface. Format: YYYY-MM-DD. */
   scheduledDate: Scalars['Date'];
   /** The GUID of the Scheduled Surface the Approved Item is going to appear on. Example: 'NEW_TAB_EN_US'. */
@@ -949,6 +950,22 @@ export type ListItemEdge = {
   /** The ListItem at the end of the edge. */
   node: ShareableListItem;
 };
+
+/**
+ * Reasons for manually scheduling a corpus item.
+ *
+ * This is used by ML downstream to improve their modeling.
+ */
+export enum ManualScheduleReason {
+  Evergreen = 'EVERGREEN',
+  FormatDiversity = 'FORMAT_DIVERSITY',
+  PublisherDiversity = 'PUBLISHER_DIVERSITY',
+  TimeSensitiveExplainer = 'TIME_SENSITIVE_EXPLAINER',
+  TimeSensitiveNews = 'TIME_SENSITIVE_NEWS',
+  TopicDiversity = 'TOPIC_DIVERSITY',
+  Trending = 'TRENDING',
+  UnderTheRadar = 'UNDER_THE_RADAR',
+}
 
 export type MarkdownImagePosition = {
   __typename?: 'MarkdownImagePosition';
@@ -2068,6 +2085,7 @@ export type UpdateLabelInput = {
 export type UrlMetadata = {
   __typename?: 'UrlMetadata';
   authors?: Maybe<Scalars['String']>;
+  datePublished?: Maybe<Scalars['String']>;
   domain?: Maybe<Scalars['String']>;
   excerpt?: Maybe<Scalars['String']>;
   imageUrl?: Maybe<Scalars['String']>;
@@ -2338,6 +2356,7 @@ export type CuratedItemDataFragment = {
   title: string;
   language: CorpusLanguage;
   publisher: string;
+  datePublished?: any | null;
   url: any;
   imageUrl: any;
   excerpt: string;
@@ -2492,6 +2511,7 @@ export type ScheduledItemDataFragment = {
     title: string;
     language: CorpusLanguage;
     publisher: string;
+    datePublished?: any | null;
     url: any;
     imageUrl: any;
     excerpt: string;
@@ -2525,6 +2545,7 @@ export type UrlMetadataFragment = {
   url: string;
   imageUrl?: string | null;
   publisher?: string | null;
+  datePublished?: string | null;
   domain?: string | null;
   title?: string | null;
   excerpt?: string | null;
@@ -2547,6 +2568,7 @@ export type CreateApprovedCorpusItemMutation = {
     title: string;
     language: CorpusLanguage;
     publisher: string;
+    datePublished?: any | null;
     url: any;
     imageUrl: any;
     excerpt: string;
@@ -2771,6 +2793,7 @@ export type CreateScheduledCorpusItemMutation = {
       title: string;
       language: CorpusLanguage;
       publisher: string;
+      datePublished?: any | null;
       url: any;
       imageUrl: any;
       excerpt: string;
@@ -2870,6 +2893,7 @@ export type DeleteScheduledItemMutation = {
       title: string;
       language: CorpusLanguage;
       publisher: string;
+      datePublished?: any | null;
       url: any;
       imageUrl: any;
       excerpt: string;
@@ -2964,6 +2988,7 @@ export type RejectApprovedItemMutation = {
     title: string;
     language: CorpusLanguage;
     publisher: string;
+    datePublished?: any | null;
     url: any;
     imageUrl: any;
     excerpt: string;
@@ -3066,6 +3091,7 @@ export type RescheduleScheduledCorpusItemMutation = {
       title: string;
       language: CorpusLanguage;
       publisher: string;
+      datePublished?: any | null;
       url: any;
       imageUrl: any;
       excerpt: string;
@@ -3108,6 +3134,7 @@ export type UpdateApprovedCorpusItemMutation = {
     title: string;
     language: CorpusLanguage;
     publisher: string;
+    datePublished?: any | null;
     url: any;
     imageUrl: any;
     excerpt: string;
@@ -3633,6 +3660,7 @@ export type GetApprovedItemByUrlQuery = {
     title: string;
     language: CorpusLanguage;
     publisher: string;
+    datePublished?: any | null;
     url: any;
     imageUrl: any;
     excerpt: string;
@@ -3688,6 +3716,7 @@ export type GetApprovedItemsQuery = {
         title: string;
         language: CorpusLanguage;
         publisher: string;
+        datePublished?: any | null;
         url: any;
         imageUrl: any;
         excerpt: string;
@@ -4205,6 +4234,7 @@ export type GetScheduledItemsQuery = {
         title: string;
         language: CorpusLanguage;
         publisher: string;
+        datePublished?: any | null;
         url: any;
         imageUrl: any;
         excerpt: string;
@@ -4362,6 +4392,7 @@ export type GetUrlMetadataQuery = {
     url: string;
     imageUrl?: string | null;
     publisher?: string | null;
+    datePublished?: string | null;
     domain?: string | null;
     title?: string | null;
     excerpt?: string | null;
@@ -4667,6 +4698,7 @@ export const CuratedItemDataFragmentDoc = gql`
     title
     language
     publisher
+    datePublished
     authors {
       name
       sortOrder
@@ -4713,6 +4745,7 @@ export const UrlMetadataFragmentDoc = gql`
     url
     imageUrl
     publisher
+    datePublished
     domain
     title
     excerpt

--- a/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.tsx
+++ b/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.tsx
@@ -6,10 +6,10 @@ import {
   Grid,
   LinearProgress,
   Link,
+  styled,
   Switch,
   TextField,
   Tooltip,
-  styled,
 } from '@mui/material';
 import { FormikHelpers, FormikValues, useFormik } from 'formik';
 import { validationSchema } from './ApprovedItemForm.validation';
@@ -91,6 +91,9 @@ export const ApprovedItemForm: React.FC<
       title: approvedItem.title,
       authors: flattenAuthors(approvedItem.authors),
       publisher: approvedItem.publisher,
+      // A read-only value we may get back from the Pocket Graph
+      // for some stories + all collections and syndicated items.
+      datePublished: approvedItem.datePublished ?? '',
       language: approvedItem.language ?? '',
       topic: approvedItem.topic ?? '',
       curationStatus: isRecommendation
@@ -432,7 +435,14 @@ export const ApprovedItemForm: React.FC<
           label="source"
           {...formik.getFieldProps('source')}
         />
+        <TextField
+          type="hidden"
+          id="datePublished"
+          label="datePublished"
+          {...formik.getFieldProps('datePublished')}
+        />
       </Box>
+
       {formik.isSubmitting && (
         <Grid item xs={12}>
           <Box mb={3}>

--- a/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.validation.tsx
+++ b/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.validation.tsx
@@ -27,6 +27,10 @@ export const validationSchema = yup.object({
     .min(2, 'Publisher needs to be longer than 2 characters.')
     .max(255, 'Publisher is too long, cannot exceed 255 characters.'),
 
+  // This value may not be present in initial curated corpus data,
+  // so it's not a required field.
+  datePublished: yup.date(),
+
   language: yup.string().required('Please select a language.'),
 
   topic: yup.string().required('Please select a topic.'),

--- a/src/curated-corpus/components/SuggestedScheduleItemListCard/SuggestedScheduleItemListCard.tsx
+++ b/src/curated-corpus/components/SuggestedScheduleItemListCard/SuggestedScheduleItemListCard.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, useState } from 'react';
 import { Box, CardContent, Link, Typography } from '@mui/material';
+import { DateTime } from 'luxon';
 
 import { ApprovedCorpusItem } from '../../../api/generatedTypes';
 import { flattenAuthors } from '../../../_shared/utils/flattenAuthors';
@@ -80,6 +81,13 @@ export const SuggestedScheduleItemListCard: React.FC<
     setScheduleHistoryModalOpen(!isScheduleHistoryModalOpen);
   };
 
+  // Display the date this story was published on if it's avaiable
+  const humanReadableDatePublished = item.datePublished
+    ? DateTime.fromFormat(item.datePublished, 'yyyy-MM-dd')
+        .setLocale('en')
+        .toLocaleString(DateTime.DATE_FULL)
+    : null;
+
   return (
     <>
       <CorpusItemCardImage
@@ -117,7 +125,12 @@ export const SuggestedScheduleItemListCard: React.FC<
         >
           <span>{item.publisher}</span> &middot;{' '}
           <span>{flattenAuthors(item.authors)}</span>
-          {/* <span>TODO add published date</span> */}
+          {item.datePublished && (
+            <>
+              {' '}
+              &middot; <span>{humanReadableDatePublished}</span>
+            </>
+          )}
         </Typography>
         <Typography
           variant="h5"

--- a/src/curated-corpus/components/actions/EditCorpusItemAction/EditCorpusItemAction.tsx
+++ b/src/curated-corpus/components/actions/EditCorpusItemAction/EditCorpusItemAction.tsx
@@ -69,6 +69,7 @@ export const EditCorpusItemAction: React.FC<EditCorpusItemActionProps> = (
         language: values.language,
         authors: transformAuthors(values.authors),
         publisher: values.publisher,
+        datePublished: values.datePublished,
         imageUrl: values.imageUrl,
         topic: values.topic,
         isTimeSensitive: values.timeSensitive,

--- a/src/curated-corpus/helpers/approvedItem.ts
+++ b/src/curated-corpus/helpers/approvedItem.ts
@@ -16,6 +16,7 @@ export const approvedCorpusItem: ApprovedCorpusItem = {
   language: CorpusLanguage.De,
   authors: [{ name: 'One Author', sortOrder: 0 }],
   publisher: 'Amazing Inventions',
+  datePublished: '2024-01-03',
   topic: Topics.HealthFitness,
   source: CorpusItemSource.Prospect,
   status: CuratedStatus.Recommendation,

--- a/src/curated-corpus/helpers/prospects.test.ts
+++ b/src/curated-corpus/helpers/prospects.test.ts
@@ -57,7 +57,7 @@ describe('helper functions related to prospects', () => {
 
   describe('transformProspectToApprovedItem function', () => {
     it('should create an ApprovedCorpusItem with all the provided fields', () => {
-      const prospect: Prospect = {
+      const prospect: Prospect & { datePublished?: string | null } = {
         id: 'test-id',
         prospectId: 'test-prospect-id',
         scheduledSurfaceGuid: 'en-us',
@@ -71,6 +71,7 @@ describe('helper functions related to prospects', () => {
         isSyndicated: true,
         language: CorpusLanguage.En,
         publisher: 'test-prospect-publisher',
+        datePublished: '2024-01-01',
         saveCount: 10,
         title: 'test-prospect-title',
         topic: 'test-prospect-topic',
@@ -89,6 +90,7 @@ describe('helper functions related to prospects', () => {
         title: prospect.title,
         imageUrl: prospect.imageUrl,
         publisher: prospect.publisher,
+        datePublished: prospect.datePublished,
         language: CorpusLanguage.En,
         topic: prospect.topic,
         status: CuratedStatus.Recommendation,
@@ -109,7 +111,7 @@ describe('helper functions related to prospects', () => {
         url: 'test-prospect-url',
         prospectId: 'test-prospect-id',
         scheduledSurfaceGuid: 'en-us',
-        prospectType: ProspectType.Global,
+        prospectType: ProspectType.Recommended,
       };
 
       const approvedItemFromProspect = transformProspectToApprovedItem(
@@ -125,6 +127,7 @@ describe('helper functions related to prospects', () => {
         title: '',
         imageUrl: '',
         publisher: '',
+        datePublished: null,
         language: undefined,
         topic: '',
         status: CuratedStatus.Corpus,
@@ -142,7 +145,9 @@ describe('helper functions related to prospects', () => {
 
   describe('transformUrlMetaDataToProspect function', () => {
     const urlMetadata: UrlMetadata = { url: 'www.test-url.com' };
-    const defaultExpectedProspect: Prospect = {
+    const defaultExpectedProspect: Prospect & {
+      datePublished?: string | null;
+    } = {
       id: '',
       prospectId: '',
       url: urlMetadata.url,
@@ -150,6 +155,7 @@ describe('helper functions related to prospects', () => {
       imageUrl: '',
       authors: '',
       publisher: '',
+      datePublished: null,
       language: undefined,
       isSyndicated: false,
       isCollection: false,

--- a/src/curated-corpus/helpers/prospects.ts
+++ b/src/curated-corpus/helpers/prospects.ts
@@ -76,7 +76,7 @@ export const getProspectFilterOptions = (
  * ProspectItemModal
  */
 export const transformProspectToApprovedItem = (
-  prospect: Prospect,
+  prospect: Prospect & { datePublished?: string | null },
   isRecommendation: boolean,
   isManual: boolean
 ): ApprovedItemFromProspect => {
@@ -88,6 +88,7 @@ export const transformProspectToApprovedItem = (
     imageUrl: prospect.imageUrl ?? '',
     authors: transformAuthors(prospect.authors),
     publisher: prospect.publisher ?? '',
+    datePublished: prospect.datePublished ?? null,
     language: prospect.language || undefined,
     source: isManual ? CorpusItemSource.Manual : CorpusItemSource.Prospect,
     topic: prospect.topic ?? '',
@@ -114,7 +115,7 @@ export const transformProspectToApprovedItem = (
  */
 export const transformUrlMetaDataToProspect = (
   metadata: UrlMetadata
-): Prospect => {
+): Prospect & { datePublished?: string | null } => {
   // set language to undefined if metadata.language is an empty string or undefined.
   // if not, then map it from string to its corresponding CorpusLanguage enum value
   let language: CorpusLanguage | undefined = undefined;
@@ -137,6 +138,13 @@ export const transformUrlMetaDataToProspect = (
     imageUrl: metadata.imageUrl ?? '',
     authors: metadata.authors ?? '',
     publisher: metadata.publisher ?? '',
+    // Only take the first 10 characters of the date value:
+    // if it comes from the Parser, it will look like a full timestamp.
+    // For collections and syndicated items, it will be a date
+    // in YYYY-MM-DD format, which is what we save to curated corpus data store.
+    datePublished: metadata.datePublished
+      ? metadata.datePublished.substring(0, 10)
+      : null,
     language,
     isSyndicated: metadata.isSyndicated ?? false,
     isCollection: metadata.isCollection ?? false,

--- a/src/curated-corpus/integration-test-mocks/getScheduledItems.ts
+++ b/src/curated-corpus/integration-test-mocks/getScheduledItems.ts
@@ -5,6 +5,7 @@ import {
   CuratedStatus,
   GetScheduledItemsQuery,
   ScheduledCorpusItem,
+  ScheduledItemSource,
   Topics,
 } from '../../api/generatedTypes';
 import { getScheduledItems } from '../../api/queries/getScheduledItems';
@@ -20,6 +21,7 @@ const approvedItem: ApprovedCorpusItem = {
   excerpt: 'Everything You Wanted to Know About React and Were Afraid To Ask',
   language: CorpusLanguage.De,
   publisher: 'Amazing Inventions',
+  datePublished: null,
   topic: Topics.Politics,
   status: CuratedStatus.Recommendation,
   isCollection: false,
@@ -47,6 +49,7 @@ export const scheduledItems: ScheduledCorpusItem[] = [
     updatedAt: 1635014926,
     updatedBy: 'Amy',
     scheduledSurfaceGuid: 'NEW_TAB_EN_US',
+    source: ScheduledItemSource.Manual,
     approvedItem,
   },
   {
@@ -57,6 +60,7 @@ export const scheduledItems: ScheduledCorpusItem[] = [
     updatedAt: 1635014926,
     updatedBy: 'Amy',
     scheduledSurfaceGuid: 'NEW_TAB_EN_US',
+    source: ScheduledItemSource.Manual,
     // Tweak topic & publisher to test ScheduleSummaryConnector
     approvedItem: {
       ...approvedItem,
@@ -73,6 +77,7 @@ export const scheduledItems: ScheduledCorpusItem[] = [
     updatedAt: 1635014926,
     updatedBy: 'Amy',
     scheduledSurfaceGuid: 'NEW_TAB_EN_US',
+    source: ScheduledItemSource.Ml,
     approvedItem: {
       ...approvedItem,
       topic: Topics.HealthFitness,

--- a/src/curated-corpus/integration-test-mocks/updateApprovedItem.ts
+++ b/src/curated-corpus/integration-test-mocks/updateApprovedItem.ts
@@ -15,6 +15,7 @@ export const successMock = {
         language: item.language,
         authors: item.authors,
         publisher: item.publisher,
+        datePublished: item.datePublished,
         imageUrl: item.imageUrl,
         topic: item.topic,
         isTimeSensitive: item.isTimeSensitive,

--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -388,6 +388,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
       language: values.language,
       authors: transformAuthors(values.authors),
       publisher: values.publisher,
+      datePublished: values.datePublished,
       source: values.source,
       imageUrl,
       topic: values.topic,

--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -454,6 +454,7 @@ export const SchedulePage: React.FC = (): ReactElement => {
       language: values.language,
       authors: transformAuthors(values.authors),
       publisher: values.publisher,
+      datePublished: values.datePublished,
       source: values.source,
       imageUrl,
       topic: values.topic,


### PR DESCRIPTION
## Goal

- Added the `datePublished` field throughout to be able to add this data when manually adding prospects or curated items. This is a hidden field and the data is supplied by the Pocket Graph for collections and syndicated items and by the Parser for all other stories if available.

- Added the publication date to the new look scheduled item card.

- Updated tests, query and mutation mocks, generated types.

## Implementation decisions

- The publication date is a hidden field for the time being - if the curators need to adjust or view it when adding a curated item manually, we can find a spot for it on the Approved Item form. I didn't want to add any more scope creep to a ticket that started out as a seemingly very small task.

## Video walkthrough

I'm adding an item manually on the Schedule page in the walkthrough; adding an item manually from the Prospecting page also works similarly - in that, it adds a date if it's available.


https://github.com/Pocket/curation-admin-tools/assets/22447785/cdd175a7-a4f3-4dd3-8914-d87f69660783



## Reference

Ref: https://mozilla-hub.atlassian.net/browse/MC-781

