### PR TITLE
feat(scheduling): [MC-1019] Always highlight previously scheduled non-syndicated items

### DIFF
--- a/src/_shared/components/CorpusItemCardImage/CorpusItemCardImage.tsx
+++ b/src/_shared/components/CorpusItemCardImage/CorpusItemCardImage.tsx
@@ -176,7 +176,16 @@ export const CorpusItemCardImage: React.FC<CorpusItemCardImageProps> = (
 
   // Determine whether to highlight the "Last scheduled X days ago" overlay
   const highlightLastScheduled = !!(
-    lastScheduledOnThisSurface && lastScheduledOnThisSurface <= 2
+    // for syndicated items, only highlight items scheduled up to two days ago
+    // on the same surface
+    (
+      (item.isSyndicated &&
+        lastScheduledOnThisSurface &&
+        lastScheduledOnThisSurface <= 2) ||
+      // for all other items, always highlight if they were previously EVER
+      // scheduled on the same surface
+      (!item.isSyndicated && lastScheduledOnThisSurface)
+    )
   );
 
   return (


### PR DESCRIPTION
## Goal

Alert in red font / red background when the item has had any non-Syndicated scheduling on the same surface, EVER (remove last 1 or 3 days restriction).

### Changes: 
- Removed the restriction that only highlighted prior scheduling within the last two days for non-syndicated items. Now the "Last scheduled X days ago" overlay is always highlighted if a non-syndicated item has previously been scheduled on the same surface, whether it's two days ago or two decades ago.

- Added three new tests.

## Visual changes:

TBA

## References: 

JIRA: https://mozilla-hub.atlassian.net/browse/MC-1019
