### PR TITLE
fix(scheduling): [MC-962] Reschedule button moves the last article posted

### DIFF
--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -125,6 +125,13 @@ export const SchedulePage: React.FC = (): ReactElement => {
   const [scheduleItemModalOpen, toggleScheduleItemModal] = useToggle(false);
 
   /**
+   * Set up a separate toggle for an identical modal that is used for
+   * manually scheduled items.
+   */
+  const [manualScheduleItemModalOpen, toggleManualScheduleItemModal] =
+    useToggle(false);
+
+  /**
    * Keep track of whether the "Edit item modal" is open or not
    */
   const [editItemModalOpen, toggleEditModal] = useToggle(false);
@@ -478,7 +485,7 @@ export const SchedulePage: React.FC = (): ReactElement => {
 
         setApprovedItem(approvedItemData.createApprovedCorpusItem);
         // transition to scheduling it and specifying manual addition reasons
-        toggleScheduleItemModal();
+        toggleManualScheduleItemModal();
       }
     );
   };
@@ -557,13 +564,7 @@ export const SchedulePage: React.FC = (): ReactElement => {
         formikHelpers.setSubmitting(false);
 
         // Hide the Schedule Item Form modal
-        toggleScheduleItemModal();
-
-        // Unset the corpus item that was added manually so that
-        // the ScheduleItemModal specific to manually added stories
-        // (with reasons for scheduling for the New Tab (US) surface)
-        // does not show up when a reorder/reschedule action is triggered.
-        setApprovedItem(undefined);
+        toggleManualScheduleItemModal();
       },
       () => {
         // Hide the loading indicator
@@ -643,7 +644,7 @@ export const SchedulePage: React.FC = (): ReactElement => {
           approvedItem={approvedItem}
           date={addItemDate}
           headingCopy="Confirm Schedule"
-          isOpen={scheduleItemModalOpen}
+          isOpen={manualScheduleItemModalOpen}
           scheduledSurfaceGuid={currentScheduledSurfaceGuid}
           showManualScheduleReasons={
             /* Only ask for manual schedule reasons if the curator is working on the US New Tab
@@ -652,7 +653,7 @@ export const SchedulePage: React.FC = (): ReactElement => {
             !approvedItem.isSyndicated
           }
           onSave={onScheduleSave}
-          toggleModal={toggleScheduleItemModal}
+          toggleModal={toggleManualScheduleItemModal}
         />
       )}
 
@@ -826,7 +827,6 @@ export const SchedulePage: React.FC = (): ReactElement => {
                               toggleRemoveModal();
                             }}
                             onMoveToBottom={() => {
-                              setCurrentItem(item);
                               moveItemToBottom(item);
                             }}
                             onReschedule={() => {

--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -826,6 +826,7 @@ export const SchedulePage: React.FC = (): ReactElement => {
                               toggleRemoveModal();
                             }}
                             onMoveToBottom={() => {
+                              setCurrentItem(item);
                               moveItemToBottom(item);
                             }}
                             onReschedule={() => {


### PR DESCRIPTION
## Goal

Fix the bug - rescheduling modal should be showing the correct item and not the latest (manual) item added to the schedule. 

(invalid - was thinking of reordering items rather than rescheduling them) ~~Fix the bug! I have traced this bug to April 2022: https://github.com/Pocket/curation-admin-tools/commit/92d14a6e15e8ef2b9c86c98f9ca126f3c038098e#r141000157 - which means it has been there ever since this feature was introduced, it may not have been used often enough to be detected up until recently.~~

## Video walkthrough

Adding a manual item, then rescheduling a different item - all works as intended now.


https://github.com/Pocket/curation-admin-tools/assets/22447785/bc87346f-737e-488c-98ba-eb641e8f4c98



## Reference

https://mozilla-hub.atlassian.net/browse/MC-962