### PR TITLE
fix(corpus): Adjust validation for 'datePublished' field to allow for null values

### DIFF
--- a/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.tsx
+++ b/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.tsx
@@ -93,7 +93,7 @@ export const ApprovedItemForm: React.FC<
       publisher: approvedItem.publisher,
       // A read-only value we may get back from the Pocket Graph
       // for some stories + all collections and syndicated items.
-      datePublished: approvedItem.datePublished ?? '',
+      datePublished: approvedItem.datePublished ?? null,
       language: approvedItem.language ?? '',
       topic: approvedItem.topic ?? '',
       curationStatus: isRecommendation

--- a/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.validation.tsx
+++ b/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.validation.tsx
@@ -29,7 +29,7 @@ export const validationSchema = yup.object({
 
   // This value may not be present in initial curated corpus data,
   // so it's not a required field.
-  datePublished: yup.date(),
+  datePublished: yup.date().nullable().default(null),
 
   language: yup.string().required('Please select a language.'),
 


### PR DESCRIPTION
## Goal

This is a follow-up fix to https://github.com/Pocket/curation-admin-tools/pull/1180 which broke editing metadata for existing curated items that don't have a publication date.
