### PR TITLE
MC-1190: fix German quotes / dashes formatting

### DIFF
--- a/src/_shared/utils/applyQuotesDashesDE.test.ts
+++ b/src/_shared/utils/applyQuotesDashesDE.test.ts
@@ -18,7 +18,7 @@ describe('applyQuotesDashesDE', () => {
       `“Nicht eine mehr”: Diese spanische Netflix-Serie ist ein Mix aus “Tote Mädchen lügen nicht” und “Élite” – das musst du darüber wissen`,
     );
     expect(result).toEqual(
-      '„Nicht eine mehr”: Diese spanische Netflix-Serie ist ein Mix aus „Tote Mädchen lügen nicht” und „Élite” — das musst du darüber wissen',
+      '„Nicht eine mehr”: Diese spanische Netflix-Serie ist ein Mix aus „Tote Mädchen lügen nicht” und „Élite” – das musst du darüber wissen',
     );
   });
   it('Replaces opening « with „', () => {
@@ -29,9 +29,13 @@ describe('applyQuotesDashesDE', () => {
     const result = applyQuotesDashesDE("Here's to the great ones!»");
     expect(result).toEqual("Here's to the great ones!”");
   });
-  it('Replaces « with „ and » with “', () => {
+  it('Replaces «Here\'s to the great ones!» with „Here\'s to the great ones!”', () => {
     const result = applyQuotesDashesDE("«Here's to the great ones!»");
     expect(result).toEqual("„Here's to the great ones!”");
+  });
+  it('Replaces »example« with „example”', () => {
+    const result = applyQuotesDashesDE("»example«");
+    expect(result).toEqual("„example”");
   });
   it('Replaces opening " with „', () => {
     const result = applyQuotesDashesDE('"Here\'s to the great ones!');
@@ -49,24 +53,24 @@ describe('applyQuotesDashesDE', () => {
     const result = applyQuotesDashesDE('“Here\'s to the great ones!"');
     expect(result).toEqual("„Here's to the great ones!”");
   });
-  it('Replaces short dash (with whitespaces) with long em dash', () => {
+  it('Replaces short dash (with whitespaces) with long en dash', () => {
     const result = applyQuotesDashesDE('"Here\'s to the great - ones!"');
-    expect(result).toEqual("„Here's to the great — ones!”");
+    expect(result).toEqual("„Here's to the great – ones!”");
   });
-  it('Replaces en dash (–) (with whitespaces) with long em dash', () => {
+  it('Replaces long em dash (–) (with whitespaces) with long en dash', () => {
     const result = applyQuotesDashesDE(
-      '"Meeresregionen – in die pelagischen Zonen – verlegt"',
+      '"Meeresregionen — in die pelagischen Zonen — verlegt"',
     );
     expect(result).toEqual(
-      '„Meeresregionen — in die pelagischen Zonen — verlegt”',
+      '„Meeresregionen – in die pelagischen Zonen – verlegt”',
     );
   });
-  it('Should not replace short dash (-) with long em dash (—) if no whitespaces in short dash', () => {
+  it('Should not replace short dash (-) with long en dash (–) if no whitespaces in short dash', () => {
     const result = applyQuotesDashesDE('"Here\'s to the great-ones!"');
     expect(result).toEqual("„Here's to the great-ones!”");
   });
-  it('Should not replace en dash (–) with long em dash (—) if no whitespaces in en dash', () => {
-    const result = applyQuotesDashesDE('"Here\'s to the great–ones!"');
-    expect(result).toEqual("„Here's to the great–ones!”");
+  it('Should not replace em dash (—) with long en dash (–) if no whitespaces in em dash', () => {
+    const result = applyQuotesDashesDE('"Here\'s to the great—ones!"');
+    expect(result).toEqual("„Here's to the great—ones!”");
   });
 });

--- a/src/_shared/utils/applyQuotesDashesDE.test.ts
+++ b/src/_shared/utils/applyQuotesDashesDE.test.ts
@@ -29,13 +29,13 @@ describe('applyQuotesDashesDE', () => {
     const result = applyQuotesDashesDE("Here's to the great ones!»");
     expect(result).toEqual("Here's to the great ones!”");
   });
-  it('Replaces «Here\'s to the great ones!» with „Here\'s to the great ones!”', () => {
+  it("Replaces «Here's to the great ones!» with „Here's to the great ones!”", () => {
     const result = applyQuotesDashesDE("«Here's to the great ones!»");
     expect(result).toEqual("„Here's to the great ones!”");
   });
   it('Replaces »example« with „example”', () => {
-    const result = applyQuotesDashesDE("»example«");
-    expect(result).toEqual("„example”");
+    const result = applyQuotesDashesDE('»example«');
+    expect(result).toEqual('„example”');
   });
   it('Replaces opening " with „', () => {
     const result = applyQuotesDashesDE('"Here\'s to the great ones!');

--- a/src/_shared/utils/applyQuotesDashesDE.ts
+++ b/src/_shared/utils/applyQuotesDashesDE.ts
@@ -12,10 +12,13 @@ export const applyQuotesDashesDE = (text: string): string | undefined => {
   }
   return text
     .replace(/(^|[-\u2014/([{\u2018\s])\u00AB/g, '$1\u201E') // Replaces opening « with „
+    .replace(/(^|[-\u2014/([{\u2018\s])\u00BB/g, '$1\u201E') // Replaces opening » with „
     .replace(/\u00BB/g, '\u201D') // Replaces closing » with ”
+    .replace(/\u00AB/g, '\u201D') // Replaces closing « with ”
     .replace(/(^|[-\u2014/([{\u2018\s])"/g, '$1\u201E') // Opening doubles (replaces opening " with „)
     .replace(/"/g, '\u201D') // Closing doubles (replaces closing " with ”)
     .replace(/(^|[-\u2014/([{\u2018\s])\u201c/g, '$1\u201E') // Replaces opening “ with „
-    .replace(/\s\u2013\s/g, ' \u2014 ') // Replace en dash (–) with long em dash (—)
-    .replace(/\s-\s/g, ' \u2014 '); // Replace short dash (-) with long em dash (—)
+    .replace(/\s\u2014\s/g, ' \u2013 ') // Replace em dash (—) with en dash (–)
+    .replace(/\s-\s/g, ' \u2013 '); // Replace short dash (-) with long en dash (–)
+
 };

--- a/src/_shared/utils/applyQuotesDashesDE.ts
+++ b/src/_shared/utils/applyQuotesDashesDE.ts
@@ -20,5 +20,4 @@ export const applyQuotesDashesDE = (text: string): string | undefined => {
     .replace(/(^|[-\u2014/([{\u2018\s])\u201c/g, '$1\u201E') // Replaces opening “ with „
     .replace(/\s\u2014\s/g, ' \u2013 ') // Replace em dash (—) with en dash (–)
     .replace(/\s-\s/g, ' \u2013 '); // Replace short dash (-) with long en dash (–)
-
 };

--- a/src/curated-corpus/helpers/helperFunctions.test.ts
+++ b/src/curated-corpus/helpers/helperFunctions.test.ts
@@ -328,7 +328,7 @@ describe('helperFunctions ', () => {
           CorpusLanguage.De,
           '«Meeresregionen» – in die pelagischen "Zonen" – verlegt',
         ),
-      ).toEqual('„Meeresregionen” — in die pelagischen „Zonen” — verlegt');
+      ).toEqual('„Meeresregionen” – in die pelagischen „Zonen” – verlegt');
     });
   });
 
@@ -351,9 +351,9 @@ describe('helperFunctions ', () => {
       expect(
         applyTitleFormattingByLanguage(
           CorpusLanguage.De,
-          '«Meeresregionen» – in die pelagischen Zonen – verlegt',
+          '«Meeresregionen» – in die »pelagischen« Zonen – verlegt',
         ),
-      ).toEqual('„Meeresregionen” — in die pelagischen Zonen — verlegt');
+      ).toEqual('„Meeresregionen” – in die „pelagischen” Zonen – verlegt');
     });
   });
 });


### PR DESCRIPTION
## Goal

- Dashes should be changed to `en` dashes not `em` dashes. Fixed & updated tests.
- Accommodate »example« use case, should be changed to „example"

## Deployment steps

- [x] Deployed to dev

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-1190