### PR TITLE
chore(tests): [MC-991] Improve test coverage for AprovedItemForm

### DIFF
--- a/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.test.tsx
+++ b/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.test.tsx
@@ -31,6 +31,7 @@ describe('The ApprovedItemForm component', () => {
       imageUrl: 'https://placeimg.com/640/480/people?random=494',
       excerpt:
         'Everything You Wanted to Know About React and Were Afraid To Ask',
+      hasTrustedDomain: true,
       language: CorpusLanguage.De,
       authors: [
         { name: 'One Author', sortOrder: 1 },

--- a/src/curated-corpus/components/actions/EditCorpusItemAction/EditCorpusItemAction.test.tsx
+++ b/src/curated-corpus/components/actions/EditCorpusItemAction/EditCorpusItemAction.test.tsx
@@ -4,9 +4,13 @@ import { render, screen } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
 import { EditCorpusItemAction } from './EditCorpusItemAction';
 import { getTestApprovedItem } from '../../../helpers/approvedItem';
-import { successMock } from '../../../integration-test-mocks/updateApprovedItem';
+import {
+  successMock,
+  successMockSansDatePublished,
+} from '../../../integration-test-mocks/updateApprovedItem';
 import userEvent from '@testing-library/user-event';
 import { apolloCache } from '../../../../api/client';
+import { ActionScreen } from '../../../../api/generatedTypes';
 
 describe('The EditCorpusItemAction', () => {
   let mocks: MockedResponse[] = [];
@@ -21,6 +25,7 @@ describe('The EditCorpusItemAction', () => {
             item={getTestApprovedItem()}
             toggleModal={jest.fn()}
             modalOpen={true}
+            actionScreen={ActionScreen.Corpus}
           />
         </SnackbarProvider>
       </MockedProvider>
@@ -43,6 +48,36 @@ describe('The EditCorpusItemAction', () => {
             item={getTestApprovedItem()}
             toggleModal={jest.fn()}
             modalOpen={true}
+            actionScreen={ActionScreen.Corpus}
+          />
+        </SnackbarProvider>
+      </MockedProvider>
+    );
+
+    // The most basic of integration tests - we simply send through
+    // the corpus item without any actual edits.
+    userEvent.click(screen.getByText(/save/i));
+
+    expect(
+      await screen.findByText(/curated item .* successfully updated/i)
+    ).toBeInTheDocument();
+  });
+
+  it('completes the action successfully for an item with no `datePublished`', async () => {
+    mocks = [successMockSansDatePublished];
+
+    // Unset the publication date in test data
+    const curatedItem = getTestApprovedItem();
+    curatedItem.datePublished = null;
+
+    render(
+      <MockedProvider mocks={mocks} cache={apolloCache}>
+        <SnackbarProvider maxSnack={3}>
+          <EditCorpusItemAction
+            item={curatedItem}
+            toggleModal={jest.fn()}
+            modalOpen={true}
+            actionScreen={ActionScreen.Corpus}
           />
         </SnackbarProvider>
       </MockedProvider>

--- a/src/curated-corpus/integration-test-mocks/updateApprovedItem.ts
+++ b/src/curated-corpus/integration-test-mocks/updateApprovedItem.ts
@@ -1,25 +1,39 @@
 import { getTestApprovedItem } from '../helpers/approvedItem';
 import { updateApprovedItem } from '../../api/mutations/updateApprovedItem';
+import { ActionScreen } from '../../api/generatedTypes';
 
 const item = getTestApprovedItem();
+
+const data = {
+  externalId: item.externalId,
+  title: item.title,
+  excerpt: item.excerpt,
+  status: item.status,
+  language: item.language,
+  authors: item.authors,
+  publisher: item.publisher,
+  datePublished: item.datePublished,
+  imageUrl: item.imageUrl,
+  topic: item.topic,
+  isTimeSensitive: item.isTimeSensitive,
+  actionScreen: ActionScreen.Corpus,
+};
 
 export const successMock = {
   request: {
     query: updateApprovedItem,
     variables: {
-      data: {
-        externalId: item.externalId,
-        title: item.title,
-        excerpt: item.excerpt,
-        status: item.status,
-        language: item.language,
-        authors: item.authors,
-        publisher: item.publisher,
-        datePublished: item.datePublished,
-        imageUrl: item.imageUrl,
-        topic: item.topic,
-        isTimeSensitive: item.isTimeSensitive,
-      },
+      data,
+    },
+  },
+  result: { data: { updateApprovedCorpusItem: item } },
+};
+
+export const successMockSansDatePublished = {
+  request: {
+    query: updateApprovedItem,
+    variables: {
+      data: { ...data, datePublished: null },
     },
   },
   result: { data: { updateApprovedCorpusItem: item } },


### PR DESCRIPTION
## Goal

Improve test coverage so the incident that is referenced in the JIRA ticket can't happen ever again.

- Updated EditCorpusItemAction tests to add test coverage around not providing a value for `datePublished`. Form-level tests are fine as they are but the edit action is the component that was missing the needed test coverage.

Reference: https://mozilla-hub.atlassian.net/browse/MC-991
