### PR TITLE
fix(scheduling): [MC-922] Do not require manual scheduling reasons for syndicated items

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,4 +11,5 @@ services:
       - NODE_ENV=development
       - AWS_XRAY_LOG_LEVEL=silent
       - AWS_XRAY_CONTEXT_MISSING=LOG_ERROR
+      - TZ=America/New_York
     platform: linux/amd64

--- a/src/curated-corpus/components/actions/ScheduleCorpusItemAction/ScheduleCorpusItemAction.test.tsx
+++ b/src/curated-corpus/components/actions/ScheduleCorpusItemAction/ScheduleCorpusItemAction.test.tsx
@@ -48,13 +48,15 @@ describe('The ScheduleCorpusItemAction', () => {
   it('completes the action successfully', async () => {
     // setting a fixed timezone since this test has a tendency of passing locally but failing
     // on CI due to server and local timezone discrepancies
-    const today = DateTime.local()
-      .setZone('America/New_York')
+    const chosenDate = DateTime.local()
+      .setZone('Europe/London')
       .plus({ days: 1 });
+
+    const chosenSurfaceGuid = 'NEW_TAB_EN_GB';
 
     mocks = [
       mock_AllScheduledSurfaces,
-      successMock(today.toFormat('yyyy-MM-dd')),
+      successMock(chosenDate.toFormat('yyyy-MM-dd'), chosenSurfaceGuid),
     ];
 
     render(
@@ -80,7 +82,7 @@ describe('The ScheduleCorpusItemAction', () => {
     ) as HTMLSelectElement;
 
     // Select a scheduled surface
-    userEvent.selectOptions(surfaceSelect, 'NEW_TAB_EN_US');
+    userEvent.selectOptions(surfaceSelect, chosenSurfaceGuid);
 
     const datePicker = screen.getByRole('button', {
       name: /choose date/i,
@@ -89,18 +91,18 @@ describe('The ScheduleCorpusItemAction', () => {
     // Click on the date field to bring up the calendar
     userEvent.click(datePicker);
 
-    // Find today's date on the monthly calendar (in MUI 5, it's a grid cell)
-    const todaysMonthYear = screen.getAllByRole('grid', {
-      name: today.toFormat('MMMM yyyy'),
+    // Find the chosen date on the monthly calendar (in MUI 5, it's a grid cell)
+    const monthYear = screen.getAllByRole('grid', {
+      name: chosenDate.toFormat('MMMM yyyy'),
     });
-    expect(todaysMonthYear).toHaveLength(1);
+    expect(monthYear).toHaveLength(1);
 
-    const todaysDate = screen.getAllByRole('gridcell', {
-      name: today.toFormat('d'),
+    const day = screen.getAllByRole('gridcell', {
+      name: chosenDate.toFormat('d'),
     })[0];
 
     // Choose it
-    userEvent.click(todaysDate);
+    userEvent.click(day);
 
     userEvent.click(screen.getByText('Save'));
 

--- a/src/curated-corpus/integration-test-mocks/createScheduledCorpusItem.ts
+++ b/src/curated-corpus/integration-test-mocks/createScheduledCorpusItem.ts
@@ -10,13 +10,16 @@ import { getTestApprovedItem } from '../helpers/approvedItem';
  *
  * @param scheduledDate
  */
-export const successMock = (scheduledDate: string) => {
+export const successMock = (
+  scheduledDate: string,
+  scheduledSurfaceGuid = 'NEW_TAB_EN_US'
+) => {
   return {
     request: {
       query: createScheduledCorpusItem,
       variables: {
         approvedItemExternalId: '123-abc',
-        scheduledSurfaceGuid: 'NEW_TAB_EN_US',
+        scheduledSurfaceGuid,
         scheduledDate,
         source: ScheduledItemSource.Manual,
         actionScreen: ActionScreen.Schedule,
@@ -31,7 +34,7 @@ export const successMock = (scheduledDate: string) => {
           createdBy: 'Amy',
           updatedAt: 1635014926,
           updatedBy: 'Amy',
-          scheduledSurfaceGuid: 'NEW_TAB_EN_US',
+          scheduledSurfaceGuid,
           approvedItem: getTestApprovedItem(),
         },
       },

--- a/src/curated-corpus/integration-test-mocks/getScheduledSurfacesForUser.ts
+++ b/src/curated-corpus/integration-test-mocks/getScheduledSurfacesForUser.ts
@@ -11,7 +11,6 @@ const allScheduledSurfaces: ScheduledSurface[] = [
     guid: 'NEW_TAB_EN_US',
     ianaTimezone: 'America/New_York',
     prospectTypes: [
-      ProspectType.ConstraintSchedule,
       ProspectType.Counts,
       ProspectType.Timespent,
       ProspectType.Recommended,
@@ -25,7 +24,6 @@ const allScheduledSurfaces: ScheduledSurface[] = [
       ProspectType.TitleUrlModeled,
       ProspectType.RssLogistic,
       ProspectType.RssLogisticRecent,
-      ProspectType.SlateScheduler,
       ProspectType.SlateSchedulerV2,
     ],
   },

--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -737,8 +737,10 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
           scheduledSurfaceGuid={currentScheduledSurfaceGuid}
           disableScheduledSurface={disableScheduledSurface}
           showManualScheduleReasons={
-            /* Only ask for manual schedule reasons if the curator is working on the US New Tab */
-            currentScheduledSurfaceGuid === 'NEW_TAB_EN_US'
+            /* Only ask for manual schedule reasons if the curator is working on the US New Tab
+             * and if it's not a syndicated item */
+            currentScheduledSurfaceGuid === 'NEW_TAB_EN_US' &&
+            !approvedItem.isSyndicated
           }
           onSave={onScheduleSave}
           toggleModal={toggleScheduleModalAndDisableScheduledSurface}

--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -633,8 +633,10 @@ export const SchedulePage: React.FC = (): ReactElement => {
           isOpen={scheduleItemModalOpen}
           scheduledSurfaceGuid={currentScheduledSurfaceGuid}
           showManualScheduleReasons={
-            /* Only ask for manual schedule reasons if the curator is working on the US New Tab */
-            currentScheduledSurfaceGuid === 'NEW_TAB_EN_US'
+            /* Only ask for manual schedule reasons if the curator is working on the US New Tab
+             * and if it's not a syndicated item */
+            currentScheduledSurfaceGuid === 'NEW_TAB_EN_US' &&
+            !approvedItem.isSyndicated
           }
           onSave={onScheduleSave}
           toggleModal={toggleScheduleItemModal}


### PR DESCRIPTION
## Goal

Modify the workflow introduced in https://github.com/Pocket/curation-admin-tools/pull/1183 so that our syndication coordinator does not need to provide reasons when manually adding syndicated articles to the corpus.

## Video walkthrough

https://github.com/Pocket/curation-admin-tools/assets/22447785/ce295b8a-eb4c-4b04-859e-22f924880e20


## Reference

https://mozilla-hub.atlassian.net/browse/MC-922