### PR TITLE
MC-1123: Support for "Fix Title", quotes for German Language via UI

### DIFF
--- a/src/_shared/utils/applyQuotesDashesDE.test.ts
+++ b/src/_shared/utils/applyQuotesDashesDE.test.ts
@@ -1,0 +1,64 @@
+import { applyQuotesDashesDE } from './applyQuotesDashesDE';
+describe('applyQuotesDashesDE', () => {
+  it('should return undefined if text is null/undefined/empty string', () => {
+    // null
+    let output = applyQuotesDashesDE(null as unknown as string);
+    expect(output).toBeUndefined();
+
+    // undefined
+    output = applyQuotesDashesDE(undefined as unknown as string);
+    expect(output).toBeUndefined();
+
+    // empty string
+    output = applyQuotesDashesDE('');
+    expect(output).toBeUndefined();
+  });
+  it('Successfully does all replacements', () => {
+    const result = applyQuotesDashesDE('“Nicht eine mehr”: Diese spanische Netflix-Serie ist ein Mix aus “Tote Mädchen lügen nicht” und “Élite” – das musst du darüber wissen');
+    expect(result).toEqual('„Nicht eine mehr”: Diese spanische Netflix-Serie ist ein Mix aus „Tote Mädchen lügen nicht” und „Élite” — das musst du darüber wissen');
+  });
+  it('Replaces opening « with „', () => {
+    const result = applyQuotesDashesDE('«Here\'s to the great ones!');
+    expect(result).toEqual('„Here\'s to the great ones!');
+  });
+  it('Replaces closing » with “', () => {
+    const result = applyQuotesDashesDE('Here\'s to the great ones!»');
+    expect(result).toEqual('Here\'s to the great ones!”');
+  });
+  it('Replaces « with „ and » with “', () => {
+    const result = applyQuotesDashesDE('«Here\'s to the great ones!»');
+    expect(result).toEqual('„Here\'s to the great ones!”');
+  });
+  it('Replaces opening " with „', () => {
+    const result = applyQuotesDashesDE('"Here\'s to the great ones!');
+    expect(result).toEqual('„Here\'s to the great ones!');
+  });
+  it('Replaces closing " with “', () => {
+    const result = applyQuotesDashesDE('Here\'s to the great ones!"');
+    expect(result).toEqual('Here\'s to the great ones!”');
+  });
+  it('Replaces opening " with „ and closing " with “', () => {
+    const result = applyQuotesDashesDE('"Here\'s to the great ones!"');
+    expect(result).toEqual('„Here\'s to the great ones!”');
+  });
+  it('Replaces opening “ with „', () => {
+    const result = applyQuotesDashesDE('“Here\'s to the great ones!"');
+    expect(result).toEqual('„Here\'s to the great ones!”');
+  });
+  it('Replaces short dash (with whitespaces) with long em dash', () => {
+    const result = applyQuotesDashesDE('"Here\'s to the great - ones!"');
+    expect(result).toEqual('„Here\'s to the great — ones!”');
+  });
+  it('Replaces en dash (–) (with whitespaces) with long em dash', () => {
+    const result = applyQuotesDashesDE('"Meeresregionen – in die pelagischen Zonen – verlegt"');
+    expect(result).toEqual('„Meeresregionen — in die pelagischen Zonen — verlegt”');
+  });
+  it('Should not replace short dash (-) with long em dash (—) if no whitespaces in short dash', () => {
+    const result = applyQuotesDashesDE('"Here\'s to the great-ones!"');
+    expect(result).toEqual('„Here\'s to the great-ones!”');
+  });
+  it('Should not replace en dash (–) with long em dash (—) if no whitespaces in en dash', () => {
+    const result = applyQuotesDashesDE('"Here\'s to the great–ones!"');
+    expect(result).toEqual('„Here\'s to the great–ones!”');
+  });
+});

--- a/src/_shared/utils/applyQuotesDashesDE.ts
+++ b/src/_shared/utils/applyQuotesDashesDE.ts
@@ -1,0 +1,21 @@
+/**
+ * Helper to replace opening and closing quotes, arrow brackets (» «) for German
+ * Quotes represented in unicode
+ *
+ * @param text
+ * @returns string
+ */
+
+export const applyQuotesDashesDE = (text: string): string | undefined => {
+  if (!text) {
+    return undefined;
+  }
+  return text
+    .replace(/(^|[-\u2014/([{\u2018\s])\u00AB/g, '$1\u201E') // Replaces opening « with „
+    .replace(/\u00BB/g, '\u201D') // Replaces closing » with ”
+    .replace(/(^|[-\u2014/([{\u2018\s])"/g, '$1\u201E') // Opening doubles (replaces opening " with „)
+    .replace(/"/g, '\u201D') // Closing doubles (replaces closing " with ”)
+    .replace(/(^|[-\u2014/([{\u2018\s])\u201c/g, '$1\u201E') // Replaces opening “ with „
+    .replace(/\s\u2013\s/g, ' \u2014 ') // Replace en dash (–) with long em dash (—)
+    .replace(/\s-\s/g, ' \u2014 '); // Replace short dash (-) with long em dash (—)
+};

--- a/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.tsx
+++ b/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.tsx
@@ -9,22 +9,23 @@ import {
   styled,
   Switch,
   TextField,
-  Tooltip,
+  Tooltip
 } from '@mui/material';
 import { FormikHelpers, FormikValues, useFormik } from 'formik';
 import { validationSchema } from './ApprovedItemForm.validation';
 import {
   ApprovedCorpusItem,
+  CorpusLanguage,
   CuratedStatus,
   useGetOpenGraphFieldsQuery,
-  useGetUrlMetadataLazyQuery,
+  useGetUrlMetadataLazyQuery
 } from '../../../api/generatedTypes';
 import {
   ApprovedItemFromProspect,
   curationStatusOptions,
   DropdownOption,
   languages,
-  topics,
+  topics
 } from '../../helpers/definitions';
 import {
   Button,
@@ -32,12 +33,11 @@ import {
   FormikTextField,
   ImageUpload,
   SharedFormButtons,
-  SharedFormButtonsProps,
+  SharedFormButtonsProps
 } from '../../../_shared/components';
 import { flattenAuthors } from '../../../_shared/utils/flattenAuthors';
-import { applyCurlyQuotes } from '../../../_shared/utils/applyCurlyQuotes';
-import { applyApTitleCase } from '../../../_shared/utils/applyApTitleCase';
 import { curationPalette } from '../../../theme';
+import { applyStrFormatByLanguage } from '../../helpers/helperFunctions';
 
 interface ApprovedItemFormProps {
   /**
@@ -183,12 +183,15 @@ export const ApprovedItemForm: React.FC<
   const fixTitle = () => {
     formik.setFieldValue(
       'title',
-      applyCurlyQuotes(applyApTitleCase(formik.values.title))
+      applyStrFormatByLanguage(approvedItem.language as CorpusLanguage, formik.values.title, false)
     );
   };
 
   const fixExcerpt = () => {
-    formik.setFieldValue('excerpt', applyCurlyQuotes(formik.values.excerpt));
+    formik.setFieldValue(
+      'excerpt',
+      applyStrFormatByLanguage(approvedItem.language as CorpusLanguage, formik.values.excerpt, true)
+    );
   };
 
   // Boolean. Set to true if the current excerpt in the form excerpt input field is the og excerpt.

--- a/src/curated-corpus/helpers/helperFunctions.test.ts
+++ b/src/curated-corpus/helpers/helperFunctions.test.ts
@@ -1,16 +1,17 @@
 import { DateTime } from 'luxon';
-import { ProspectType } from '../../api/generatedTypes';
+import { CorpusLanguage, ProspectType } from '../../api/generatedTypes';
 import { ScheduledSurfaces } from './definitions';
 import {
+  applyStrFormatByLanguage,
   downloadAndUploadApprovedItemImageToS3,
   fetchFileFromUrl,
   formatFormLabel,
   getCuratorNameFromLdap,
+  getFormattedImageUrl,
+  getLastScheduledDayDiff,
   getLocalDateTimeForGuid,
   getScheduledSurfaceName,
-  getFormattedImageUrl,
-  readImageFileFromDisk,
-  getLastScheduledDayDiff,
+  readImageFileFromDisk
 } from './helperFunctions';
 
 describe('helperFunctions ', () => {
@@ -300,6 +301,27 @@ describe('helperFunctions ', () => {
         ),
       );
       expect(result).toBe(expected);
+    });
+  });
+
+  describe('applyStrFormatByLanguage function', () => {
+    it('should default to EN_US formatting for title & excerpt if language is not EN or DE', () => {
+      // title case (Spanish language)
+      expect(applyStrFormatByLanguage(CorpusLanguage.Es, 'spanish-title\'s', false)).toEqual('Spanish-Title’s');
+      // excerpt case (Italian language)
+      expect(applyStrFormatByLanguage(CorpusLanguage.It, 'italian - "excerpt\'s"', true)).toEqual('italian - “excerpt’s”');
+    });
+    it('should use EN_US formatting for title & excerpt if language is EN', () => {
+      // title case (English language)
+      expect(applyStrFormatByLanguage(CorpusLanguage.En, 'example Title in english Language "sample"', false)).toEqual('Example Title in English Language “Sample”');
+      // excerpt case (English language)
+      expect(applyStrFormatByLanguage(CorpusLanguage.En, 'example excerpt in English Language "sample\'s"', true)).toEqual('example excerpt in English Language “sample’s”');
+    });
+    it('should use DE_DE formatting for title & excerpt if language is DE', () => {
+      // title (German language) no capitalization should be applied
+      expect(applyStrFormatByLanguage(CorpusLanguage.De, '«Meeresregionen» – in die pelagischen Zonen – verlegt', false)).toEqual('„Meeresregionen” — in die pelagischen Zonen — verlegt');
+      // excerpt case (English language)
+      expect(applyStrFormatByLanguage(CorpusLanguage.De, '«Meeresregionen» – in die pelagischen "Zonen" – verlegt', true)).toEqual('„Meeresregionen” — in die pelagischen „Zonen” — verlegt');
     });
   });
 });

--- a/src/curated-corpus/helpers/helperFunctions.ts
+++ b/src/curated-corpus/helpers/helperFunctions.ts
@@ -1,7 +1,10 @@
 import { DateTime } from 'luxon';
 import { FileWithPath } from 'react-dropzone';
-import { GetScheduledSurfacesForUserQuery } from '../../api/generatedTypes';
+import { CorpusLanguage, GetScheduledSurfacesForUserQuery } from '../../api/generatedTypes';
 import { ScheduledSurfaces } from './definitions';
+import { applyCurlyQuotes } from '../../_shared/utils/applyCurlyQuotes';
+import { applyApTitleCase } from '../../_shared/utils/applyApTitleCase';
+import { applyQuotesDashesDE } from '../../_shared/utils/applyQuotesDashesDE';
 
 // downloads image from source url
 export const fetchFileFromUrl = async (
@@ -175,3 +178,38 @@ export const getLastScheduledDayDiff = (
     new Date(mostRecentScheduleDate).getTime();
   return Math.abs(Math.ceil(daysDifference / (1000 * 3600 * 24)));
 };
+
+/**
+ * Formats a string using rules based on the string language.
+ * @param language the language the passed string is in
+ * @param str string to format
+ * @param isExcerpt indicates if string is an excerpt as different formatting rules are applied for certain languages
+ * @returns formatted string
+ */
+export const applyStrFormatByLanguage = (
+  language: CorpusLanguage,
+  str: string,
+  isExcerpt: boolean
+): string => {
+  // if not excerpt (title is passed), apply quotes & title case for EN
+  if (language === CorpusLanguage.En && !isExcerpt) {
+    return applyCurlyQuotes(applyApTitleCase(str));
+  }
+  // if excerpt, apply quotes formatting for EN
+  if(language === CorpusLanguage.En && isExcerpt) {
+    applyCurlyQuotes(str)
+  }
+  //if excerpt or title, apply German quotes/dashes formatting
+  if(language === CorpusLanguage.De) {
+    return applyQuotesDashesDE(str) as string;
+  }
+  // apply EN formatting rules for other languages for now
+  else {
+    if(!isExcerpt) {
+      return applyCurlyQuotes(applyApTitleCase(str));
+    }
+    else {
+      return applyCurlyQuotes(str);
+    }
+  }
+}


### PR DESCRIPTION
## Goal

* There should be no change in capitalization for title

* Quotation marks need to be updated to „ at the beginning and “ at the end.

* Dashes should be long (em dash) ( – ) not short ( - )

## Deployment steps

- [ ] Deployed to dev

## References

JIRA ticket: https://mozilla-hub.atlassian.net/browse/MC-1123