### PR TITLE
feat(scheduling): [MC-859] Provide a reason for unscheduling an item on New Tab DE

### DIFF
--- a/src/curated-corpus/components/RemoveItemFromScheduledSurfaceModal/RemoveItemFromScheduledSurfaceModal.test.tsx
+++ b/src/curated-corpus/components/RemoveItemFromScheduledSurfaceModal/RemoveItemFromScheduledSurfaceModal.test.tsx
@@ -1,22 +1,25 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import { ScheduledCorpusItem } from '../../../api/generatedTypes';
+import {
+  ScheduledCorpusItem,
+  ScheduledItemSource,
+} from '../../../api/generatedTypes';
 import { RemoveItemFromScheduledSurfaceModal } from './RemoveItemFromScheduledSurfaceModal';
 import { getTestApprovedItem } from '../../helpers/approvedItem';
-import { ScheduledSurfaces } from '../../helpers/definitions';
 import userEvent from '@testing-library/user-event';
 
 describe('The RemoveItemFromScheduledSurfaceModal component', () => {
   const approvedItem = getTestApprovedItem();
-  const germanItem: ScheduledCorpusItem = {
+  const pocketHitsItem: ScheduledCorpusItem = {
     approvedItem,
     createdAt: 1635014926,
     createdBy: 'jdoe',
     externalId: '123-test-id',
     scheduledDate: '2022-05-24',
-    scheduledSurfaceGuid: ScheduledSurfaces[1].guid,
+    scheduledSurfaceGuid: 'POCKET_HITS_DE_DE',
     updatedAt: 1635114926,
     updatedBy: 'jdoe',
+    source: ScheduledItemSource.Manual,
   };
   const usItem: ScheduledCorpusItem = {
     approvedItem,
@@ -24,9 +27,10 @@ describe('The RemoveItemFromScheduledSurfaceModal component', () => {
     createdBy: 'klm',
     externalId: '1234-test-id',
     scheduledDate: '2022-05-24',
-    scheduledSurfaceGuid: ScheduledSurfaces[0].guid,
+    scheduledSurfaceGuid: 'NEW_TAB_EN_US',
     updatedAt: 1935114924,
     updatedBy: 'klm',
+    source: ScheduledItemSource.Manual,
   };
   const isOpen = true;
   const onSave = jest.fn();
@@ -56,10 +60,10 @@ describe('The RemoveItemFromScheduledSurfaceModal component', () => {
     expect(screen.getByText('Niche')).toBeInTheDocument();
   });
 
-  it('should render this component successfully for german item', async () => {
+  it('should render this component successfully for Pocket Hits item', async () => {
     render(
       <RemoveItemFromScheduledSurfaceModal
-        item={germanItem}
+        item={pocketHitsItem}
         isOpen={isOpen}
         onSave={onSave}
         toggleModal={toggleModal}
@@ -77,10 +81,10 @@ describe('The RemoveItemFromScheduledSurfaceModal component', () => {
     expect(screen.getByRole('checkbox')).toBeInTheDocument();
   });
 
-  it('should call the onSave function when the checkbox is checked and "Save" form button is clicked for german item', async () => {
+  it('should call the onSave function when the checkbox is checked and "Save" form button is clicked for Pocket Hits item', async () => {
     render(
       <RemoveItemFromScheduledSurfaceModal
-        item={germanItem}
+        item={pocketHitsItem}
         isOpen={isOpen}
         onSave={onSave}
         toggleModal={toggleModal}
@@ -105,17 +109,17 @@ describe('The RemoveItemFromScheduledSurfaceModal component', () => {
     expect(onSave).toHaveBeenCalled();
   });
 
-  it('should not call the onSave function when the checkbox is not checked and "Save" form button is clicked for german item', async () => {
+  it('should not call the onSave function when the checkbox is not checked and "Save" form button is clicked for Pocket Hits item', async () => {
     render(
       <RemoveItemFromScheduledSurfaceModal
-        item={germanItem}
+        item={pocketHitsItem}
         isOpen={isOpen}
         onSave={onSave}
         toggleModal={toggleModal}
       />
     );
 
-    const errorMessage = `Yes, I want to remove ${germanItem.approvedItem.title} from this scheduled surface`;
+    const errorMessage = `Yes, I want to remove ${pocketHitsItem.approvedItem.title} from this scheduled surface`;
 
     // fetch the button elements
     const saveButton = screen.getByRole('button', { name: /save/i });

--- a/src/curated-corpus/components/RemoveItemFromScheduledSurfaceModal/RemoveItemFromScheduledSurfaceModal.tsx
+++ b/src/curated-corpus/components/RemoveItemFromScheduledSurfaceModal/RemoveItemFromScheduledSurfaceModal.tsx
@@ -20,8 +20,11 @@ export const RemoveItemFromScheduledSurfaceModal: React.FC<
   RemoveItemFromScheduledSurfaceModalProps
 > = (props): JSX.Element => {
   const { item, isOpen, onSave, toggleModal } = props;
-  // whether to show the remove item form
-  const isSurfaceEN = item.scheduledSurfaceGuid === 'NEW_TAB_EN_US';
+  // Surfaces for which unsheduling/removal reasons are required
+  const surfaces = ['NEW_TAB_EN_US', 'NEW_TAB_DE_DE'];
+
+  // Whether to show the remove item form
+  const showRemovalReasons = surfaces.includes(item.scheduledSurfaceGuid);
 
   return (
     <Modal
@@ -31,25 +34,24 @@ export const RemoveItemFromScheduledSurfaceModal: React.FC<
       }}
     >
       <Grid container spacing={2}>
-        {/*<h2>Remove this item from this scheduled surface</h2>*/}
-        {isSurfaceEN && (
-          <Grid item xs={12}>
-            <h2>Reason(s) for Unscheduling this item</h2>
-            <Box mb={1}>
-              <Typography variant="subtitle1">
-                <em>Title</em>: {item.approvedItem.title}
-              </Typography>
-            </Box>
-          </Grid>
+        {showRemovalReasons && (
+          <>
+            <Grid item xs={12}>
+              <h2>Reason(s) for Unscheduling this item</h2>
+              <Box mb={1}>
+                <Typography variant="subtitle1">
+                  <em>Title</em>: {item.approvedItem.title}
+                </Typography>
+              </Box>
+            </Grid>
+            <Grid item xs={12}>
+              <Box p={3} mt={-3.5}>
+                <RemoveItemForm onSubmit={onSave} onCancel={toggleModal} />
+              </Box>
+            </Grid>
+          </>
         )}
-        {isSurfaceEN && (
-          <Grid item xs={12}>
-            <Box p={3} mt={-3.5}>
-              <RemoveItemForm onSubmit={onSave} onCancel={toggleModal} />
-            </Box>
-          </Grid>
-        )}
-        {!isSurfaceEN && (
+        {!showRemovalReasons && (
           <Grid item xs={12}>
             <h2>Remove this item from this scheduled surface</h2>
             <RemoveItemFromScheduledSurfaceForm


### PR DESCRIPTION
## Goal

Provide a reason for unscheduling an item on New Tab DE.

- Enabled unscheduling/removal reasons for NEW_TAB_DE_DE

- Updated tests.

## Video walkthrough


https://github.com/Pocket/curation-admin-tools/assets/22447785/d4f57dc9-d558-4616-9f24-c5fb9a12924f



## Reference

https://mozilla-hub.atlassian.net/browse/MC-859