### PR TITLE
feat: send actionScreen value to relevant mutations

### DIFF
--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -40,6 +40,16 @@ export type Scalars = {
   Url: any;
 };
 
+/** Indicates where in the Curation Tools UI the action took place */
+export enum ActionScreen {
+  /** This action took place from the corpus screen in the admin tool */
+  Corpus = 'CORPUS',
+  /** This action took place from the prospecting screen in the admin tool */
+  Prospecting = 'PROSPECTING',
+  /** This action took place from the schedule screen in the admin tool */
+  Schedule = 'SCHEDULE',
+}
+
 export type ApprovedCorpusImageUrl = {
   __typename?: 'ApprovedCorpusImageUrl';
   /** The url of the image stored in the s3 bucket */
@@ -470,6 +480,8 @@ export enum CorpusLanguage {
 
 /** Input data for creating an Approved Item and optionally scheduling this item to appear on a Scheduled Surface. */
 export type CreateApprovedCorpusItemInput = {
+  /** The UI screen where the approved corpus item is being created from. */
+  actionScreen?: InputMaybe<ActionScreen>;
   /** A name and sort order for each author. */
   authors: Array<CorpusItemAuthorInput>;
   /** The publication date for this story. */
@@ -568,6 +580,11 @@ export type CreateCollectionStoryInput = {
 
 /** Input data for creating a Rejected Item. */
 export type CreateRejectedCorpusItemInput = {
+  /**
+   * The UI screen where the rejected corpus item is being created from.
+   * Currently only available on prospect screen.
+   */
+  actionScreen?: InputMaybe<ActionScreen>;
   /** What language this item is in. This is a two-letter code, for example, 'EN' for English. */
   language?: InputMaybe<CorpusLanguage>;
   /** The GUID of the corresponding Prospect ID. Will be empty for manually added item. */
@@ -589,6 +606,11 @@ export type CreateRejectedCorpusItemInput = {
 
 /** Input data for creating a scheduled entry for an Approved Item on a Scheduled Surface. */
 export type CreateScheduledCorpusItemInput = {
+  /**
+   * The UI screen where the scheduled corpus item is being created from.
+   * Can be from the prospecting, corpus, or schedule screens.
+   */
+  actionScreen?: InputMaybe<ActionScreen>;
   /** The ID of the Approved Item that needs to be scheduled. */
   approvedItemExternalId: Scalars['ID'];
   /** Free-text entered by the curator to give further detail to the manual schedule reason(s) provided. */
@@ -624,6 +646,11 @@ export type DeleteCollectionPartnerAssociationInput = {
 
 /** Input data for deleting a scheduled item for a Scheduled Surface. */
 export type DeleteScheduledCorpusItemInput = {
+  /**
+   * The UI screen where the scheduled corpus item is being deleted from.
+   * Can only be from the schedule screen.
+   */
+  actionScreen?: InputMaybe<ActionScreen>;
   /** ID of the scheduled item. A string in UUID format. */
   externalId: Scalars['ID'];
   /** Free-text entered by the curator to give further detail to the reason(s) provided. */
@@ -1584,6 +1611,11 @@ export type QuerySearchShareableListArgs = {
 
 /** Input data for rejecting an Approved Item. */
 export type RejectApprovedCorpusItemInput = {
+  /**
+   * The UI screen where the approved corpus item is being rejected from.
+   * Can be the schedule screen or the corpus screen.
+   */
+  actionScreen?: InputMaybe<ActionScreen>;
   /** Approved Item ID. */
   externalId: Scalars['ID'];
   /** A comma-separated list of rejection reasons. */
@@ -1713,6 +1745,11 @@ export type RemoveProspectInput = {
 
 /** Input data for rescheduling a scheduled item for a Scheduled Surface. */
 export type RescheduleScheduledCorpusItemInput = {
+  /**
+   * The UI screen where the scheduled corpus item is being resceduled from.
+   * Can only be from the schedule screen.
+   */
+  actionScreen?: InputMaybe<ActionScreen>;
   /** ID of the scheduled item. A string in UUID format. */
   externalId: Scalars['ID'];
   /** The new scheduled date for the scheduled item to appear on a Scheduled Surface. Format: YYYY-MM-DD. */
@@ -1963,6 +2000,11 @@ export type UpdateApprovedCorpusItemAuthorsInput = {
 
 /** Input data for updating an Approved Item. */
 export type UpdateApprovedCorpusItemInput = {
+  /**
+   * The UI screen where the approved corpus item is being updated from.
+   * Can be on the corpus screen or the schedule screen.
+   */
+  actionScreen?: InputMaybe<ActionScreen>;
   /** A name and sort order for each author. */
   authors: Array<CorpusItemAuthorInput>;
   /** The publication date for this story. */
@@ -2777,6 +2819,7 @@ export type CreateScheduledCorpusItemMutationVariables = Exact<{
   source: ScheduledItemSource;
   reasons?: InputMaybe<Scalars['String']>;
   reasonComment?: InputMaybe<Scalars['String']>;
+  actionScreen?: InputMaybe<ActionScreen>;
 }>;
 
 export type CreateScheduledCorpusItemMutation = {
@@ -3073,6 +3116,7 @@ export type RescheduleScheduledCorpusItemMutationVariables = Exact<{
   externalId: Scalars['ID'];
   scheduledDate: Scalars['Date'];
   source: ScheduledItemSource;
+  actionScreen?: InputMaybe<ActionScreen>;
 }>;
 
 export type RescheduleScheduledCorpusItemMutation = {
@@ -5208,6 +5252,7 @@ export const CreateScheduledCorpusItemDocument = gql`
     $source: ScheduledItemSource!
     $reasons: String
     $reasonComment: String
+    $actionScreen: ActionScreen
   ) {
     createScheduledCorpusItem(
       data: {
@@ -5217,6 +5262,7 @@ export const CreateScheduledCorpusItemDocument = gql`
         source: $source
         reasons: $reasons
         reasonComment: $reasonComment
+        actionScreen: $actionScreen
       }
     ) {
       externalId
@@ -5256,6 +5302,7 @@ export type CreateScheduledCorpusItemMutationFn = Apollo.MutationFunction<
  *      source: // value for 'source'
  *      reasons: // value for 'reasons'
  *      reasonComment: // value for 'reasonComment'
+ *      actionScreen: // value for 'actionScreen'
  *   },
  * });
  */
@@ -5718,12 +5765,14 @@ export const RescheduleScheduledCorpusItemDocument = gql`
     $externalId: ID!
     $scheduledDate: Date!
     $source: ScheduledItemSource!
+    $actionScreen: ActionScreen
   ) {
     rescheduleScheduledCorpusItem(
       data: {
         externalId: $externalId
         scheduledDate: $scheduledDate
         source: $source
+        actionScreen: $actionScreen
       }
     ) {
       ...ScheduledItemData
@@ -5752,6 +5801,7 @@ export type RescheduleScheduledCorpusItemMutationFn = Apollo.MutationFunction<
  *      externalId: // value for 'externalId'
  *      scheduledDate: // value for 'scheduledDate'
  *      source: // value for 'source'
+ *      actionScreen: // value for 'actionScreen'
  *   },
  * });
  */

--- a/src/api/mutations/createScheduledCorpusItem.ts
+++ b/src/api/mutations/createScheduledCorpusItem.ts
@@ -9,6 +9,7 @@ export const createScheduledCorpusItem = gql`
     $source: ScheduledItemSource!
     $reasons: String
     $reasonComment: String
+    $actionScreen: ActionScreen
   ) {
     createScheduledCorpusItem(
       data: {
@@ -18,6 +19,7 @@ export const createScheduledCorpusItem = gql`
         source: $source
         reasons: $reasons
         reasonComment: $reasonComment
+        actionScreen: $actionScreen
       }
     ) {
       externalId

--- a/src/api/mutations/rescheduledScheduledItem.ts
+++ b/src/api/mutations/rescheduledScheduledItem.ts
@@ -6,12 +6,14 @@ export const rescheduleScheduledItem = gql`
     $externalId: ID!
     $scheduledDate: Date!
     $source: ScheduledItemSource!
+    $actionScreen: ActionScreen
   ) {
     rescheduleScheduledCorpusItem(
       data: {
         externalId: $externalId
         scheduledDate: $scheduledDate
         source: $source
+        actionScreen: $actionScreen
       }
     ) {
       ...ScheduledItemData

--- a/src/curated-corpus/components/actions/EditCorpusItemAction/EditCorpusItemAction.tsx
+++ b/src/curated-corpus/components/actions/EditCorpusItemAction/EditCorpusItemAction.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { FormikHelpers, FormikValues } from 'formik';
 import {
+  ActionScreen,
   ApprovedCorpusItem,
   useUpdateApprovedCorpusItemMutation,
 } from '../../../../api/generatedTypes';
@@ -13,6 +14,11 @@ interface EditCorpusItemActionProps {
    * The approved item that is about to become a rejected item instead.
    */
   item: ApprovedCorpusItem;
+
+  /**
+   * Indicates from which page the edit happened. (Analytics)
+   */
+  actionScreen: ActionScreen;
 
   /**
    * A state variable that tracks whether the ApprovedIteModal is visible
@@ -46,7 +52,7 @@ interface EditCorpusItemActionProps {
 export const EditCorpusItemAction: React.FC<EditCorpusItemActionProps> = (
   props
 ) => {
-  const { item, toggleModal, modalOpen, refetch } = props;
+  const { item, actionScreen, toggleModal, modalOpen, refetch } = props;
 
   // Get a helper function that will execute each mutation, show standard notifications
   // and execute any additional actions in a callback
@@ -73,6 +79,7 @@ export const EditCorpusItemAction: React.FC<EditCorpusItemActionProps> = (
         imageUrl: values.imageUrl,
         topic: values.topic,
         isTimeSensitive: values.timeSensitive,
+        actionScreen,
       },
     };
 

--- a/src/curated-corpus/components/actions/RejectAndUnscheduleItemAction/RejectAndUnscheduleItemAction.test.tsx
+++ b/src/curated-corpus/components/actions/RejectAndUnscheduleItemAction/RejectAndUnscheduleItemAction.test.tsx
@@ -2,11 +2,15 @@ import React from 'react';
 import { MockedProvider, MockedResponse } from '@apollo/client/testing';
 import { render, screen } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
+import userEvent from '@testing-library/user-event';
+
+import { ActionScreen } from '../../../../api/generatedTypes';
+
 import { RejectAndUnscheduleItemAction } from './RejectAndUnscheduleItemAction';
 import { getTestScheduledItem } from '../../../helpers/scheduledItem';
 import { successMock as unscheduleItemSuccessMock } from '../../../integration-test-mocks/deleteScheduledCorpusItem';
 import { successMock as rejectItemSuccessMock } from '../../../integration-test-mocks/rejectApprovedItem';
-import userEvent from '@testing-library/user-event';
+
 import { apolloCache } from '../../../../api/client';
 
 describe('The RejectAndUnscheduleItemAction', () => {
@@ -20,6 +24,7 @@ describe('The RejectAndUnscheduleItemAction', () => {
         <SnackbarProvider maxSnack={3}>
           <RejectAndUnscheduleItemAction
             item={getTestScheduledItem()}
+            actionScreen={ActionScreen.Schedule}
             toggleModal={jest.fn()}
             modalOpen={true}
           />
@@ -42,6 +47,7 @@ describe('The RejectAndUnscheduleItemAction', () => {
         <SnackbarProvider maxSnack={3}>
           <RejectAndUnscheduleItemAction
             item={getTestScheduledItem()}
+            actionScreen={ActionScreen.Schedule}
             toggleModal={jest.fn()}
             modalOpen={true}
           />

--- a/src/curated-corpus/components/actions/RejectAndUnscheduleItemAction/RejectAndUnscheduleItemAction.tsx
+++ b/src/curated-corpus/components/actions/RejectAndUnscheduleItemAction/RejectAndUnscheduleItemAction.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { FormikHelpers, FormikValues } from 'formik';
 import {
+  ActionScreen,
   DeleteScheduledCorpusItemInput,
   RejectApprovedCorpusItemInput,
   ScheduledCorpusItem,
@@ -15,6 +16,11 @@ interface RejectAndUnscheduleItemActionProps {
    * The scheduled item that is about to be rejected and unscheduled in one go.
    */
   item: ScheduledCorpusItem;
+
+  /**
+   * Indicate on which screen the action was performed.
+   */
+  actionScreen: ActionScreen;
 
   /**
    * A state variable that tracks whether the RejectItemModal is visible
@@ -50,7 +56,7 @@ interface RejectAndUnscheduleItemActionProps {
 export const RejectAndUnscheduleItemAction: React.FC<
   RejectAndUnscheduleItemActionProps
 > = (props) => {
-  const { item, toggleModal, modalOpen, refetch } = props;
+  const { item, actionScreen, toggleModal, modalOpen, refetch } = props;
 
   // Get a helper function that will execute each mutation, show standard notifications
   // and execute any additional actions in a callback
@@ -71,12 +77,14 @@ export const RejectAndUnscheduleItemAction: React.FC<
     // Set up all the variables we need to pass to the unschedule mutation
     const unscheduleInput: DeleteScheduledCorpusItemInput = {
       externalId: item.externalId as string,
+      actionScreen,
     };
 
     // Set out all the variables we need to pass to the reject mutation
     const rejectInput: RejectApprovedCorpusItemInput = {
       externalId: item.approvedItem!.externalId,
       reason: values.reason,
+      actionScreen,
     };
 
     // First unschedule the item, otherwise the rejection will fail

--- a/src/curated-corpus/components/actions/RejectCorpusItemAction/RejectCorpusItemAction.test.tsx
+++ b/src/curated-corpus/components/actions/RejectCorpusItemAction/RejectCorpusItemAction.test.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../../integration-test-mocks/rejectApprovedItem';
 import userEvent from '@testing-library/user-event';
 import { apolloCache } from '../../../../api/client';
+import { ActionScreen } from '../../../../api/generatedTypes';
 
 describe('The RejectCorpusItemAction', () => {
   let mocks: MockedResponse[] = [];
@@ -22,6 +23,7 @@ describe('The RejectCorpusItemAction', () => {
         <SnackbarProvider maxSnack={3}>
           <RejectCorpusItemAction
             item={getTestApprovedItem()}
+            actionScreen={ActionScreen.Schedule}
             toggleModal={jest.fn()}
             modalOpen={true}
           />
@@ -44,6 +46,7 @@ describe('The RejectCorpusItemAction', () => {
         <SnackbarProvider maxSnack={3}>
           <RejectCorpusItemAction
             item={getTestApprovedItem()}
+            actionScreen={ActionScreen.Schedule}
             toggleModal={jest.fn()}
             modalOpen={true}
           />
@@ -85,6 +88,7 @@ describe('The RejectCorpusItemAction', () => {
         <SnackbarProvider maxSnack={3}>
           <RejectCorpusItemAction
             item={getTestApprovedItem({ externalId: '456-cde' })}
+            actionScreen={ActionScreen.Schedule}
             toggleModal={jest.fn()}
             modalOpen={true}
           />

--- a/src/curated-corpus/components/actions/RejectCorpusItemAction/RejectCorpusItemAction.tsx
+++ b/src/curated-corpus/components/actions/RejectCorpusItemAction/RejectCorpusItemAction.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { FormikHelpers, FormikValues } from 'formik';
 import {
+  ActionScreen,
   ApprovedCorpusItem,
   useRejectApprovedItemMutation,
 } from '../../../../api/generatedTypes';
@@ -12,6 +13,11 @@ interface RejectCorpusItemActionProps {
    * The approved item that is about to become a rejected item instead.
    */
   item: ApprovedCorpusItem;
+
+  /**
+   * Identify from which screen the rejection action happened.
+   */
+  actionScreen: ActionScreen;
 
   /**
    * A state variable that tracks whether the RejectItemModal is visible
@@ -47,7 +53,7 @@ interface RejectCorpusItemActionProps {
 export const RejectCorpusItemAction: React.FC<RejectCorpusItemActionProps> = (
   props
 ) => {
-  const { item, toggleModal, modalOpen, refetch } = props;
+  const { item, actionScreen, toggleModal, modalOpen, refetch } = props;
 
   // Get a helper function that will execute each mutation, show standard notifications
   // and execute any additional actions in a callback
@@ -67,6 +73,7 @@ export const RejectCorpusItemAction: React.FC<RejectCorpusItemActionProps> = (
       data: {
         externalId: item.externalId,
         reason: values.reason,
+        actionScreen,
       },
     };
 

--- a/src/curated-corpus/components/actions/ScheduleCorpusItemAction/ScheduleCorpusItemAction.test.tsx
+++ b/src/curated-corpus/components/actions/ScheduleCorpusItemAction/ScheduleCorpusItemAction.test.tsx
@@ -2,13 +2,16 @@ import React from 'react';
 import { MockedProvider, MockedResponse } from '@apollo/client/testing';
 import { render, screen } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
+import { DateTime } from 'luxon';
 import userEvent from '@testing-library/user-event';
+
+import { ActionScreen } from '../../../../api/generatedTypes';
+
 import { getTestApprovedItem } from '../../../helpers/approvedItem';
 import { successMock } from '../../../integration-test-mocks/createScheduledCorpusItem';
 import { apolloCache } from '../../../../api/client';
 import { ScheduleCorpusItemAction } from './ScheduleCorpusItemAction';
 import { mock_AllScheduledSurfaces } from '../../../integration-test-mocks/getScheduledSurfacesForUser';
-import { DateTime } from 'luxon';
 
 describe('The ScheduleCorpusItemAction', () => {
   let mocks: MockedResponse[] = [];
@@ -25,6 +28,7 @@ describe('The ScheduleCorpusItemAction', () => {
         <SnackbarProvider maxSnack={3}>
           <ScheduleCorpusItemAction
             item={getTestApprovedItem()}
+            actionScreen={ActionScreen.Schedule}
             toggleModal={jest.fn()}
             modalOpen={true}
           />
@@ -58,6 +62,7 @@ describe('The ScheduleCorpusItemAction', () => {
         <SnackbarProvider maxSnack={3}>
           <ScheduleCorpusItemAction
             item={getTestApprovedItem()}
+            actionScreen={ActionScreen.Schedule}
             toggleModal={jest.fn()}
             modalOpen={true}
           />

--- a/src/curated-corpus/components/actions/ScheduleCorpusItemAction/ScheduleCorpusItemAction.tsx
+++ b/src/curated-corpus/components/actions/ScheduleCorpusItemAction/ScheduleCorpusItemAction.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { FormikHelpers, FormikValues } from 'formik';
 import { DateTime } from 'luxon';
 import {
+  ActionScreen,
   ApprovedCorpusItem,
   CreateScheduledCorpusItemInput,
   ScheduledItemSource,
@@ -15,6 +16,11 @@ interface ScheduleCorpusItemActionProps {
    * The approved item that is to be scheduled onto a surface.
    */
   item: ApprovedCorpusItem;
+
+  /**
+   * Indicates from which page the scheduling happened. (Analytics)
+   */
+  actionScreen: ActionScreen;
 
   /**
    * A state variable that tracks whether the ScheduleItemModal is visible
@@ -48,7 +54,7 @@ interface ScheduleCorpusItemActionProps {
 export const ScheduleCorpusItemAction: React.FC<
   ScheduleCorpusItemActionProps
 > = (props) => {
-  const { item, toggleModal, modalOpen, refetch } = props;
+  const { item, actionScreen, toggleModal, modalOpen, refetch } = props;
 
   // set up the hook for toast notification
   const { showNotification } = useNotifications();
@@ -57,7 +63,7 @@ export const ScheduleCorpusItemAction: React.FC<
   // and execute any additional actions in a callback
   const { runMutation } = useRunMutation();
 
-  // 1. Prepare the "reject curated item" mutation
+  // 1. Prepare the "schedule curated item" mutation
   const [scheduleCuratedItem] = useCreateScheduledCorpusItemMutation();
 
   const onSave = (
@@ -78,6 +84,7 @@ export const ScheduleCorpusItemAction: React.FC<
       scheduledSurfaceGuid: values.scheduledSurfaceGuid,
       scheduledDate: values.scheduledDate.toISODate(),
       source: ScheduledItemSource.Manual,
+      actionScreen,
     };
     // Run the mutation
     runMutation(

--- a/src/curated-corpus/integration-test-mocks/createScheduledCorpusItem.ts
+++ b/src/curated-corpus/integration-test-mocks/createScheduledCorpusItem.ts
@@ -1,4 +1,4 @@
-import { ScheduledItemSource } from '../../api/generatedTypes';
+import { ActionScreen, ScheduledItemSource } from '../../api/generatedTypes';
 
 import { createScheduledCorpusItem } from '../../api/mutations/createScheduledCorpusItem';
 import { getTestApprovedItem } from '../helpers/approvedItem';
@@ -19,6 +19,7 @@ export const successMock = (scheduledDate: string) => {
         scheduledSurfaceGuid: 'NEW_TAB_EN_US',
         scheduledDate,
         source: ScheduledItemSource.Manual,
+        actionScreen: ActionScreen.Schedule,
       },
     },
     result: {

--- a/src/curated-corpus/integration-test-mocks/deleteScheduledCorpusItem.ts
+++ b/src/curated-corpus/integration-test-mocks/deleteScheduledCorpusItem.ts
@@ -1,3 +1,5 @@
+import { ActionScreen } from '../../api/generatedTypes';
+
 import { deleteScheduledItem } from '../../api/mutations/deleteScheduledItem';
 import { getTestScheduledItem } from '../helpers/scheduledItem';
 
@@ -6,7 +8,12 @@ const item = getTestScheduledItem();
 export const successMock = {
   request: {
     query: deleteScheduledItem,
-    variables: { data: { externalId: item.externalId } },
+    variables: {
+      data: {
+        externalId: item.externalId,
+        actionScreen: ActionScreen.Schedule,
+      },
+    },
   },
   result: { data: { deleteScheduledCorpusItem: item } },
 };

--- a/src/curated-corpus/integration-test-mocks/rejectApprovedItem.ts
+++ b/src/curated-corpus/integration-test-mocks/rejectApprovedItem.ts
@@ -1,10 +1,18 @@
+import { ActionScreen } from '../../api/generatedTypes';
+
 import { rejectApprovedItem } from '../../api/mutations/rejectApprovedItem';
 import { getTestApprovedItem } from '../helpers/approvedItem';
 
 export const successMock = {
   request: {
     query: rejectApprovedItem,
-    variables: { data: { externalId: '123-abc', reason: 'TIME_SENSITIVE' } },
+    variables: {
+      data: {
+        externalId: '123-abc',
+        reason: 'TIME_SENSITIVE',
+        actionScreen: ActionScreen.Schedule,
+      },
+    },
   },
   result: { data: { rejectApprovedCorpusItem: getTestApprovedItem() } },
 };

--- a/src/curated-corpus/pages/CorpusItemPage/CorpusItemPage.tsx
+++ b/src/curated-corpus/pages/CorpusItemPage/CorpusItemPage.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import { useApprovedCorpusItemByExternalIdQuery } from '../../../api/generatedTypes';
+import {
+  ActionScreen,
+  useApprovedCorpusItemByExternalIdQuery,
+} from '../../../api/generatedTypes';
 import { HandleApiResponse } from '../../../_shared/components';
 import {
   Alert,
@@ -110,6 +113,7 @@ export const CorpusItemPage: React.FC = (): JSX.Element => {
           </Grid>
           <RejectCorpusItemAction
             item={data.approvedCorpusItemByExternalId!}
+            actionScreen={ActionScreen.Corpus}
             modalOpen={rejectModalOpen}
             toggleModal={toggleRejectModal}
             refetch={refetch}
@@ -119,9 +123,11 @@ export const CorpusItemPage: React.FC = (): JSX.Element => {
             modalOpen={scheduleModalOpen}
             toggleModal={toggleScheduleModal}
             refetch={refetch}
+            actionScreen={ActionScreen.Corpus}
           />
           <EditCorpusItemAction
             item={data.approvedCorpusItemByExternalId!}
+            actionScreen={ActionScreen.Corpus}
             modalOpen={editModalOpen}
             toggleModal={toggleEditModal}
             refetch={refetch}

--- a/src/curated-corpus/pages/CorpusPage/CorpusPage.tsx
+++ b/src/curated-corpus/pages/CorpusPage/CorpusPage.tsx
@@ -3,6 +3,7 @@ import { Grid, Typography } from '@mui/material';
 import { FormikValues } from 'formik';
 import { config } from '../../../config';
 import {
+  ActionScreen,
   ApprovedCorpusItem,
   ApprovedCorpusItemEdge,
   ApprovedCorpusItemFilter,
@@ -152,15 +153,18 @@ export const CorpusPage: React.FC = (): JSX.Element => {
                 modalOpen={scheduleModalOpen}
                 toggleModal={toggleScheduleModal}
                 refetch={refetch}
+                actionScreen={ActionScreen.Corpus}
               />
               <EditCorpusItemAction
                 item={currentItem}
+                actionScreen={ActionScreen.Corpus}
                 modalOpen={editModalOpen}
                 toggleModal={toggleEditModal}
                 refetch={refetch}
               />
               <RejectCorpusItemAction
                 item={currentItem}
+                actionScreen={ActionScreen.Corpus}
                 modalOpen={rejectModalOpen}
                 toggleModal={toggleRejectModal}
                 refetch={refetch}

--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -21,6 +21,7 @@ import {
   SplitButton,
 } from '../../components';
 import {
+  ActionScreen,
   ApprovedCorpusItem,
   CreateApprovedCorpusItemMutation,
   CuratedStatus,
@@ -304,6 +305,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
         publisher: currentProspect?.publisher,
         reason: values.reason,
         prospectId: currentProspect?.prospectId,
+        actionScreen: ActionScreen.Prospecting,
       },
     };
 
@@ -395,6 +397,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
       isCollection: values.collection,
       isTimeSensitive: values.timeSensitive,
       isSyndicated: values.syndicated,
+      actionScreen: ActionScreen.Prospecting,
     };
 
     // call the create approved item mutation
@@ -531,6 +534,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
       reason:
         values.manualScheduleReason == '' ? null : values.manualScheduleReason,
       reasonComment: values.reasonComment == '' ? null : values.reasonComment,
+      actionScreen: ActionScreen.Prospecting,
     };
 
     // Run the mutation

--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -32,6 +32,7 @@ import {
   SplitButton,
 } from '../../components';
 import {
+  ActionScreen,
   ApprovedCorpusItem,
   CreateApprovedCorpusItemMutation,
   DeleteScheduledCorpusItemInput,
@@ -313,6 +314,7 @@ export const SchedulePage: React.FC = (): ReactElement => {
       externalId: currentItem?.externalId,
       scheduledDate: values.scheduledDate.toISODate(),
       source: currentItem.source,
+      actionScreen: ActionScreen.Schedule,
     };
 
     // Run the mutation
@@ -376,6 +378,7 @@ export const SchedulePage: React.FC = (): ReactElement => {
       externalId: currentItem?.externalId as string,
       reasonComment: values.otherReason,
       reasons: values.removalReason,
+      actionScreen: ActionScreen.Schedule,
     };
     // Run the mutation
     runMutation(
@@ -461,6 +464,7 @@ export const SchedulePage: React.FC = (): ReactElement => {
       isCollection: values.collection,
       isTimeSensitive: values.timeSensitive,
       isSyndicated: values.syndicated,
+      actionScreen: ActionScreen.Schedule,
     };
 
     // call the create approved item mutation
@@ -538,6 +542,7 @@ export const SchedulePage: React.FC = (): ReactElement => {
       reason:
         values.manualScheduleReason == '' ? null : values.manualScheduleReason,
       reasonComment: values.reasonComment == '' ? null : values.reasonComment,
+      actionScreen: ActionScreen.Schedule,
     };
 
     // Run the mutation
@@ -584,12 +589,14 @@ export const SchedulePage: React.FC = (): ReactElement => {
           />
           <EditCorpusItemAction
             item={currentItem.approvedItem}
+            actionScreen={ActionScreen.Schedule}
             modalOpen={editItemModalOpen}
             toggleModal={toggleEditModal}
             refetch={refetch}
           />
           <RejectAndUnscheduleItemAction
             item={currentItem}
+            actionScreen={ActionScreen.Schedule}
             modalOpen={rejectAndUnscheduleModalOpen}
             toggleModal={toggleRejectAndUnscheduleModal}
             refetch={refetch}


### PR DESCRIPTION
## Goal

send actionScreen value to relevant mutations.

## Reference

- https://mozilla-hub.atlassian.net/browse/MC-748
