### PR TITLE
MC-670: automatically format title using AP style title case

### DIFF
--- a/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.tsx
+++ b/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.tsx
@@ -128,6 +128,7 @@ export const ApprovedItemListCard: React.FC<ApprovedItemListCardProps> = (
             }}
           >
             {isItemEnglish && applyApTitleCase(item.title)}
+            {!isItemEnglish && item.title}
           </Link>
         </Typography>
         <Typography variant="body2" component="p" gutterBottom>

--- a/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.tsx
+++ b/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.tsx
@@ -21,6 +21,7 @@ import { flattenAuthors } from '../../../_shared/utils/flattenAuthors';
 import { ScheduleHistory } from '../';
 
 import { curationPalette } from '../../../theme';
+import { applyApTitleCase } from '../../../_shared/utils/applyApTitleCase';
 
 interface ApprovedItemListCardProps {
   /**
@@ -121,7 +122,7 @@ export const ApprovedItemListCard: React.FC<ApprovedItemListCardProps> = (
               color: curationPalette.pocketBlack,
             }}
           >
-            {item.title}
+            {applyApTitleCase(item.title)}
           </Link>
         </Typography>
         <Typography variant="body2" component="p" gutterBottom>

--- a/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.tsx
+++ b/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.tsx
@@ -127,8 +127,7 @@ export const ApprovedItemListCard: React.FC<ApprovedItemListCardProps> = (
               color: curationPalette.pocketBlack,
             }}
           >
-            {isItemEnglish && applyApTitleCase(item.title)}
-            {!isItemEnglish && item.title}
+            {isItemEnglish ? applyApTitleCase(item.title) : item.title}
           </Link>
         </Typography>
         <Typography variant="body2" component="p" gutterBottom>

--- a/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.tsx
+++ b/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.tsx
@@ -15,7 +15,11 @@ import BookmarksIcon from '@mui/icons-material/Bookmarks';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import CategoryIcon from '@mui/icons-material/Category';
 import LanguageIcon from '@mui/icons-material/Language';
-import { ApprovedCorpusItem, CuratedStatus } from '../../../api/generatedTypes';
+import {
+  ApprovedCorpusItem,
+  CorpusLanguage,
+  CuratedStatus,
+} from '../../../api/generatedTypes';
 import { getDisplayTopic } from '../../helpers/topics';
 import { flattenAuthors } from '../../../_shared/utils/flattenAuthors';
 import { ScheduleHistory } from '../';
@@ -59,6 +63,7 @@ export const ApprovedItemListCard: React.FC<ApprovedItemListCardProps> = (
     );
 
   const showScheduleHistory = item.scheduledSurfaceHistory.length != 0;
+  const isItemEnglish = item.language.toUpperCase() === CorpusLanguage.En;
 
   return (
     <>
@@ -122,7 +127,7 @@ export const ApprovedItemListCard: React.FC<ApprovedItemListCardProps> = (
               color: curationPalette.pocketBlack,
             }}
           >
-            {applyApTitleCase(item.title)}
+            {isItemEnglish && applyApTitleCase(item.title)}
           </Link>
         </Typography>
         <Typography variant="body2" component="p" gutterBottom>

--- a/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
+++ b/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Item, Prospect } from '../../../api/generatedTypes';
+import { CorpusLanguage, Item, Prospect } from '../../../api/generatedTypes';
 import {
   Card,
   CardActions,
@@ -80,6 +80,8 @@ export const ProspectListCard: React.FC<ProspectListCardProps> = (
   ) : (
     <span> &mdash;</span>
   );
+
+  const isItemEnglish = prospect.language?.toUpperCase() === CorpusLanguage.En;
 
   return (
     <Card
@@ -174,7 +176,7 @@ export const ProspectListCard: React.FC<ProspectListCardProps> = (
                     fontWeight: 500,
                   }}
                 >
-                  {applyApTitleCase(prospect.title as string)}
+                  {isItemEnglish && applyApTitleCase(prospect.title as string)}
                 </Typography>
               </Link>
             </Grid>

--- a/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
+++ b/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
@@ -26,6 +26,7 @@ import { getDisplayTopic } from '../../helpers/topics';
 import { RemoveProspectAction } from '../actions/RemoveProspectAction/RemoveProspectAction';
 import { useToggle } from '../../../_shared/hooks';
 import { DateTime } from 'luxon';
+import { applyApTitleCase } from '../../../_shared/utils/applyApTitleCase';
 
 interface ProspectListCardProps {
   /**
@@ -173,7 +174,7 @@ export const ProspectListCard: React.FC<ProspectListCardProps> = (
                     fontWeight: 500,
                   }}
                 >
-                  {prospect.title}
+                  {applyApTitleCase(prospect.title as string)}
                 </Typography>
               </Link>
             </Grid>

--- a/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
+++ b/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
@@ -176,8 +176,9 @@ export const ProspectListCard: React.FC<ProspectListCardProps> = (
                     fontWeight: 500,
                   }}
                 >
-                  {isItemEnglish && applyApTitleCase(prospect.title as string)}
-                  {!isItemEnglish && prospect.title}
+                  {isItemEnglish
+                    ? applyApTitleCase(prospect.title as string)
+                    : prospect.title}
                 </Typography>
               </Link>
             </Grid>

--- a/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
+++ b/src/curated-corpus/components/ProspectListCard/ProspectListCard.tsx
@@ -177,6 +177,7 @@ export const ProspectListCard: React.FC<ProspectListCardProps> = (
                   }}
                 >
                   {isItemEnglish && applyApTitleCase(prospect.title as string)}
+                  {!isItemEnglish && prospect.title}
                 </Typography>
               </Link>
             </Grid>

--- a/src/curated-corpus/components/SuggestedScheduleItemListCard/SuggestedScheduleItemListCard.tsx
+++ b/src/curated-corpus/components/SuggestedScheduleItemListCard/SuggestedScheduleItemListCard.tsx
@@ -2,7 +2,10 @@ import React, { ReactElement, useState } from 'react';
 import { Box, CardContent, Link, Typography } from '@mui/material';
 import { DateTime } from 'luxon';
 
-import { ApprovedCorpusItem } from '../../../api/generatedTypes';
+import {
+  ApprovedCorpusItem,
+  CorpusLanguage,
+} from '../../../api/generatedTypes';
 import { flattenAuthors } from '../../../_shared/utils/flattenAuthors';
 
 import { curationPalette } from '../../../theme';
@@ -89,6 +92,8 @@ export const SuggestedScheduleItemListCard: React.FC<
         .toLocaleString(DateTime.DATE_FULL)
     : null;
 
+  const isItemEnglish = item.language.toUpperCase() === CorpusLanguage.En;
+
   return (
     <>
       <CorpusItemCardImage
@@ -152,7 +157,7 @@ export const SuggestedScheduleItemListCard: React.FC<
               color: curationPalette.pocketBlack,
             }}
           >
-            {applyApTitleCase(item.title)}
+            {isItemEnglish && applyApTitleCase(item.title)}
           </Link>
         </Typography>
         <Typography

--- a/src/curated-corpus/components/SuggestedScheduleItemListCard/SuggestedScheduleItemListCard.tsx
+++ b/src/curated-corpus/components/SuggestedScheduleItemListCard/SuggestedScheduleItemListCard.tsx
@@ -158,6 +158,7 @@ export const SuggestedScheduleItemListCard: React.FC<
             }}
           >
             {isItemEnglish && applyApTitleCase(item.title)}
+            {!isItemEnglish && item.title}
           </Link>
         </Typography>
         <Typography

--- a/src/curated-corpus/components/SuggestedScheduleItemListCard/SuggestedScheduleItemListCard.tsx
+++ b/src/curated-corpus/components/SuggestedScheduleItemListCard/SuggestedScheduleItemListCard.tsx
@@ -11,6 +11,7 @@ import {
   CorpusItemCardImage,
 } from '../../../_shared/components';
 import { ScheduleHistoryModal } from '../ScheduleHistoryModal/ScheduleHistoryModal';
+import { applyApTitleCase } from '../../../_shared/utils/applyApTitleCase';
 
 interface SuggestedScheduleItemListCardProps {
   /**
@@ -151,7 +152,7 @@ export const SuggestedScheduleItemListCard: React.FC<
               color: curationPalette.pocketBlack,
             }}
           >
-            {item.title}
+            {applyApTitleCase(item.title)}
           </Link>
         </Typography>
         <Typography

--- a/src/curated-corpus/components/SuggestedScheduleItemListCard/SuggestedScheduleItemListCard.tsx
+++ b/src/curated-corpus/components/SuggestedScheduleItemListCard/SuggestedScheduleItemListCard.tsx
@@ -157,8 +157,7 @@ export const SuggestedScheduleItemListCard: React.FC<
               color: curationPalette.pocketBlack,
             }}
           >
-            {isItemEnglish && applyApTitleCase(item.title)}
-            {!isItemEnglish && item.title}
+            {isItemEnglish ? applyApTitleCase(item.title) : item.title}
           </Link>
         </Typography>
         <Typography


### PR DESCRIPTION
## Goal

Automatically formatting the title for corpus item, scheduled item & prospecting item. 
Constrained to English items only.
Re-using the existing `applyApTitleCase` function.

## Todos

- [x] push to dev

## Reference

Tickets:

- [https://mozilla-hub.atlassian.net/browse/MC-663](https://mozilla-hub.atlassian.net/browse/MC-663)
- [https://mozilla-hub.atlassian.net/browse/MC-670](https://mozilla-hub.atlassian.net/browse/MC-670)
