### PR TITLE
feat(scheduling): [MC-923] Expand Topic & Publisher summary for manually scheduled syndicated articles

### DIFF
--- a/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.test.tsx
+++ b/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.test.tsx
@@ -234,6 +234,31 @@ describe('The ScheduleItemForm component', () => {
     expect(handleSubmit).not.toHaveBeenCalled();
   });
 
+  it('expands the Topic & Publisher summary by default if requested', async () => {
+    render(
+      <MockedProvider mocks={[mock_scheduledItems]}>
+        <ScheduleItemForm
+          data-testId="surface-selector"
+          handleDateChange={jest.fn()}
+          selectedDate={DateTime.fromFormat('2023-01-01', 'yyyy-MM-dd')}
+          onSubmit={handleSubmit}
+          scheduledSurfaces={[scheduledSurfaces[0]]}
+          approvedItemExternalId={'123abc'}
+          showManualScheduleReasons={true}
+          expandSummary={true}
+        />
+      </MockedProvider>
+    );
+
+    // Wait for the summary to load, then expect to see the main headings
+    // (full functionality of the summary is tested in ScheduleSummaryConnector tests,
+    // we just want to make sure here it's visible to the user)
+    await waitFor(() => {
+      expect(screen.getByText(/Publishers/i)).toBeInTheDocument();
+      expect(screen.getByText(/Topics/i)).toBeInTheDocument();
+    });
+  });
+
   // TODO: fix the test below. possibly failing due to apollo query mocks mismatch?
   it.skip('submits the form if at least one checkbox was selected', async () => {
     render(

--- a/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.test.tsx
+++ b/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.test.tsx
@@ -43,7 +43,7 @@ describe('The ScheduleItemForm component', () => {
 
     // there is at least a form and nothing falls over
     const form = screen.getByRole('form');
-    expect(form).toBeInTheDocument();
+    expect(form).toBeVisible();
   });
 
   it('has three buttons and an accordion widget', () => {
@@ -140,27 +140,6 @@ describe('The ScheduleItemForm component', () => {
     expect(select.options[1].selected).toBeTruthy();
   });
 
-  it('ensure that the schedule context is rendered when scheduled surface is populated', async () => {
-    render(
-      <MockedProvider>
-        <ScheduleItemForm
-          data-testId="surface-selector"
-          handleDateChange={jest.fn()}
-          selectedDate={DateTime.local()}
-          onSubmit={handleSubmit}
-          scheduledSurfaces={scheduledSurfaces}
-          scheduledSurfaceGuid="NEW_TAB_EN_US"
-          approvedItemExternalId={'123abc'}
-        />
-      </MockedProvider>
-    );
-
-    await waitFor(() => {
-      expect(screen.getByText(/story/i)).toBeInTheDocument();
-      expect(screen.getByText(/syndicated/i)).toBeInTheDocument();
-    });
-  });
-
   it('does not show manual scheduling reasons by default', async () => {
     render(
       <MockedProvider>
@@ -201,10 +180,10 @@ describe('The ScheduleItemForm component', () => {
 
     await waitFor(() => {
       // Should there be a pre-defined reason? This time around, yes
-      expect(screen.queryByLabelText('Evergreen')).toBeInTheDocument();
+      expect(screen.getByText('Evergreen')).toBeVisible();
 
       // Should there be a "Reason Comment" field for other reasons? Yes
-      expect(screen.queryByLabelText('Reason Comment')).toBeInTheDocument();
+      expect(screen.getByLabelText('Reason Comment')).toBeVisible();
     });
   });
 
@@ -230,7 +209,7 @@ describe('The ScheduleItemForm component', () => {
     const errorMessage = screen.getByText(
       /Please choose at least one reason to schedule this item manually./i
     );
-    expect(errorMessage).toBeInTheDocument();
+    expect(errorMessage).toBeVisible();
     expect(handleSubmit).not.toHaveBeenCalled();
   });
 
@@ -254,8 +233,33 @@ describe('The ScheduleItemForm component', () => {
     // (full functionality of the summary is tested in ScheduleSummaryConnector tests,
     // we just want to make sure here it's visible to the user)
     await waitFor(() => {
-      expect(screen.getByText(/Publishers/i)).toBeInTheDocument();
-      expect(screen.getByText(/Topics/i)).toBeInTheDocument();
+      expect(screen.getByText(/Publishers/i)).toBeVisible();
+      expect(screen.getByText(/Topics/i)).toBeVisible();
+    });
+  });
+
+  it('does not expand the Topic & Publisher summary by default if not requested', async () => {
+    render(
+      <MockedProvider mocks={[mock_scheduledItems]}>
+        <ScheduleItemForm
+          data-testId="surface-selector"
+          handleDateChange={jest.fn()}
+          selectedDate={DateTime.fromFormat('2023-01-01', 'yyyy-MM-dd')}
+          onSubmit={handleSubmit}
+          scheduledSurfaces={[scheduledSurfaces[0]]}
+          approvedItemExternalId={'123abc'}
+          showManualScheduleReasons={true}
+          expandSummary={false}
+        />
+      </MockedProvider>
+    );
+
+    // Wait for the summary to load, then expect to see the main headings
+    // (full functionality of the summary is tested in ScheduleSummaryConnector tests,
+    // we just want to make sure here it's visible to the user)
+    await waitFor(() => {
+      expect(screen.getByText(/Publishers/i)).not.toBeVisible();
+      expect(screen.getByText(/Topics/i)).not.toBeVisible();
     });
   });
 

--- a/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.tsx
+++ b/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.tsx
@@ -68,6 +68,11 @@ interface ScheduleItemFormProps {
   showManualScheduleReasons?: boolean;
 
   /**
+   * Whether to expand the Topic & Publisher summary.
+   */
+  expandSummary?: boolean;
+
+  /**
    *
    * Note that null is an option here to keep MUI types happy, nothing else.
    */
@@ -92,6 +97,7 @@ export const ScheduleItemForm: React.FC<
     scheduledSurfaceGuid,
     disableScheduledSurface = false,
     showManualScheduleReasons = false,
+    expandSummary = false,
     selectedDate,
     onCancel,
     onSubmit,
@@ -227,7 +233,7 @@ export const ScheduleItemForm: React.FC<
           >
             <Grid item xs={12}>
               <Box mt={3}>
-                <Accordion>
+                <Accordion defaultExpanded={expandSummary}>
                   <AccordionSummary
                     expandIcon={<ExpandMoreIcon />}
                     sx={{ maxHeight: '2rem' }}

--- a/src/curated-corpus/components/ScheduleItemFormConnector/ScheduleItemFormConnector.tsx
+++ b/src/curated-corpus/components/ScheduleItemFormConnector/ScheduleItemFormConnector.tsx
@@ -37,6 +37,11 @@ interface ScheduleItemFormConnectorProps {
   showManualScheduleReasons?: boolean;
 
   /**
+   * Whether to expand the Topic & Publisher summary.
+   */
+  expandSummary?: boolean;
+
+  /**
    * What do we do with the submitted data?
    */
   onSubmit: (
@@ -54,6 +59,7 @@ export const ScheduleItemFormConnector: React.FC<
     disableScheduledSurface,
     scheduledSurfaceGuid,
     showManualScheduleReasons,
+    expandSummary,
     onCancel,
     onSubmit,
   } = props;
@@ -92,6 +98,7 @@ export const ScheduleItemFormConnector: React.FC<
           scheduledSurfaceGuid={scheduledSurfaceGuid}
           disableScheduledSurface={disableScheduledSurface}
           showManualScheduleReasons={showManualScheduleReasons}
+          expandSummary={expandSummary}
           selectedDate={selectedDate}
           onSubmit={onSubmit}
           onCancel={onCancel}

--- a/src/curated-corpus/components/ScheduleItemModal/ScheduleItemModal.tsx
+++ b/src/curated-corpus/components/ScheduleItemModal/ScheduleItemModal.tsx
@@ -46,6 +46,11 @@ interface ScheduleItemModalProps {
   showManualScheduleReasons?: boolean;
 
   /**
+   * Whether to expand the Topic & Publisher summary.
+   */
+  expandSummary?: boolean;
+
+  /**
    * The action to run when the user hits the "Save" button at the bottom of the modal.
    * @param values
    * @param formikHelpers
@@ -79,6 +84,7 @@ export const ScheduleItemModal: React.FC<ScheduleItemModalProps> = (
     isOpen,
     scheduledSurfaceGuid,
     showManualScheduleReasons,
+    expandSummary,
     onSave,
     toggleModal,
   } = props;
@@ -106,6 +112,7 @@ export const ScheduleItemModal: React.FC<ScheduleItemModalProps> = (
             scheduledSurfaceGuid={scheduledSurfaceGuid}
             disableScheduledSurface={disableScheduledSurface}
             showManualScheduleReasons={showManualScheduleReasons}
+            expandSummary={expandSummary}
             onSubmit={onSave}
             onCancel={() => {
               toggleModal();

--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -746,6 +746,10 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
             currentScheduledSurfaceGuid === 'NEW_TAB_EN_US' &&
             !approvedItem.isSyndicated
           }
+          expandSummary={
+            /* Expand the Topic & Publisher Summary for syndicated articles */
+            approvedItem.isSyndicated
+          }
           onSave={onScheduleSave}
           toggleModal={toggleScheduleModalAndDisableScheduledSurface}
         />

--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -651,6 +651,10 @@ export const SchedulePage: React.FC = (): ReactElement => {
             currentScheduledSurfaceGuid === 'NEW_TAB_EN_US' &&
             !approvedItem.isSyndicated
           }
+          expandSummary={
+            /* Expand the Topic & Publisher Summary for syndicated articles */
+            approvedItem.isSyndicated
+          }
           onSave={onScheduleSave}
           toggleModal={toggleScheduleItemModal}
         />


### PR DESCRIPTION
## Goal

Now that the Topic & Publisher summary is hidden by default in an Accordion component to make space for the manual  schedule reasons, let's expand it for syndicated articles to simplify curators' workflow. 

## Video Walkthrough


https://github.com/Pocket/curation-admin-tools/assets/22447785/99e378d9-bf4e-4b0c-a462-70bd4da91d2e



## Reference

https://mozilla-hub.atlassian.net/browse/MC-923