### PR TITLE
MC-1042: do not show manual add reasos for DE New Tab when adding to corpus / recommending from prospecting page

### DIFF
--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -744,7 +744,8 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
             /* Only ask for manual schedule reasons if the curator is working on the US New Tab or German New Tab
              * and if it's not a syndicated item */
             (currentScheduledSurfaceGuid === 'NEW_TAB_EN_US' ||
-              currentScheduledSurfaceGuid === 'NEW_TAB_DE_DE') &&
+              (currentScheduledSurfaceGuid === 'NEW_TAB_DE_DE' &&
+                !approvedItem.prospectId)) &&
             !approvedItem.isSyndicated
           }
           expandSummary={

--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -650,7 +650,8 @@ export const SchedulePage: React.FC = (): ReactElement => {
             /* Only ask for manual schedule reasons if the curator is working on the US New Tab or German New Tab
              * and if it's not a syndicated item */
             (currentScheduledSurfaceGuid === 'NEW_TAB_EN_US' ||
-              currentScheduledSurfaceGuid === 'NEW_TAB_DE_DE') &&
+              (currentScheduledSurfaceGuid === 'NEW_TAB_DE_DE' &&
+                !approvedItem.prospectId)) &&
             !approvedItem.isSyndicated
           }
           expandSummary={


### PR DESCRIPTION
## Goal

When clicking “Schedule” or “Recommend/Add to Corpus” via any New Tab de-de Prospect source, curators will not receive the Manual Add Reasons modal.

## Todos

- [x] deployed to dev

## Reference

Tickets:

- https://mozilla-hub.atlassian.net/browse/MC-1042
