### PR TITLE
fix(scheduling): [MC-754] Items are being scheduled for multiple days

### DIFF
--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -558,6 +558,12 @@ export const SchedulePage: React.FC = (): ReactElement => {
 
         // Hide the Schedule Item Form modal
         toggleScheduleItemModal();
+
+        // Unset the corpus item that was added manually so that
+        // the ScheduleItemModal specific to manually added stories
+        // (with reasons for scheduling for the New Tab (US) surface)
+        // does not show up when a reorder/reschedule action is triggered.
+        setApprovedItem(undefined);
       },
       () => {
         // Hide the loading indicator


### PR DESCRIPTION
## Goal

Unset the last manually added corpus item so that when curators reorder or reschedule other items on the page, the ScheduleItemModal component specific to manually added items is not triggered instead.

## Video walkthrough

Before - with the GraphQL calls in the DevTools panel to demonstrate it was calling the wrong mutation; and after with the right mutation going through on the "Reschedule" action.

Before:


https://github.com/Pocket/curation-admin-tools/assets/22447785/379168f1-cd4e-4fe5-b21e-6d2f310b6794

After:

https://github.com/Pocket/curation-admin-tools/assets/22447785/6ba61e3e-caa8-42cd-941c-c7ea89050ed1

## Reference

Ref: https://mozilla-hub.atlassian.net/browse/MC-754