### PR TITLE
fix(linting): fix local npm lint scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,8 +97,8 @@
     "build": "DISABLE_ESLINT_PLUGIN=true node scripts/build.js",
     "test": "node scripts/test.js --transformIgnorePatterns \"node_modules/(?!@apollo/client/link/core/ApolloLink.js)/\"",
     "test:nowatch": "node scripts/test.js --watchAll=false  --transformIgnorePatterns \"node_modules/(?!@apollo/client/link/core/ApolloLink.js)/\"",
-    "lint-check": "tsc --noEmit && eslint src/**/*.ts{,x}",
-    "lint-fix": "tsc --noEmit && eslint src/**/*.ts{,x} --fix",
+    "lint-check": "eslint src/**/*.ts{,x}",
+    "lint-fix": "eslint src/**/*.ts{,x} --fix",
     "api:generate-types": "graphql-codegen --config src/config/admin-api-codegen.json -r dotenv/config"
   },
   "jest": {

--- a/src/_shared/components/Button/Button.test.tsx
+++ b/src/_shared/components/Button/Button.test.tsx
@@ -15,7 +15,7 @@ describe('The Button component', () => {
     render(
       <Button buttonType="neutral" size="large">
         Snooze
-      </Button>
+      </Button>,
     );
 
     const button = screen.getByRole('button');

--- a/src/_shared/components/CardActionButtonRow/CardActionButtonRow.test.tsx
+++ b/src/_shared/components/CardActionButtonRow/CardActionButtonRow.test.tsx
@@ -20,7 +20,7 @@ describe('The CardActionButtonRow component', () => {
         onReschedule={onReschedule}
         onMoveToBottom={onMoveToBottom}
         onReject={onReject}
-      />
+      />,
     );
 
     // assert edit button is present and calls its callback

--- a/src/_shared/components/CorpusItemCardImage/CorpusItemCardImage.test.tsx
+++ b/src/_shared/components/CorpusItemCardImage/CorpusItemCardImage.test.tsx
@@ -21,7 +21,7 @@ describe('The CorpusItemCardImage component', () => {
         currentScheduledDate={currentScheduledDate}
         scheduledSurfaceGuid="NEW_TAB_EN_US"
         toggleScheduleHistoryModal={toggleScheduleHistoryModal}
-      />
+      />,
     );
 
     expect(screen.getByText('Health & Fitness')).toBeInTheDocument();
@@ -46,7 +46,7 @@ describe('The CorpusItemCardImage component', () => {
         currentScheduledDate={currentScheduledDate}
         scheduledSurfaceGuid="NEW_TAB_EN_US"
         toggleScheduleHistoryModal={toggleScheduleHistoryModal}
-      />
+      />,
     );
 
     expect(screen.getByText(/time sensitive/i)).toBeInTheDocument();
@@ -65,7 +65,7 @@ describe('The CorpusItemCardImage component', () => {
         currentScheduledDate={currentScheduledDate}
         scheduledSurfaceGuid="NEW_TAB_EN_US"
         toggleScheduleHistoryModal={toggleScheduleHistoryModal}
-      />
+      />,
     );
 
     expect(screen.getByText(/collection/i)).toBeInTheDocument();
@@ -81,7 +81,7 @@ describe('The CorpusItemCardImage component', () => {
         currentScheduledDate={currentScheduledDate}
         scheduledSurfaceGuid="NEW_TAB_EN_US"
         toggleScheduleHistoryModal={toggleScheduleHistoryModal}
-      />
+      />,
     );
 
     expect(screen.getByText(/syndicated/i)).toBeInTheDocument();
@@ -113,7 +113,7 @@ describe('The CorpusItemCardImage component', () => {
         currentScheduledDate={currentScheduledDate}
         scheduledSurfaceGuid="NEW_TAB_EN_US"
         toggleScheduleHistoryModal={toggleScheduleHistoryModal}
-      />
+      />,
     );
 
     expect(screen.getByText(/last scheduled 2 days ago/i)).toBeInTheDocument();
@@ -146,7 +146,7 @@ describe('The CorpusItemCardImage component', () => {
         currentScheduledDate="2024-05-25"
         scheduledSurfaceGuid="NEW_TAB_EN_US"
         toggleScheduleHistoryModal={toggleScheduleHistoryModal}
-      />
+      />,
     );
 
     expect(screen.getByTestId('last-scheduled-overlay')).toHaveStyle({
@@ -180,7 +180,7 @@ describe('The CorpusItemCardImage component', () => {
         currentScheduledDate="2024-05-25"
         scheduledSurfaceGuid="NEW_TAB_EN_US"
         toggleScheduleHistoryModal={toggleScheduleHistoryModal}
-      />
+      />,
     );
 
     expect(screen.getByTestId('last-scheduled-overlay')).toHaveStyle({
@@ -214,7 +214,7 @@ describe('The CorpusItemCardImage component', () => {
         currentScheduledDate="2024-05-25"
         scheduledSurfaceGuid="NEW_TAB_EN_US"
         toggleScheduleHistoryModal={toggleScheduleHistoryModal}
-      />
+      />,
     );
 
     expect(screen.getByTestId('last-scheduled-overlay')).toHaveStyle({
@@ -248,7 +248,7 @@ describe('The CorpusItemCardImage component', () => {
         currentScheduledDate="2024-05-25"
         scheduledSurfaceGuid="NEW_TAB_EN_US"
         toggleScheduleHistoryModal={toggleScheduleHistoryModal}
-      />
+      />,
     );
 
     expect(screen.getByTestId('last-scheduled-overlay')).toHaveStyle({
@@ -282,7 +282,7 @@ describe('The CorpusItemCardImage component', () => {
         currentScheduledDate="2024-05-25"
         scheduledSurfaceGuid="NEW_TAB_EN_US"
         toggleScheduleHistoryModal={toggleScheduleHistoryModal}
-      />
+      />,
     );
 
     expect(screen.getByTestId('last-scheduled-overlay')).toHaveStyle({
@@ -303,7 +303,7 @@ describe('The CorpusItemCardImage component', () => {
         currentScheduledDate={currentScheduledDate}
         scheduledSurfaceGuid="NEW_TAB_EN_US"
         toggleScheduleHistoryModal={toggleScheduleHistoryModal}
-      />
+      />,
     );
 
     expect(screen.getByText(/NEW DOMAIN/i)).toBeVisible();

--- a/src/_shared/components/HandleApiResponse/HandleApiResponse.test.tsx
+++ b/src/_shared/components/HandleApiResponse/HandleApiResponse.test.tsx
@@ -11,7 +11,7 @@ describe('The HandleApiResponse component', () => {
         loading={true}
         loadingText="Loading data, please wait..."
         error={undefined}
-      />
+      />,
     );
 
     expect(screen.getByText(/^loading data/i)).toBeInTheDocument();
@@ -27,7 +27,7 @@ describe('The HandleApiResponse component', () => {
             networkError: new Error('Server not found.'),
           })
         }
-      />
+      />,
     );
 
     // error messages
@@ -37,7 +37,7 @@ describe('The HandleApiResponse component', () => {
 
   it('renders nothing if the API call is successful', () => {
     const { container } = render(
-      <HandleApiResponse loading={false} error={undefined} />
+      <HandleApiResponse loading={false} error={undefined} />,
     );
 
     expect(container).toBeEmptyDOMElement();

--- a/src/_shared/components/Header/Header.test.tsx
+++ b/src/_shared/components/Header/Header.test.tsx
@@ -38,7 +38,7 @@ describe('The Header component', () => {
             productName="Collections"
           />
         </ThemeProvider>
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // There are two logos: one for desktop, one for mobile
@@ -66,7 +66,7 @@ describe('The Header component', () => {
             productName="Collections"
           />
         </ThemeProvider>
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // Menu links are actual links and not buttons in MUI 5, hooray!

--- a/src/_shared/components/LoadMore/LoadMore.test.tsx
+++ b/src/_shared/components/LoadMore/LoadMore.test.tsx
@@ -20,7 +20,7 @@ describe('The LoadMore component', () => {
         buttonDisabled={buttonDisabled}
         loadMore={loadMore}
         showSpinner={showSpinner}
-      />
+      />,
     );
 
     expect(screen.getByText(/load more results/i)).toBeInTheDocument();
@@ -34,7 +34,7 @@ describe('The LoadMore component', () => {
         buttonDisabled={buttonDisabled}
         loadMore={loadMore}
         showSpinner={showSpinner}
-      />
+      />,
     );
 
     const button = screen.getByRole('button') as HTMLButtonElement;
@@ -52,7 +52,7 @@ describe('The LoadMore component', () => {
         buttonDisabled={buttonDisabled}
         loadMore={loadMore}
         showSpinner={showSpinner}
-      />
+      />,
     );
     expect(screen.getByRole('progressbar')).toBeInTheDocument();
   });
@@ -63,7 +63,7 @@ describe('The LoadMore component', () => {
         buttonDisabled={buttonDisabled}
         loadMore={loadMore}
         showSpinner={showSpinner}
-      />
+      />,
     );
 
     const button = screen.getByRole('button') as HTMLButtonElement;

--- a/src/_shared/components/MarkdownPreview/MarkdownPreview.test.tsx
+++ b/src/_shared/components/MarkdownPreview/MarkdownPreview.test.tsx
@@ -24,7 +24,7 @@ describe('The MarkdownPreview component', () => {
     render(
       <MarkdownPreview minHeight={10} source={markdownSource}>
         <textarea value={markdownSource} onChange={jest.fn()} />
-      </MarkdownPreview>
+      </MarkdownPreview>,
     );
 
     // Let's check if we can see the tabs
@@ -39,7 +39,7 @@ describe('The MarkdownPreview component', () => {
     render(
       <MarkdownPreview minHeight={10} source={markdownSource}>
         <textarea value={markdownSource} onChange={jest.fn()} />
-      </MarkdownPreview>
+      </MarkdownPreview>,
     );
 
     userEvent.click(screen.getByText(/preview/i));

--- a/src/_shared/components/Modal/Modal.test.tsx
+++ b/src/_shared/components/Modal/Modal.test.tsx
@@ -7,7 +7,7 @@ describe('The Modal component', () => {
     render(
       <Modal open={true} handleClose={jest.fn()}>
         Loading...
-      </Modal>
+      </Modal>,
     );
     const modal = screen.getByText(/^Loading...$/i);
 

--- a/src/_shared/components/ScrollToTop/ScrollToTop.test.tsx
+++ b/src/_shared/components/ScrollToTop/ScrollToTop.test.tsx
@@ -13,7 +13,7 @@ describe('The ScrollToTop component', () => {
     render(
       <Router history={history}>
         <ScrollToTop />
-      </Router>
+      </Router>,
     );
 
     // move to another page

--- a/src/_shared/components/Tab/Tab.test.tsx
+++ b/src/_shared/components/Tab/Tab.test.tsx
@@ -14,7 +14,7 @@ describe('The Tab component', () => {
           to="/en-US/live"
           hasLink={true}
         />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     const tab = screen.getByRole('tab');

--- a/src/_shared/components/TabLink/TabLink.test.tsx
+++ b/src/_shared/components/TabLink/TabLink.test.tsx
@@ -10,7 +10,7 @@ describe('The TabLink component', () => {
         <TabLink isCurrentTab={false} to="/any/path/">
           Tab title
         </TabLink>
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     const tabLink = screen.getByRole('link');
@@ -25,7 +25,7 @@ describe('The TabLink component', () => {
         <TabLink count={22} isCurrentTab to="/any/path/">
           Tab title
         </TabLink>
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     const tabLink = screen.getByRole('link');
@@ -38,7 +38,7 @@ describe('The TabLink component', () => {
         <TabLink count={1235} isCurrentTab to="/any/path/">
           Tab title
         </TabLink>
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     const tabLink = screen.getByRole('link');

--- a/src/_shared/components/TabNavigation/TabNavigation.test.tsx
+++ b/src/_shared/components/TabNavigation/TabNavigation.test.tsx
@@ -18,7 +18,7 @@ describe('The TabNavigation component', () => {
             to="/de-DE/scheduled/"
           />
         </TabNavigation>
-      </MemoryRouter>
+      </MemoryRouter>,
     );
     const tabNavigation = screen.getByRole('tablist');
     const tabs = within(tabNavigation).getAllByRole('tab');
@@ -49,7 +49,7 @@ describe('The TabNavigation component', () => {
           />
           <Tab label="Scheduled" count={333} value={activeTab} to={activeTab} />
         </TabNavigation>
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     const tabNavigation = screen.getByRole('tablist');

--- a/src/_shared/components/TabPanel/TabPanel.test.tsx
+++ b/src/_shared/components/TabPanel/TabPanel.test.tsx
@@ -9,7 +9,7 @@ describe('The TabPanel component', () => {
     render(
       <TabPanel heading="Test tab" value="test-tab" index="test-tab">
         <p>Tab contents</p>
-      </TabPanel>
+      </TabPanel>,
     );
 
     const tabPanel = screen.getByRole('tabpanel');

--- a/src/_shared/components/TabSet/TabSet.test.tsx
+++ b/src/_shared/components/TabSet/TabSet.test.tsx
@@ -20,7 +20,7 @@ describe('The TabSet component', () => {
           handleChange={jest.fn()}
           tabs={tabs}
         />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     const tab = screen.getByRole('tab');

--- a/src/_shared/components/_form-elements/FormikSelectField/FormikSelectField.test.tsx
+++ b/src/_shared/components/_form-elements/FormikSelectField/FormikSelectField.test.tsx
@@ -35,7 +35,7 @@ describe('The FormikSelectField component', () => {
         <option value="2">Option 2</option>
         <option value="3">Option 3</option>
         <option value="4">Option 4</option>
-      </FormikSelectField>
+      </FormikSelectField>,
     );
 
     const field = screen.getByRole('combobox') as HTMLInputElement;
@@ -54,7 +54,7 @@ describe('The FormikSelectField component', () => {
         <option value="2">Option 2</option>
         <option value="3">Option 3</option>
         <option value="4">Option 4</option>
-      </FormikSelectField>
+      </FormikSelectField>,
     );
 
     const field = screen.getByRole('combobox') as HTMLSelectElement;

--- a/src/_shared/components/_form-elements/FormikTextField/FormikTextField.test.tsx
+++ b/src/_shared/components/_form-elements/FormikTextField/FormikTextField.test.tsx
@@ -30,7 +30,7 @@ describe('The FormikTextField component', () => {
         label="Test Title"
         fieldProps={fieldProps}
         fieldMeta={fieldMeta}
-      />
+      />,
     );
 
     const field = screen.getByRole('textbox') as HTMLInputElement;
@@ -44,7 +44,7 @@ describe('The FormikTextField component', () => {
         label="Test Title"
         fieldProps={fieldProps}
         fieldMeta={fieldMeta}
-      />
+      />,
     );
 
     const field = screen.getByRole('textbox') as HTMLInputElement;

--- a/src/collections/components/AuthorForm/AuthorForm.test.tsx
+++ b/src/collections/components/AuthorForm/AuthorForm.test.tsx
@@ -41,7 +41,7 @@ describe('The AuthorForm component', () => {
 
   it('only shows two buttons if cancel button is not requested', () => {
     render(
-      <AuthorForm author={author} editMode={false} onSubmit={handleSubmit} />
+      <AuthorForm author={author} editMode={false} onSubmit={handleSubmit} />,
     );
 
     const buttons = screen.getAllByRole('button');
@@ -76,10 +76,10 @@ describe('The AuthorForm component', () => {
       userEvent.click(saveButton);
     });
     expect(
-      screen.queryByText(/please enter the full name of the author/i)
+      screen.queryByText(/please enter the full name of the author/i),
     ).toBeInTheDocument();
     expect(
-      screen.queryByText(/name must be at least 2 characters/i)
+      screen.queryByText(/name must be at least 2 characters/i),
     ).not.toBeInTheDocument();
 
     // Submit a name that is too short (under 2 characters)
@@ -91,10 +91,10 @@ describe('The AuthorForm component', () => {
       userEvent.click(saveButton);
     });
     expect(
-      screen.queryByText(/please enter the full name of the author/i)
+      screen.queryByText(/please enter the full name of the author/i),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByText(/name must be at least 2 characters/i)
+      screen.queryByText(/name must be at least 2 characters/i),
     ).toBeInTheDocument();
 
     // Submit a name that satisfies all the requirements
@@ -103,10 +103,10 @@ describe('The AuthorForm component', () => {
       userEvent.click(saveButton);
     });
     expect(
-      screen.queryByText(/please enter the full name of the author/i)
+      screen.queryByText(/please enter the full name of the author/i),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByText(/name must be at least 2 characters/i)
+      screen.queryByText(/name must be at least 2 characters/i),
     ).not.toBeInTheDocument();
   });
 
@@ -123,7 +123,7 @@ describe('The AuthorForm component', () => {
     });
     expect(screen.queryByText(/please enter a slug/i)).toBeInTheDocument();
     expect(
-      screen.queryByText(/slug must be at least 2 characters/i)
+      screen.queryByText(/slug must be at least 2 characters/i),
     ).not.toBeInTheDocument();
 
     // Submit a slug that is too short (under 2 characters)
@@ -134,7 +134,7 @@ describe('The AuthorForm component', () => {
     });
     expect(screen.queryByText(/please enter a slug/i)).not.toBeInTheDocument();
     expect(
-      screen.queryByText(/slug must be at least 2 characters/i)
+      screen.queryByText(/slug must be at least 2 characters/i),
     ).toBeInTheDocument();
 
     // Submit a slug that satisfies all the requirements
@@ -144,7 +144,7 @@ describe('The AuthorForm component', () => {
     });
     expect(screen.queryByText(/please enter a slug/i)).not.toBeInTheDocument();
     expect(
-      screen.queryByText(/slug must be at least 2 characters/i)
+      screen.queryByText(/slug must be at least 2 characters/i),
     ).not.toBeInTheDocument();
   });
 

--- a/src/collections/components/AuthorInfo/AuthorInfo.test.tsx
+++ b/src/collections/components/AuthorInfo/AuthorInfo.test.tsx
@@ -30,7 +30,7 @@ describe('The AuthorInfo component', () => {
         <MemoryRouter>
           <AuthorInfo author={author} />
         </MemoryRouter>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // The author bio is present
@@ -44,7 +44,7 @@ describe('The AuthorInfo component', () => {
         <MemoryRouter>
           <AuthorInfo author={author} />
         </MemoryRouter>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // Shows 'Active' subtitle for an active author
@@ -64,7 +64,7 @@ describe('The AuthorInfo component', () => {
         <MemoryRouter>
           <AuthorInfo author={author} />
         </MemoryRouter>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // Shows 'Inactive' subtitle for an inactive author

--- a/src/collections/components/AuthorListCard/AuthorListCard.test.tsx
+++ b/src/collections/components/AuthorListCard/AuthorListCard.test.tsx
@@ -30,7 +30,7 @@ describe('The AuthorListCard component', () => {
     render(
       <MemoryRouter>
         <AuthorListCard author={author} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // The author photo is present and the alt text is the author's name
@@ -42,7 +42,7 @@ describe('The AuthorListCard component', () => {
     expect(linkToAuthorPage).toBeInTheDocument();
     expect(linkToAuthorPage).toHaveAttribute(
       'href',
-      expect.stringContaining(author.externalId)
+      expect.stringContaining(author.externalId),
     );
 
     // The author bio is also present
@@ -54,7 +54,7 @@ describe('The AuthorListCard component', () => {
     render(
       <MemoryRouter>
         <AuthorListCard author={author} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // Shows 'Active' subtitle for an active author
@@ -72,7 +72,7 @@ describe('The AuthorListCard component', () => {
     render(
       <MemoryRouter>
         <AuthorListCard author={author} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // Shows 'Inactive' subtitle for an inactive author
@@ -94,14 +94,14 @@ describe('The AuthorListCard component', () => {
         <Router history={history}>
           <AuthorListCard author={author} />
         </Router>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // While the entire card is a giant link, we can click on
     // anything we like within that link - i.e., the author's name
     userEvent.click(screen.getByText(author.name));
     expect(history.location.pathname).toEqual(
-      `/collections/authors/${author.externalId}/`
+      `/collections/authors/${author.externalId}/`,
     );
 
     // Let's go back to the Authors page
@@ -111,7 +111,7 @@ describe('The AuthorListCard component', () => {
     // And click on the image this time
     userEvent.click(screen.getByRole('img'));
     expect(history.location.pathname).toEqual(
-      `/collections/authors/${author.externalId}/`
+      `/collections/authors/${author.externalId}/`,
     );
   });
 });

--- a/src/collections/components/ChipLabelsList/ChipLabelsList.test.tsx
+++ b/src/collections/components/ChipLabelsList/ChipLabelsList.test.tsx
@@ -42,7 +42,7 @@ describe('The ChipLabelsList component', () => {
     render(
       <MemoryRouter>
         <ChipLabelsList collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.getByText('region-east-africa')).toBeInTheDocument();
@@ -68,7 +68,7 @@ describe('The ChipLabelsList component', () => {
     render(
       <MemoryRouter>
         <ChipLabelsList collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // grab expand button, expect +1 as there are total of 3 labels
@@ -104,7 +104,7 @@ describe('The ChipLabelsList component', () => {
     render(
       <MemoryRouter>
         <ChipLabelsList collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // grab expand button, expect +1 as there are total of 3 labels
@@ -123,7 +123,7 @@ describe('The ChipLabelsList component', () => {
     render(
       <MemoryRouter>
         <ChipLabelsList collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.queryByText('region-east-africa')).not.toBeInTheDocument();

--- a/src/collections/components/CollectionForm/CollectionForm.test.tsx
+++ b/src/collections/components/CollectionForm/CollectionForm.test.tsx
@@ -113,7 +113,7 @@ describe('The CollectionForm component', () => {
         labels={labels}
         languages={Object.values(CollectionLanguage)}
         onSubmit={handleSubmit}
-      />
+      />,
     );
 
     // there is at least a form and nothing falls over
@@ -131,7 +131,7 @@ describe('The CollectionForm component', () => {
         labels={labels}
         languages={languages}
         onSubmit={handleSubmit}
-      />
+      />,
     );
 
     const buttons = screen.getAllByRole('button');
@@ -151,7 +151,7 @@ describe('The CollectionForm component', () => {
         languages={languages}
         editMode={false}
         onSubmit={handleSubmit}
-      />
+      />,
     );
 
     const buttons = screen.getAllByRole('button');
@@ -170,7 +170,7 @@ describe('The CollectionForm component', () => {
         labels={labels}
         languages={languages}
         onSubmit={handleSubmit}
-      />
+      />,
     );
 
     const titleField = screen.getByLabelText('Title');
@@ -214,7 +214,7 @@ describe('The CollectionForm component', () => {
         labels={labels}
         languages={languages}
         onSubmit={handleSubmit}
-      />
+      />,
     );
 
     const titleField = screen.getByLabelText(/title/i);
@@ -226,10 +226,10 @@ describe('The CollectionForm component', () => {
       userEvent.click(saveButton);
     });
     expect(
-      screen.queryByText(/please enter a title for this collection/i)
+      screen.queryByText(/please enter a title for this collection/i),
     ).toBeInTheDocument();
     expect(
-      screen.queryByText(/title must be at least 6 characters/i)
+      screen.queryByText(/title must be at least 6 characters/i),
     ).not.toBeInTheDocument();
 
     // Submit a collection title that is too short (under 6 characters)
@@ -238,10 +238,10 @@ describe('The CollectionForm component', () => {
       userEvent.click(saveButton);
     });
     expect(
-      screen.queryByText(/please enter a title for this collection/i)
+      screen.queryByText(/please enter a title for this collection/i),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByText(/title must be at least 6 characters/i)
+      screen.queryByText(/title must be at least 6 characters/i),
     ).toBeInTheDocument();
 
     // Submit a title that satisfies all the requirements
@@ -250,10 +250,10 @@ describe('The CollectionForm component', () => {
       userEvent.click(saveButton);
     });
     expect(
-      screen.queryByText(/please enter a title for this collection/i)
+      screen.queryByText(/please enter a title for this collection/i),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByText(/title must be at least 6 characters/i)
+      screen.queryByText(/title must be at least 6 characters/i),
     ).not.toBeInTheDocument();
   });
 
@@ -267,7 +267,7 @@ describe('The CollectionForm component', () => {
         labels={labels}
         languages={languages}
         onSubmit={handleSubmit}
-      />
+      />,
     );
 
     const slugField = screen.getByLabelText(/slug/i);
@@ -280,7 +280,7 @@ describe('The CollectionForm component', () => {
     });
     expect(screen.queryByText(/please enter a slug/i)).toBeInTheDocument();
     expect(
-      screen.queryByText(/slug must be at least 6 characters/i)
+      screen.queryByText(/slug must be at least 6 characters/i),
     ).not.toBeInTheDocument();
 
     // Submit a slug that is too short (under 6 characters)
@@ -290,7 +290,7 @@ describe('The CollectionForm component', () => {
     });
     expect(screen.queryByText(/please enter a slug/i)).not.toBeInTheDocument();
     expect(
-      screen.queryByText(/slug must be at least 6 characters/i)
+      screen.queryByText(/slug must be at least 6 characters/i),
     ).toBeInTheDocument();
 
     // Submit a slug that satisfies all the requirements
@@ -300,7 +300,7 @@ describe('The CollectionForm component', () => {
     });
     expect(screen.queryByText(/please enter a slug/i)).not.toBeInTheDocument();
     expect(
-      screen.queryByText(/slug must be at least 6 characters/i)
+      screen.queryByText(/slug must be at least 6 characters/i),
     ).not.toBeInTheDocument();
   });
 
@@ -314,7 +314,7 @@ describe('The CollectionForm component', () => {
         labels={labels}
         languages={languages}
         onSubmit={handleSubmit}
-      />
+      />,
     );
 
     // The "Suggest slug" button slugifies whatever is present in the "Title" field
@@ -342,7 +342,7 @@ describe('The CollectionForm component', () => {
 
     // Slugified version of the title appears in the slug input field
     expect(
-      screen.getByDisplayValue('a-very-long-and-elaborate-collection-name')
+      screen.getByDisplayValue('a-very-long-and-elaborate-collection-name'),
     ).toBeInTheDocument();
   });
 
@@ -356,7 +356,7 @@ describe('The CollectionForm component', () => {
         labels={labels}
         languages={languages}
         onSubmit={handleSubmit}
-      />
+      />,
     );
 
     const slugField = screen.getByLabelText(/slug/i);
@@ -370,7 +370,7 @@ describe('The CollectionForm component', () => {
 
     userEvent.type(
       titleField,
-      'A !!!title ??? full ### of ```special~~~ chars!#@*^*#^.,;*_/'
+      'A !!!title ??? full ### of ```special~~~ chars!#@*^*#^.,;*_/',
     );
 
     await waitFor(() => {
@@ -379,7 +379,7 @@ describe('The CollectionForm component', () => {
 
     // Get a slug that is free
     expect(
-      screen.getByDisplayValue('a-title-full-of-special-chars')
+      screen.getByDisplayValue('a-title-full-of-special-chars'),
     ).toBeInTheDocument();
   });
 
@@ -393,7 +393,7 @@ describe('The CollectionForm component', () => {
         labels={labels}
         languages={languages}
         onSubmit={handleSubmit}
-      />
+      />,
     );
 
     const writeTabs = screen.getAllByText(/write/i);
@@ -416,7 +416,7 @@ describe('The CollectionForm component', () => {
         labels={labels}
         languages={languages}
         onSubmit={handleSubmit}
-      />
+      />,
     );
 
     // Expect to see both of these labels on the screen

--- a/src/collections/components/CollectionInfo/CollectionInfo.test.tsx
+++ b/src/collections/components/CollectionInfo/CollectionInfo.test.tsx
@@ -31,7 +31,7 @@ describe('The CollectionInfo component', () => {
     render(
       <MemoryRouter>
         <CollectionInfo collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // The slug is present
@@ -61,7 +61,7 @@ describe('The CollectionInfo component', () => {
     render(
       <MemoryRouter>
         <CollectionInfo collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // Shows 'Published' subtitle for a published collection
@@ -83,14 +83,14 @@ describe('The CollectionInfo component', () => {
     const { rerender } = render(
       <MemoryRouter>
         <CollectionInfo collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     const link = screen.getByRole('link');
     expect(link).toBeInTheDocument();
 
     expect(link.getAttribute('href')).toEqual(
-      `https://getpocket.com/collections/${collection.slug}`
+      `https://getpocket.com/collections/${collection.slug}`,
     );
 
     const textOnlySlug = screen.queryByText(collection.slug);
@@ -101,7 +101,7 @@ describe('The CollectionInfo component', () => {
     rerender(
       <MemoryRouter>
         <CollectionInfo collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // Test that the active link persists
@@ -109,7 +109,7 @@ describe('The CollectionInfo component', () => {
     expect(link2).toBeInTheDocument();
 
     expect(link2.getAttribute('href')).toEqual(
-      `https://getpocket.com/collections/${collection.slug}`
+      `https://getpocket.com/collections/${collection.slug}`,
     );
 
     const textOnlySlug2 = screen.queryByText(collection.slug);
@@ -120,7 +120,7 @@ describe('The CollectionInfo component', () => {
     render(
       <MemoryRouter>
         <CollectionInfo collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.getByText(/^de$/i)).toBeInTheDocument();
@@ -136,7 +136,7 @@ describe('The CollectionInfo component', () => {
     render(
       <MemoryRouter>
         <CollectionInfo collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.getByText('Food')).toBeInTheDocument();
@@ -146,7 +146,7 @@ describe('The CollectionInfo component', () => {
     render(
       <MemoryRouter>
         <CollectionInfo collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.queryByText('Food')).not.toBeInTheDocument();
@@ -168,7 +168,7 @@ describe('The CollectionInfo component', () => {
     render(
       <MemoryRouter>
         <CollectionInfo collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.getByText('Careers → Job Fairs')).toBeInTheDocument();
@@ -178,7 +178,7 @@ describe('The CollectionInfo component', () => {
     render(
       <MemoryRouter>
         <CollectionInfo collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.queryByText('Careers → Job Fairs')).not.toBeInTheDocument();
@@ -199,7 +199,7 @@ describe('The CollectionInfo component', () => {
     render(
       <MemoryRouter>
         <CollectionInfo collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.getByText('region-east-africa')).toBeInTheDocument();
@@ -225,7 +225,7 @@ describe('The CollectionInfo component', () => {
     render(
       <MemoryRouter>
         <CollectionInfo collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // grab expand button, expect +1 as there are total of 3 labels
@@ -261,7 +261,7 @@ describe('The CollectionInfo component', () => {
     render(
       <MemoryRouter>
         <CollectionInfo collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // grab expand button, expect +1 as there are total of 3 labels
@@ -280,7 +280,7 @@ describe('The CollectionInfo component', () => {
     render(
       <MemoryRouter>
         <CollectionInfo collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.queryByText('region-east-africa')).not.toBeInTheDocument();

--- a/src/collections/components/CollectionListCard/CollectionListCard.test.tsx
+++ b/src/collections/components/CollectionListCard/CollectionListCard.test.tsx
@@ -34,7 +34,7 @@ describe('The CollectionListCard component', () => {
     render(
       <MemoryRouter>
         <CollectionListCard collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // The photo is present and the alt text is the collection title
@@ -46,7 +46,7 @@ describe('The CollectionListCard component', () => {
     expect(linkToCollectionPage).toBeInTheDocument();
     expect(linkToCollectionPage).toHaveAttribute(
       'href',
-      expect.stringContaining(collection.externalId)
+      expect.stringContaining(collection.externalId),
     );
 
     // The excerpt is also present
@@ -58,7 +58,7 @@ describe('The CollectionListCard component', () => {
     render(
       <MemoryRouter>
         <CollectionListCard collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // Shows 'Published' subtitle for a published collection
@@ -76,7 +76,7 @@ describe('The CollectionListCard component', () => {
     render(
       <MemoryRouter>
         <CollectionListCard collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.getByText(/^de$/i)).toBeInTheDocument();
@@ -92,7 +92,7 @@ describe('The CollectionListCard component', () => {
     render(
       <MemoryRouter>
         <CollectionListCard collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.getByText('Food')).toBeInTheDocument();
@@ -102,7 +102,7 @@ describe('The CollectionListCard component', () => {
     render(
       <MemoryRouter>
         <CollectionListCard collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.queryByText('Food')).not.toBeInTheDocument();
@@ -124,7 +124,7 @@ describe('The CollectionListCard component', () => {
     render(
       <MemoryRouter>
         <CollectionListCard collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.getByText('Careers → Job Fairs')).toBeInTheDocument();
@@ -134,7 +134,7 @@ describe('The CollectionListCard component', () => {
     render(
       <MemoryRouter>
         <CollectionListCard collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.queryByText('Careers → Job Fairs')).not.toBeInTheDocument();
@@ -155,7 +155,7 @@ describe('The CollectionListCard component', () => {
     render(
       <MemoryRouter>
         <CollectionListCard collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.getByText('region-east-africa')).toBeInTheDocument();
@@ -181,7 +181,7 @@ describe('The CollectionListCard component', () => {
     render(
       <MemoryRouter>
         <CollectionListCard collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // grab expand button, expect +1 as there are total of 3 labels
@@ -217,7 +217,7 @@ describe('The CollectionListCard component', () => {
     render(
       <MemoryRouter>
         <CollectionListCard collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // grab expand button, expect +1 as there are total of 3 labels
@@ -236,7 +236,7 @@ describe('The CollectionListCard component', () => {
     render(
       <MemoryRouter>
         <CollectionListCard collection={collection} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.queryByText('region-east-africa')).not.toBeInTheDocument();
@@ -252,14 +252,14 @@ describe('The CollectionListCard component', () => {
         <Router history={history}>
           <CollectionListCard collection={collection} />
         </Router>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // While the entire card is a giant link, we can click on
     // anything we like within that link - i.e., the title of the collection
     userEvent.click(screen.getByText(collection.title));
     expect(history.location.pathname).toEqual(
-      `/collections/collections/${collection.externalId}/`
+      `/collections/collections/${collection.externalId}/`,
     );
 
     // Let's go back to the Collections page
@@ -269,7 +269,7 @@ describe('The CollectionListCard component', () => {
     // And click on the image this time
     userEvent.click(screen.getByRole('img'));
     expect(history.location.pathname).toEqual(
-      `/collections/collections/${collection.externalId}/`
+      `/collections/collections/${collection.externalId}/`,
     );
   });
 });

--- a/src/collections/components/CollectionPartnerAssociationForm/CollectionPartnerAssociationForm.test.tsx
+++ b/src/collections/components/CollectionPartnerAssociationForm/CollectionPartnerAssociationForm.test.tsx
@@ -70,7 +70,7 @@ describe('The CollectionPartnerAssociationForm component', () => {
         association={association}
         partners={partners}
         onSubmit={handleSubmit}
-      />
+      />,
     );
 
     // there is at least a form and nothing falls over
@@ -84,7 +84,7 @@ describe('The CollectionPartnerAssociationForm component', () => {
         association={association}
         partners={partners}
         onSubmit={handleSubmit}
-      />
+      />,
     );
 
     const buttons = screen.getAllByRole('button');
@@ -98,7 +98,7 @@ describe('The CollectionPartnerAssociationForm component', () => {
         partners={partners}
         onSubmit={handleSubmit}
         editMode={false}
-      />
+      />,
     );
 
     const buttons = screen.getAllByRole('button');
@@ -111,7 +111,7 @@ describe('The CollectionPartnerAssociationForm component', () => {
         association={association}
         partners={partners}
         onSubmit={handleSubmit}
-      />
+      />,
     );
 
     const typeField = screen.getByLabelText('Type');
@@ -136,7 +136,7 @@ describe('The CollectionPartnerAssociationForm component', () => {
         association={association}
         partners={partners}
         onSubmit={handleSubmit}
-      />
+      />,
     );
 
     const typeField = screen.getByLabelText(/type/i) as HTMLSelectElement;
@@ -165,7 +165,7 @@ describe('The CollectionPartnerAssociationForm component', () => {
         association={association}
         partners={partners}
         onSubmit={handleSubmit}
-      />
+      />,
     );
 
     const partnerField = screen.getByLabelText(/partner/i) as HTMLSelectElement;
@@ -194,7 +194,7 @@ describe('The CollectionPartnerAssociationForm component', () => {
         association={association}
         partners={partners}
         onSubmit={handleSubmit}
-      />
+      />,
     );
 
     const nameField = screen.getByLabelText(/name/i);
@@ -207,7 +207,7 @@ describe('The CollectionPartnerAssociationForm component', () => {
       userEvent.click(saveButton);
     });
     expect(
-      screen.queryByText(/please enter at least two characters/i)
+      screen.queryByText(/please enter at least two characters/i),
     ).toBeInTheDocument();
 
     // Submit a longer name
@@ -217,7 +217,7 @@ describe('The CollectionPartnerAssociationForm component', () => {
       userEvent.click(saveButton);
     });
     expect(
-      screen.queryByText(/please enter at least two characters/i)
+      screen.queryByText(/please enter at least two characters/i),
     ).not.toBeInTheDocument();
 
     // Since we're not modifying any other test data, and the default test data
@@ -232,7 +232,7 @@ describe('The CollectionPartnerAssociationForm component', () => {
         association={association}
         partners={partners}
         onSubmit={handleSubmit}
-      />
+      />,
     );
 
     const urlField = screen.getByLabelText(/url/i);
@@ -245,7 +245,7 @@ describe('The CollectionPartnerAssociationForm component', () => {
       userEvent.click(saveButton);
     });
     expect(
-      screen.queryByText(/please enter at least 10 characters/i)
+      screen.queryByText(/please enter at least 10 characters/i),
     ).toBeInTheDocument();
 
     // Submit a longer url
@@ -255,7 +255,7 @@ describe('The CollectionPartnerAssociationForm component', () => {
       userEvent.click(saveButton);
     });
     expect(
-      screen.queryByText(/please enter at least 10 characters/i)
+      screen.queryByText(/please enter at least 10 characters/i),
     ).not.toBeInTheDocument();
 
     // Since we're not modifying any other test data, and the default test data
@@ -270,7 +270,7 @@ describe('The CollectionPartnerAssociationForm component', () => {
         association={association}
         partners={partners}
         onSubmit={handleSubmit}
-      />
+      />,
     );
 
     const blurbField = screen.getByLabelText(/blurb/i);
@@ -283,20 +283,20 @@ describe('The CollectionPartnerAssociationForm component', () => {
       userEvent.click(saveButton);
     });
     expect(
-      screen.queryByText(/please enter at least 10 characters/i)
+      screen.queryByText(/please enter at least 10 characters/i),
     ).toBeInTheDocument();
 
     // Submit a longer url
     userEvent.clear(blurbField);
     userEvent.type(
       blurbField,
-      'Hmm, this test tends to time out if this line is too long'
+      'Hmm, this test tends to time out if this line is too long',
     );
     await waitFor(() => {
       userEvent.click(saveButton);
     });
     expect(
-      screen.queryByText(/please enter at least 10 characters/i)
+      screen.queryByText(/please enter at least 10 characters/i),
     ).not.toBeInTheDocument();
 
     // Since we're not modifying any other test data, and the default test data
@@ -311,7 +311,7 @@ describe('The CollectionPartnerAssociationForm component', () => {
         association={association}
         partners={partners}
         onSubmit={handleSubmit}
-      />
+      />,
     );
     const writeTabs = screen.getAllByText(/write/i);
     expect(writeTabs.length).toEqual(1);

--- a/src/collections/components/LabelForm/LabelForm.test.tsx
+++ b/src/collections/components/LabelForm/LabelForm.test.tsx
@@ -17,7 +17,7 @@ describe('The LabelForm component', () => {
         onSubmit={onSubmit}
         onCancel={onCancel}
         isLoaderShowing={false}
-      />
+      />,
     );
 
     // Check if form input and buttons are rendered
@@ -41,7 +41,7 @@ describe('The LabelForm component', () => {
             isLoaderShowing={false}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     const saveButton = screen.getByText(/save/i);
@@ -63,7 +63,7 @@ describe('The LabelForm component', () => {
             isLoaderShowing={false}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     const saveButton = screen.getByText(/save/i);

--- a/src/collections/components/LabelFormConnector/LabelFormConnector.test.tsx
+++ b/src/collections/components/LabelFormConnector/LabelFormConnector.test.tsx
@@ -30,7 +30,7 @@ describe('LabelFormConnector', () => {
         <SnackbarProvider>
           <LabelFormConnector toggleModal={toggleModal} />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // Wait for the form to load
@@ -61,7 +61,7 @@ describe('LabelFormConnector', () => {
         <SnackbarProvider>
           <LabelFormConnector toggleModal={toggleModal} />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // Wait for the form to load
@@ -96,7 +96,7 @@ describe('LabelFormConnector', () => {
             runCreateLabelMutation={true}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // Wait for the form to load
@@ -119,8 +119,8 @@ describe('LabelFormConnector', () => {
     // should resolve in duplicate error
     expect(
       screen.getByText(
-        'A label with the name "fake-label-duplicate" already exists'
-      )
+        'A label with the name "fake-label-duplicate" already exists',
+      ),
     ).toBeInTheDocument();
   });
 
@@ -140,7 +140,7 @@ describe('LabelFormConnector', () => {
             runUpdateLabelMutation={true}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // Wait for the form to load
@@ -162,8 +162,8 @@ describe('LabelFormConnector', () => {
     // should resolve in duplicate error
     expect(
       screen.getByText(
-        'A label with the name "fake-label-duplicate-update" already exists'
-      )
+        'A label with the name "fake-label-duplicate-update" already exists',
+      ),
     ).toBeInTheDocument();
   });
 
@@ -183,7 +183,7 @@ describe('LabelFormConnector', () => {
             runUpdateLabelMutation={true}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // Wait for the form to load
@@ -208,8 +208,8 @@ describe('LabelFormConnector', () => {
     // should resolve in duplicate error
     expect(
       screen.getByText(
-        'Cannot update label; it is associated with at least one collection'
-      )
+        'Cannot update label; it is associated with at least one collection',
+      ),
     ).toBeInTheDocument();
   });
 
@@ -221,7 +221,7 @@ describe('LabelFormConnector', () => {
         <SnackbarProvider>
           <LabelFormConnector toggleModal={toggleModal} />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // Wait for the form to load
@@ -243,7 +243,7 @@ describe('LabelFormConnector', () => {
     });
     // should resolve in min length error
     expect(
-      screen.getByText('Label name needs to be at least 2 characters.')
+      screen.getByText('Label name needs to be at least 2 characters.'),
     ).toBeInTheDocument();
   });
 
@@ -255,7 +255,7 @@ describe('LabelFormConnector', () => {
         <SnackbarProvider>
           <LabelFormConnector toggleModal={toggleModal} />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // Wait for the form to load
@@ -278,8 +278,8 @@ describe('LabelFormConnector', () => {
     // should resolve in min length error
     expect(
       screen.getByText(
-        'Label name can only contain lowercase alphanumeric characters and hyphens.'
-      )
+        'Label name can only contain lowercase alphanumeric characters and hyphens.',
+      ),
     ).toBeInTheDocument();
   });
 
@@ -294,7 +294,7 @@ describe('LabelFormConnector', () => {
             runCreateLabelMutation={true}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // Wait for the form to load
@@ -335,7 +335,7 @@ describe('LabelFormConnector', () => {
             label={label}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // Wait for the form to load
@@ -370,7 +370,7 @@ describe('LabelFormConnector', () => {
         <SnackbarProvider>
           <LabelFormConnector toggleModal={toggleModal} />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // Wait for the form to load

--- a/src/collections/components/LabelListCard/LabelListCard.test.tsx
+++ b/src/collections/components/LabelListCard/LabelListCard.test.tsx
@@ -18,7 +18,7 @@ describe('The LabelListCard component', () => {
     render(
       <MemoryRouter>
         <LabelListCard label={label} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     const name = screen.getByText(/region-east-africa/i);

--- a/src/collections/components/LabelModal/LabelModal.test.tsx
+++ b/src/collections/components/LabelModal/LabelModal.test.tsx
@@ -17,7 +17,7 @@ describe('The LabelModal component', () => {
             modalTitle="Add a New Label"
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // using the modal heading to fetch it
@@ -40,7 +40,7 @@ describe('The LabelModal component', () => {
             modalTitle="Edit Label"
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // using the modal heading to fetch it

--- a/src/collections/components/PartnerForm/PartnerForm.test.tsx
+++ b/src/collections/components/PartnerForm/PartnerForm.test.tsx
@@ -40,7 +40,11 @@ describe('The PartnerForm component', () => {
 
   it('only shows one button if cancel button is not requested', () => {
     render(
-      <PartnerForm partner={partner} editMode={false} onSubmit={handleSubmit} />
+      <PartnerForm
+        partner={partner}
+        editMode={false}
+        onSubmit={handleSubmit}
+      />,
     );
 
     const buttons = screen.getAllByRole('button');
@@ -72,10 +76,10 @@ describe('The PartnerForm component', () => {
       userEvent.click(saveButton);
     });
     expect(
-      screen.queryByText(/please enter the name of the partner company/i)
+      screen.queryByText(/please enter the name of the partner company/i),
     ).toBeInTheDocument();
     expect(
-      screen.queryByText(/please enter at least two characters/i)
+      screen.queryByText(/please enter at least two characters/i),
     ).not.toBeInTheDocument();
 
     // Submit a name that is too short (under two characters)
@@ -84,10 +88,10 @@ describe('The PartnerForm component', () => {
       userEvent.click(saveButton);
     });
     expect(
-      screen.queryByText(/please enter the name of the partner company/i)
+      screen.queryByText(/please enter the name of the partner company/i),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByText(/please enter at least two characters/i)
+      screen.queryByText(/please enter at least two characters/i),
     ).toBeInTheDocument();
 
     // Submit a name that satisfies all the requirements
@@ -96,10 +100,10 @@ describe('The PartnerForm component', () => {
       userEvent.click(saveButton);
     });
     expect(
-      screen.queryByText(/please enter the name of the partner company/i)
+      screen.queryByText(/please enter the name of the partner company/i),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByText(/please enter at least two characters/i)
+      screen.queryByText(/please enter at least two characters/i),
     ).not.toBeInTheDocument();
   });
 
@@ -116,7 +120,7 @@ describe('The PartnerForm component', () => {
     });
     expect(screen.queryByText(/please enter a url/i)).toBeInTheDocument();
     expect(
-      screen.queryByText(/url must be at least 12 characters long/i)
+      screen.queryByText(/url must be at least 12 characters long/i),
     ).not.toBeInTheDocument();
 
     // Submit a URL that is too short (under 12 characters)
@@ -126,7 +130,7 @@ describe('The PartnerForm component', () => {
     });
     expect(screen.queryByText(/please enter a url/i)).not.toBeInTheDocument();
     expect(
-      screen.queryByText(/url must be at least 12 characters long/i)
+      screen.queryByText(/url must be at least 12 characters long/i),
     ).toBeInTheDocument();
 
     // Submit a URL that satisfies all the requirements
@@ -136,7 +140,7 @@ describe('The PartnerForm component', () => {
     });
     expect(screen.queryByText(/please enter a url/i)).not.toBeInTheDocument();
     expect(
-      screen.queryByText(/url must be at least 12 characters long/i)
+      screen.queryByText(/url must be at least 12 characters long/i),
     ).not.toBeInTheDocument();
   });
 
@@ -152,7 +156,7 @@ describe('The PartnerForm component', () => {
       userEvent.click(saveButton);
     });
     expect(
-      screen.queryByText(/please enter the blurb for the partner company/i)
+      screen.queryByText(/please enter the blurb for the partner company/i),
     ).toBeInTheDocument();
 
     // Submit some text
@@ -161,7 +165,7 @@ describe('The PartnerForm component', () => {
       userEvent.click(saveButton);
     });
     expect(
-      screen.queryByText(/please enter the blurb for the partner company/i)
+      screen.queryByText(/please enter the blurb for the partner company/i),
     ).not.toBeInTheDocument();
   });
 

--- a/src/collections/components/PartnerInfo/PartnerInfo.test.tsx
+++ b/src/collections/components/PartnerInfo/PartnerInfo.test.tsx
@@ -29,7 +29,7 @@ describe('The PartnerInfo component', () => {
         <MemoryRouter>
           <PartnerInfo partner={partner} />
         </MemoryRouter>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // The link to the partner site is present

--- a/src/collections/components/PartnerListCard/PartnerListCard.test.tsx
+++ b/src/collections/components/PartnerListCard/PartnerListCard.test.tsx
@@ -29,7 +29,7 @@ describe('The PartnerListCard component', () => {
     render(
       <MemoryRouter>
         <PartnerListCard partner={partner} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // The partner image is present and the alt text is the partner's name
@@ -41,7 +41,7 @@ describe('The PartnerListCard component', () => {
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute(
       'href',
-      expect.stringContaining(partner.externalId)
+      expect.stringContaining(partner.externalId),
     );
 
     // The blurb is also present
@@ -59,14 +59,14 @@ describe('The PartnerListCard component', () => {
         <Router history={history}>
           <PartnerListCard partner={partner} />
         </Router>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // While the entire card is a giant link, we can click on
     // anything we like within that link - i.e., the partners's name
     userEvent.click(screen.getByText(partner.name));
     expect(history.location.pathname).toEqual(
-      `/collections/partners/${partner.externalId}/`
+      `/collections/partners/${partner.externalId}/`,
     );
 
     // Let's go back to the Partners page
@@ -76,7 +76,7 @@ describe('The PartnerListCard component', () => {
     // And click on the image this time
     userEvent.click(screen.getByRole('img'));
     expect(history.location.pathname).toEqual(
-      `/collections/partners/${partner.externalId}/`
+      `/collections/partners/${partner.externalId}/`,
     );
   });
 });

--- a/src/collections/components/StoryCard/StoryCard.test.tsx
+++ b/src/collections/components/StoryCard/StoryCard.test.tsx
@@ -32,7 +32,7 @@ describe('The StoryCard component', () => {
     render(
       <MemoryRouter>
         <StoryCard story={story} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // The link to the story is present and well-formed
@@ -40,11 +40,11 @@ describe('The StoryCard component', () => {
     expect(linkToStory).toBeInTheDocument();
     expect(linkToStory).toHaveAttribute(
       'href',
-      expect.stringMatching(story.url)
+      expect.stringMatching(story.url),
     );
     expect(linkToStory).toHaveAttribute(
       'target',
-      expect.stringMatching('_blank')
+      expect.stringMatching('_blank'),
     );
 
     // the title is present
@@ -74,24 +74,24 @@ describe('The StoryCard component', () => {
     render(
       <MemoryRouter>
         <StoryCard story={story} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // The sample excerpt has some line breaks
     // and should be rendered as three paragraphs.
     const firstParagraph = screen.getByText(
-      'Quia non dolores voluptatem est aut. Id officiis nulla est.'
+      'Quia non dolores voluptatem est aut. Id officiis nulla est.',
     );
     expect(firstParagraph).toBeInTheDocument();
 
     const secondParagraph = screen.getByText(
       'Harum et velit debitis. Quia assumenda commodi et dolor. ' +
-        'Ut dicta veritatis perspiciatis suscipit.'
+        'Ut dicta veritatis perspiciatis suscipit.',
     );
     expect(secondParagraph).toBeInTheDocument();
 
     const thirdParagraph = screen.getByText(
-      'Aspernatur reprehenderit laboriosam voluptates ut. Ut minus aut est.'
+      'Aspernatur reprehenderit laboriosam voluptates ut. Ut minus aut est.',
     );
     expect(thirdParagraph).toBeInTheDocument();
   });
@@ -100,7 +100,7 @@ describe('The StoryCard component', () => {
     render(
       <MemoryRouter>
         <StoryCard story={story} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     const middot = screen.getByText('\u00b7');
@@ -113,7 +113,7 @@ describe('The StoryCard component', () => {
     render(
       <MemoryRouter>
         <StoryCard story={story} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     const middot = screen.queryByText('\u00b7');
@@ -126,7 +126,7 @@ describe('The StoryCard component', () => {
     render(
       <MemoryRouter>
         <StoryCard story={story} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     const fromPartner = screen.getByText(/from partner\/sponsor/i);

--- a/src/collections/pages/AddAuthorPage/AddAuthorPage.test.tsx
+++ b/src/collections/pages/AddAuthorPage/AddAuthorPage.test.tsx
@@ -39,7 +39,7 @@ describe('The AddAuthor page', () => {
     render(
       <MockedProvider mocks={mocksWithError} addTypename={false}>
         <AddAuthorPage />
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // fill out the form

--- a/src/curated-corpus/components/AddProspectForm/AddProspectForm.test.tsx
+++ b/src/curated-corpus/components/AddProspectForm/AddProspectForm.test.tsx
@@ -15,7 +15,7 @@ describe('The AddProspectForm component', () => {
         onSubmit={onSubmit}
         onCancel={onCancel}
         isLoaderShowing={false}
-      />
+      />,
     );
 
     // Check if form input and buttons are rendered
@@ -39,7 +39,7 @@ describe('The AddProspectForm component', () => {
             isLoaderShowing={false}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     const saveButton = screen.getByText(/save/i);
@@ -60,7 +60,7 @@ describe('The AddProspectForm component', () => {
             isLoaderShowing={false}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     const urlInputField = screen.getByLabelText(/item url/i);
@@ -72,7 +72,7 @@ describe('The AddProspectForm component', () => {
     userEvent.click(saveButton);
 
     const incorrectUrlError = await screen.findByText(
-      /please enter a valid url starting with https:\/\//i
+      /please enter a valid url starting with https:\/\//i,
     );
 
     expect(incorrectUrlError).toBeInTheDocument();

--- a/src/curated-corpus/components/AddProspectModal/AddProspectModal.test.tsx
+++ b/src/curated-corpus/components/AddProspectModal/AddProspectModal.test.tsx
@@ -28,7 +28,7 @@ describe('The AddProspectModal component', () => {
             toggleDuplicateProspectModal={toggleDuplicateProspectModal}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // using the modal heading to fetch it

--- a/src/curated-corpus/components/ApprovedItemCardWrapper/ApprovedItemCardWrapper.test.tsx
+++ b/src/curated-corpus/components/ApprovedItemCardWrapper/ApprovedItemCardWrapper.test.tsx
@@ -21,7 +21,7 @@ describe('The ApprovedItemCardWrapper component', () => {
             onSchedule={jest.fn()}
           />
         </ThemeProvider>
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // Only check the title here as the rest is thoroughly tested
@@ -41,7 +41,7 @@ describe('The ApprovedItemCardWrapper component', () => {
             onSchedule={jest.fn()}
           />
         </ThemeProvider>
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     const viewButton = screen.getByRole('button', { name: /View/i });
@@ -73,7 +73,7 @@ describe('The ApprovedItemCardWrapper component', () => {
             onSchedule={jest.fn()}
           />
         </ThemeProvider>
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // The link to the corpus item page is present and is well-formed
@@ -81,7 +81,7 @@ describe('The ApprovedItemCardWrapper component', () => {
     expect(linkToItemPage).toBeInTheDocument();
     expect(linkToItemPage).toHaveAttribute(
       'href',
-      expect.stringContaining(item.externalId)
+      expect.stringContaining(item.externalId),
     );
   });
 });

--- a/src/curated-corpus/components/ApprovedItemCurationHistory/ApprovedItemCurationHistory.test.tsx
+++ b/src/curated-corpus/components/ApprovedItemCurationHistory/ApprovedItemCurationHistory.test.tsx
@@ -28,8 +28,8 @@ describe('The ApprovedItemCurationHistory component', () => {
     expect(screen.getByText(/schedule/i)).toBeInTheDocument();
     expect(
       screen.getByText(
-        /Note: up to ten most recent entries are displayed below/i
-      )
+        /Note: up to ten most recent entries are displayed below/i,
+      ),
     ).toBeInTheDocument();
   });
 
@@ -40,7 +40,7 @@ describe('The ApprovedItemCurationHistory component', () => {
     // this prevents the test from failing due to off by one day error depending on the time and timezone it's being run in.
     // keeps it consistent now with local dev machines timezones and CI server timezone
     const addedToCorpusDate = DateTime.fromSeconds(item.createdAt).toFormat(
-      'MMMM dd, yyyy'
+      'MMMM dd, yyyy',
     );
 
     expect(screen.getByText(/recommendation/i)).toBeInTheDocument();

--- a/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.test.tsx
+++ b/src/curated-corpus/components/ApprovedItemForm/ApprovedItemForm.test.tsx
@@ -64,7 +64,7 @@ describe('The ApprovedItemForm component', () => {
             />
           </SnackbarProvider>
         </ThemeProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     const url = screen.getByLabelText(/Item URL/);
@@ -139,7 +139,7 @@ describe('The ApprovedItemForm component', () => {
             />
           </SnackbarProvider>
         </ThemeProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     //This is fetching the 'Update Image' text in the ImageUpload component
@@ -161,7 +161,7 @@ describe('The ApprovedItemForm component', () => {
             />
           </SnackbarProvider>
         </ThemeProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     const saveButton = screen.getByText(/Save/);
@@ -186,7 +186,7 @@ describe('The ApprovedItemForm component', () => {
               />
             </SnackbarProvider>
           </ThemeProvider>
-        </MockedProvider>
+        </MockedProvider>,
       );
 
       const title = screen.getByLabelText(/Title/);
@@ -214,7 +214,7 @@ describe('The ApprovedItemForm component', () => {
               />
             </SnackbarProvider>
           </ThemeProvider>
-        </MockedProvider>
+        </MockedProvider>,
       );
 
       const title = screen.getByLabelText(/Title/);
@@ -266,7 +266,7 @@ describe('The ApprovedItemForm component', () => {
               />
             </SnackbarProvider>
           </ThemeProvider>
-        </MockedProvider>
+        </MockedProvider>,
       );
 
       // fetch the update image button
@@ -278,7 +278,7 @@ describe('The ApprovedItemForm component', () => {
 
       // get the input html element for us to upload the file
       const imageUploadInput = await screen.findByTestId(
-        'curated-corpus-image-upload-input'
+        'curated-corpus-image-upload-input',
       );
 
       // upload the test file by executing an upload event
@@ -298,7 +298,7 @@ describe('The ApprovedItemForm component', () => {
 
       // fetch the imageUrl field that is on the form
       const imageUrlField = (await screen.findByLabelText(
-        'imageUrl'
+        'imageUrl',
       )) as HTMLInputElement;
 
       await waitFor(() => {
@@ -323,7 +323,7 @@ describe('The ApprovedItemForm component', () => {
               />
             </SnackbarProvider>
           </ThemeProvider>
-        </MockedProvider>
+        </MockedProvider>,
       );
 
       const saveButton = screen.getByRole('button', {
@@ -351,7 +351,7 @@ describe('The ApprovedItemForm component', () => {
               />
             </SnackbarProvider>
           </ThemeProvider>
-        </MockedProvider>
+        </MockedProvider>,
       );
 
       const saveButton = screen.getByRole('button', {

--- a/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.test.tsx
+++ b/src/curated-corpus/components/ApprovedItemListCard/ApprovedItemListCard.test.tsx
@@ -19,7 +19,7 @@ describe('The ApprovedItemListCard component', () => {
         <ThemeProvider theme={theme}>
           <ApprovedItemListCard item={item} />
         </ThemeProvider>
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // The photo is present and the alt text is the item title
@@ -44,7 +44,7 @@ describe('The ApprovedItemListCard component', () => {
         <ThemeProvider theme={theme}>
           <ApprovedItemListCard item={item} />
         </ThemeProvider>
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // Shows 'Recommendation' status for a recommended story -
@@ -65,7 +65,7 @@ describe('The ApprovedItemListCard component', () => {
         <ThemeProvider theme={theme}>
           <ApprovedItemListCard item={item} />
         </ThemeProvider>
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.getByText(/^de$/i)).toBeInTheDocument();
@@ -77,7 +77,7 @@ describe('The ApprovedItemListCard component', () => {
         <ThemeProvider theme={theme}>
           <ApprovedItemListCard item={item} />
         </ThemeProvider>
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.getByText('Health & Fitness')).toBeInTheDocument();
@@ -89,7 +89,7 @@ describe('The ApprovedItemListCard component', () => {
         <ThemeProvider theme={theme}>
           <ApprovedItemListCard item={item} />
         </ThemeProvider>
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.getByText(item.excerpt)).toBeInTheDocument();
@@ -101,7 +101,7 @@ describe('The ApprovedItemListCard component', () => {
         <ThemeProvider theme={theme}>
           <ApprovedItemListCard item={item} />
         </ThemeProvider>
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.queryByText(/collection/i)).not.toBeInTheDocument();
@@ -122,7 +122,7 @@ describe('The ApprovedItemListCard component', () => {
         <ThemeProvider theme={theme}>
           <ApprovedItemListCard item={item} />
         </ThemeProvider>
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.getByText(/collection/i)).toBeInTheDocument();
@@ -136,7 +136,7 @@ describe('The ApprovedItemListCard component', () => {
         <ThemeProvider theme={theme}>
           <ApprovedItemListCard item={item} />
         </ThemeProvider>
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.getByText(flattenAuthors(item.authors))).toBeInTheDocument();
@@ -153,7 +153,7 @@ describe('The ApprovedItemListCard component', () => {
         <ThemeProvider theme={theme}>
           <ApprovedItemListCard item={item} />
         </ThemeProvider>
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.getByText('Agatha Christie')).toBeInTheDocument();
@@ -183,7 +183,7 @@ describe('The ApprovedItemListCard component', () => {
         <ThemeProvider theme={theme}>
           <ApprovedItemListCard item={item} />
         </ThemeProvider>
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // fetch the view recently scheduled button

--- a/src/curated-corpus/components/ApprovedItemModal/ApprovedItemModal.test.tsx
+++ b/src/curated-corpus/components/ApprovedItemModal/ApprovedItemModal.test.tsx
@@ -30,7 +30,7 @@ describe('The ApprovedItemModal component', () => {
             showItemTitle={showItemTitle}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // fetch and assert the modal is rendered correctly with its Heading
@@ -53,7 +53,7 @@ describe('The ApprovedItemModal component', () => {
             onImageSave={onImageSave}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // assert the modal is not rendered a heading

--- a/src/curated-corpus/components/ApprovedItemSearchForm/ApprovedItemSearchForm.test.tsx
+++ b/src/curated-corpus/components/ApprovedItemSearchForm/ApprovedItemSearchForm.test.tsx
@@ -81,7 +81,7 @@ describe('The CuratedItemSearchForm component', () => {
       userEvent.click(searchButton);
     });
     expect(
-      screen.getByText('Please enter at least two characters.')
+      screen.getByText('Please enter at least two characters.'),
     ).toBeInTheDocument();
     expect(handleSubmit).not.toHaveBeenCalled();
 
@@ -94,7 +94,7 @@ describe('The CuratedItemSearchForm component', () => {
     });
 
     expect(
-      screen.getByText('Please enter at least two characters.')
+      screen.getByText('Please enter at least two characters.'),
     ).toBeInTheDocument();
     expect(handleSubmit).not.toHaveBeenCalled();
 

--- a/src/curated-corpus/components/DuplicateProspectModal/DuplicateProspectModal.test.tsx
+++ b/src/curated-corpus/components/DuplicateProspectModal/DuplicateProspectModal.test.tsx
@@ -22,7 +22,7 @@ describe('The DuplicateProspectModal component', () => {
             toggleModal={toggleModal}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // fetch the modal by its heading and assert it rendered
@@ -34,12 +34,12 @@ describe('The DuplicateProspectModal component', () => {
 
     // fetch modal body text and assert it rendered
     expect(
-      screen.getByText(/this item is already in the corpus/i)
+      screen.getByText(/this item is already in the corpus/i),
     ).toBeInTheDocument();
 
     // fetch the view item curation history button assert it rendered
     expect(
-      screen.getByRole('button', { name: /view item curation history/i })
+      screen.getByRole('button', { name: /view item curation history/i }),
     ).toBeInTheDocument();
 
     // fetch the cancel button assert it rendered
@@ -56,7 +56,7 @@ describe('The DuplicateProspectModal component', () => {
             toggleModal={toggleModal}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     const viewCurationHistoryButton = screen.getByRole('button', {

--- a/src/curated-corpus/components/ImageUpload/ImageUpload.test.tsx
+++ b/src/curated-corpus/components/ImageUpload/ImageUpload.test.tsx
@@ -56,7 +56,7 @@ describe('The ImageUpload component', () => {
             />
           </SnackbarProvider>
         </ThemeProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     const updateImageButton = screen.getByRole('button', {
@@ -70,12 +70,12 @@ describe('The ImageUpload component', () => {
 
     // get the input html element for us to upload the file
     const imageUploadInput = await screen.findByTestId(
-      'curated-corpus-image-upload-input'
+      'curated-corpus-image-upload-input',
     );
 
     // get the drop zone element
     const dropZone = await screen.findByText(
-      /Drag and drop an image here, or click to select one/i
+      /Drag and drop an image here, or click to select one/i,
     );
 
     // assert that input html element is rendered
@@ -102,7 +102,7 @@ describe('The ImageUpload component', () => {
             />
           </SnackbarProvider>
         </ThemeProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     const updateImageButton = screen.getByRole('button', {
@@ -112,7 +112,7 @@ describe('The ImageUpload component', () => {
     userEvent.click(updateImageButton);
 
     const imageUploadInput = await screen.findByTestId(
-      'curated-corpus-image-upload-input'
+      'curated-corpus-image-upload-input',
     );
 
     // upload the test file by executing an upload event
@@ -126,24 +126,24 @@ describe('The ImageUpload component', () => {
 
     // fetch the file attributes when they get rendered
     const fileName = (await screen.findByText(
-      /name:/i
+      /name:/i,
     )) as HTMLParagraphElement;
     const fileSize = (await screen.findByText(
-      /size:/i
+      /size:/i,
     )) as HTMLParagraphElement;
     const fileType = (await screen.findByText(
-      /type:/i
+      /type:/i,
     )) as HTMLParagraphElement;
 
     // assert the uploaded file attributes match our file
     expect(fileName.textContent?.replace('Name:', '').trim()).toEqual(
-      file.name
+      file.name,
     );
     expect(fileSize.textContent?.replace('Size:', '').trim()).toEqual(
-      formatFileSize(file.size)
+      formatFileSize(file.size),
     );
     expect(fileType.textContent?.replace('Type:', '').trim()).toEqual(
-      file.type
+      file.type,
     );
   });
 });

--- a/src/curated-corpus/components/NextPrevPagination/NextPrevPagination.test.tsx
+++ b/src/curated-corpus/components/NextPrevPagination/NextPrevPagination.test.tsx
@@ -11,7 +11,7 @@ describe('The NextPrevPagination component', () => {
         hasPreviousPage={true}
         loadNext={jest.fn()}
         loadPrevious={jest.fn()}
-      />
+      />,
     );
 
     const nextButton = screen.getByText(/next page/i);
@@ -28,7 +28,7 @@ describe('The NextPrevPagination component', () => {
         hasPreviousPage={false}
         loadNext={jest.fn()}
         loadPrevious={jest.fn()}
-      />
+      />,
     );
 
     const nextButton = screen.queryByText(/next page/i);
@@ -45,7 +45,7 @@ describe('The NextPrevPagination component', () => {
         hasPreviousPage={false}
         loadNext={jest.fn()}
         loadPrevious={jest.fn()}
-      />
+      />,
     );
 
     const nextButton = screen.getByText(/next page/i);
@@ -62,7 +62,7 @@ describe('The NextPrevPagination component', () => {
         hasPreviousPage={true}
         loadNext={jest.fn()}
         loadPrevious={jest.fn()}
-      />
+      />,
     );
 
     const nextButton = screen.queryByText(/next page/i);
@@ -80,7 +80,7 @@ describe('The NextPrevPagination component', () => {
         hasPreviousPage={true}
         loadNext={loadNext}
         loadPrevious={jest.fn()}
-      />
+      />,
     );
 
     const button = screen.getByText(/next page/i);
@@ -100,7 +100,7 @@ describe('The NextPrevPagination component', () => {
         hasPreviousPage={true}
         loadNext={jest.fn()}
         loadPrevious={loadPrevious}
-      />
+      />,
     );
 
     const button = screen.getByText(/previous page/i);

--- a/src/curated-corpus/components/ProspectListCard/ProspectListCard.test.tsx
+++ b/src/curated-corpus/components/ProspectListCard/ProspectListCard.test.tsx
@@ -63,7 +63,7 @@ describe('The ProspectListCard component', () => {
             parserItem={prospect.item!}
           />
         </MemoryRouter>
-      </MockedProvider>
+      </MockedProvider>,
     );
   };
 
@@ -122,7 +122,7 @@ describe('The ProspectListCard component', () => {
     renderComponent();
 
     expect(
-      screen.getByText(prospect.prospectType.toLowerCase())
+      screen.getByText(prospect.prospectType.toLowerCase()),
     ).toBeInTheDocument();
   });
 
@@ -144,7 +144,7 @@ describe('The ProspectListCard component', () => {
     renderComponent();
 
     expect(
-      screen.getByText(`${prospect.item?.timeToRead} min(s)`)
+      screen.getByText(`${prospect.item?.timeToRead} min(s)`),
     ).toBeInTheDocument();
   });
 
@@ -163,7 +163,7 @@ describe('The ProspectListCard component', () => {
     renderComponent();
 
     expect(
-      screen.queryByText(`${prospect.item?.timeToRead} min(s)`)
+      screen.queryByText(`${prospect.item?.timeToRead} min(s)`),
     ).not.toBeInTheDocument();
   });
 
@@ -176,7 +176,7 @@ describe('The ProspectListCard component', () => {
     renderComponent();
 
     expect(
-      screen.queryByText(`${prospect.item?.timeToRead} min(s)`)
+      screen.queryByText(`${prospect.item?.timeToRead} min(s)`),
     ).not.toBeInTheDocument();
   });
 
@@ -207,7 +207,7 @@ describe('The ProspectListCard component', () => {
     userEvent.click(
       screen.getByRole('button', {
         name: /Recommend/i,
-      })
+      }),
     );
 
     expect(onRecommend).toHaveBeenCalled();
@@ -219,7 +219,7 @@ describe('The ProspectListCard component', () => {
     userEvent.click(
       screen.getByRole('button', {
         name: /Reject/i,
-      })
+      }),
     );
 
     expect(onReject).toHaveBeenCalled();
@@ -231,7 +231,7 @@ describe('The ProspectListCard component', () => {
     userEvent.click(
       screen.getByRole('button', {
         name: /Add to corpus/i,
-      })
+      }),
     );
 
     expect(onAddToCorpus).toHaveBeenCalled();

--- a/src/curated-corpus/components/ProspectPublisherFilter/ProspectPublisherFilter.test.tsx
+++ b/src/curated-corpus/components/ProspectPublisherFilter/ProspectPublisherFilter.test.tsx
@@ -23,7 +23,7 @@ describe('The ProspectPublisherFilter component', () => {
         sortByPublishedDate={sortByPublishedDate}
         sortByTimeToRead={sortByTimeToRead}
         handleSortByTimeToRead={handleSortByTimeToRead}
-      />
+      />,
     );
   };
 

--- a/src/curated-corpus/components/RefreshProspectsModal/RefreshProspectsModal.test.tsx
+++ b/src/curated-corpus/components/RefreshProspectsModal/RefreshProspectsModal.test.tsx
@@ -10,12 +10,12 @@ describe('The RefreshProspectsModal component', () => {
         isOpen={true}
         onConfirm={jest.fn()}
         toggleModal={jest.fn()}
-      />
+      />,
     );
 
     expect(screen.getByText(/refresh prospects/i)).toBeInTheDocument();
     expect(
-      screen.getByText(/there are still some prospects remaining on the page/i)
+      screen.getByText(/there are still some prospects remaining on the page/i),
     ).toBeInTheDocument();
   });
 
@@ -25,7 +25,7 @@ describe('The RefreshProspectsModal component', () => {
         isOpen={true}
         onConfirm={jest.fn()}
         toggleModal={jest.fn()}
-      />
+      />,
     );
 
     expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument();
@@ -40,7 +40,7 @@ describe('The RefreshProspectsModal component', () => {
         isOpen={true}
         onConfirm={onConfirm}
         toggleModal={jest.fn()}
-      />
+      />,
     );
 
     userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
@@ -56,7 +56,7 @@ describe('The RefreshProspectsModal component', () => {
         isOpen={true}
         onConfirm={jest.fn()}
         toggleModal={toggleModal}
-      />
+      />,
     );
 
     userEvent.click(screen.getByRole('button', { name: 'Cancel' }));

--- a/src/curated-corpus/components/RejectItemForm/RejectItemForm.test.tsx
+++ b/src/curated-corpus/components/RejectItemForm/RejectItemForm.test.tsx
@@ -35,7 +35,7 @@ describe('The RejectItemForm component', () => {
     });
 
     const errorMessage = screen.getByText(
-      /Please specify at least one rejection reason./i
+      /Please specify at least one rejection reason./i,
     );
     expect(errorMessage).toBeInTheDocument();
     expect(handleSubmit).not.toHaveBeenCalled();

--- a/src/curated-corpus/components/RejectItemModal/RejectItemModal.test.tsx
+++ b/src/curated-corpus/components/RejectItemModal/RejectItemModal.test.tsx
@@ -24,12 +24,14 @@ describe('The RejectItemModal component', () => {
         isOpen={true}
         onSave={onSave}
         toggleModal={toggleModal}
-      />
+      />,
     );
 
     // fetch the modal's heading and assert it renders successfully
     expect(
-      screen.getByText(/reject this item from inclusion in the curated corpus/i)
+      screen.getByText(
+        /reject this item from inclusion in the curated corpus/i,
+      ),
     ).toBeInTheDocument();
   });
 });

--- a/src/curated-corpus/components/RejectedItemListCard/RejectedItemListCard.test.tsx
+++ b/src/curated-corpus/components/RejectedItemListCard/RejectedItemListCard.test.tsx
@@ -29,7 +29,7 @@ describe('The RejectedItemListCard component', () => {
     render(
       <MemoryRouter>
         <RejectedItemListCard item={rejectedItem} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // The link to the rejected item page is present and is well-formed
@@ -37,7 +37,7 @@ describe('The RejectedItemListCard component', () => {
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute(
       'href',
-      expect.stringContaining(rejectedItem.url)
+      expect.stringContaining(rejectedItem.url),
     );
     // The link also opens in a new tab
     expect(link).toHaveAttribute('target', expect.stringContaining('_blank'));
@@ -47,7 +47,7 @@ describe('The RejectedItemListCard component', () => {
     render(
       <MemoryRouter>
         <RejectedItemListCard item={rejectedItem} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.getByText(rejectedItem.language!)).toBeInTheDocument();
@@ -57,7 +57,7 @@ describe('The RejectedItemListCard component', () => {
     render(
       <MemoryRouter>
         <RejectedItemListCard item={rejectedItem} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.getByText(rejectedItem.reason)).toBeInTheDocument();
@@ -67,7 +67,7 @@ describe('The RejectedItemListCard component', () => {
     render(
       <MemoryRouter>
         <RejectedItemListCard item={rejectedItem} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.getByText(rejectedItem.createdBy)).toBeInTheDocument();
@@ -77,7 +77,7 @@ describe('The RejectedItemListCard component', () => {
     render(
       <MemoryRouter>
         <RejectedItemListCard item={rejectedItem} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.getByText(rejectedItem.topic!)).toBeInTheDocument();
@@ -87,7 +87,7 @@ describe('The RejectedItemListCard component', () => {
     render(
       <MemoryRouter>
         <RejectedItemListCard item={rejectedItem} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.getByText(rejectedItem.publisher!)).toBeInTheDocument();
@@ -105,7 +105,7 @@ describe('The RejectedItemListCard component', () => {
     render(
       <MemoryRouter>
         <RejectedItemListCard item={rejectedItem} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     const placeholders = screen.getAllByText('N/A');

--- a/src/curated-corpus/components/RejectedItemSearchForm/RejectedtemSearchForm.test.tsx
+++ b/src/curated-corpus/components/RejectedItemSearchForm/RejectedtemSearchForm.test.tsx
@@ -75,7 +75,7 @@ describe('The RejectedItemSearchForm component', () => {
       userEvent.click(searchButton);
     });
     expect(
-      screen.getByText('Please enter at least two characters.')
+      screen.getByText('Please enter at least two characters.'),
     ).toBeInTheDocument();
     expect(handleSubmit).not.toHaveBeenCalled();
 
@@ -88,7 +88,7 @@ describe('The RejectedItemSearchForm component', () => {
     });
 
     expect(
-      screen.getByText('Please enter at least two characters.')
+      screen.getByText('Please enter at least two characters.'),
     ).toBeInTheDocument();
     expect(handleSubmit).not.toHaveBeenCalled();
 

--- a/src/curated-corpus/components/RemoveItemForm/RemoveItemForm.test.tsx
+++ b/src/curated-corpus/components/RemoveItemForm/RemoveItemForm.test.tsx
@@ -38,7 +38,7 @@ describe('The RemoveItemForm component', () => {
     });
 
     const errorMessage = screen.getByText(
-      /Please choose at least one removal reason./i
+      /Please choose at least one removal reason./i,
     );
     expect(errorMessage).toBeInTheDocument();
     expect(handleSubmit).not.toHaveBeenCalled();
@@ -57,7 +57,7 @@ describe('The RemoveItemForm component', () => {
     });
 
     const errorMessage = screen.getByText(
-      /Please provide a comment for removing this item./i
+      /Please provide a comment for removing this item./i,
     );
     expect(errorMessage).toBeInTheDocument();
     expect(handleSubmit).not.toHaveBeenCalled();
@@ -87,7 +87,7 @@ describe('The RemoveItemForm component', () => {
     });
 
     const errorMessage = screen.getByText(
-      /Please select the "Other" reason checkbox./i
+      /Please select the "Other" reason checkbox./i,
     );
     expect(errorMessage).toBeInTheDocument();
     expect(handleSubmit).not.toHaveBeenCalled();
@@ -116,7 +116,7 @@ describe('The RemoveItemForm component', () => {
     });
 
     const errorMessage = screen.getByText(
-      /Please provide a comment for removing this item./i
+      /Please provide a comment for removing this item./i,
     );
     expect(errorMessage).toBeInTheDocument();
     expect(handleSubmit).not.toHaveBeenCalled();
@@ -158,7 +158,7 @@ describe('The RemoveItemForm component', () => {
     expect(handleSubmit).toHaveBeenCalled();
     // error message
     const errorMessage = screen.queryByText(
-      /Please choose at least one removal reason./i
+      /Please choose at least one removal reason./i,
     );
     // check that error message is not in the form
     expect(errorMessage).not.toBeInTheDocument();

--- a/src/curated-corpus/components/RemoveItemFromScheduledSurfaceForm/RemoveItemFromScheduledSurfaceForm.test.tsx
+++ b/src/curated-corpus/components/RemoveItemFromScheduledSurfaceForm/RemoveItemFromScheduledSurfaceForm.test.tsx
@@ -11,7 +11,7 @@ describe('The RemoveItemFromScheduledSurfaceForm component', () => {
       <RemoveItemFromScheduledSurfaceForm
         onSubmit={handleSubmit}
         title="This is a test"
-      />
+      />,
     );
 
     // there is at least a form and nothing falls over
@@ -24,7 +24,7 @@ describe('The RemoveItemFromScheduledSurfaceForm component', () => {
       <RemoveItemFromScheduledSurfaceForm
         onSubmit={handleSubmit}
         title="This is a test"
-      />
+      />,
     );
 
     const checkboxes = screen.getAllByRole('checkbox');
@@ -42,7 +42,7 @@ describe('The RemoveItemFromScheduledSurfaceForm component', () => {
       <RemoveItemFromScheduledSurfaceForm
         onSubmit={handleSubmit}
         title="This is a test"
-      />
+      />,
     );
 
     await waitFor(() => {
@@ -50,7 +50,7 @@ describe('The RemoveItemFromScheduledSurfaceForm component', () => {
     });
 
     const errorMessage = screen.getByText(
-      /Please confirm your intention to remove this item./i
+      /Please confirm your intention to remove this item./i,
     );
     expect(errorMessage).toBeInTheDocument();
     expect(handleSubmit).not.toHaveBeenCalled();
@@ -61,7 +61,7 @@ describe('The RemoveItemFromScheduledSurfaceForm component', () => {
       <RemoveItemFromScheduledSurfaceForm
         onSubmit={handleSubmit}
         title="This is a test"
-      />
+      />,
     );
 
     const checkbox = screen.getByRole('checkbox');

--- a/src/curated-corpus/components/RemoveItemFromScheduledSurfaceModal/RemoveItemFromScheduledSurfaceModal.test.tsx
+++ b/src/curated-corpus/components/RemoveItemFromScheduledSurfaceModal/RemoveItemFromScheduledSurfaceModal.test.tsx
@@ -43,7 +43,7 @@ describe('The RemoveItemFromScheduledSurfaceModal component', () => {
         isOpen={isOpen}
         onSave={onSave}
         toggleModal={toggleModal}
-      />
+      />,
     );
 
     // fetching the modal heading and asserting it renders
@@ -53,7 +53,7 @@ describe('The RemoveItemFromScheduledSurfaceModal component', () => {
     expect(screen.getByRole('form')).toBeInTheDocument();
     // check for the item title
     const itemTitle = screen.getByText(
-      /How To Win Friends And Influence People with React/i
+      /How To Win Friends And Influence People with React/i,
     );
     expect(itemTitle).toBeInTheDocument();
     // check that one of the reasons is present (this indicates that the removal reason form is rendered)
@@ -67,12 +67,12 @@ describe('The RemoveItemFromScheduledSurfaceModal component', () => {
         isOpen={isOpen}
         onSave={onSave}
         toggleModal={toggleModal}
-      />
+      />,
     );
 
     // fetching the modal heading and asserting it renders
     expect(
-      screen.getByText(/remove this item from this scheduled surface/i)
+      screen.getByText(/remove this item from this scheduled surface/i),
     ).toBeInTheDocument();
 
     // fetch and assert the RemoveItemFromScheduleSurfaceForm component is rendered within this component
@@ -88,7 +88,7 @@ describe('The RemoveItemFromScheduledSurfaceModal component', () => {
         isOpen={isOpen}
         onSave={onSave}
         toggleModal={toggleModal}
-      />
+      />,
     );
 
     // fetch the checkbox and button elements
@@ -116,7 +116,7 @@ describe('The RemoveItemFromScheduledSurfaceModal component', () => {
         isOpen={isOpen}
         onSave={onSave}
         toggleModal={toggleModal}
-      />
+      />,
     );
 
     const errorMessage = `Yes, I want to remove ${pocketHitsItem.approvedItem.title} from this scheduled surface`;
@@ -134,7 +134,7 @@ describe('The RemoveItemFromScheduledSurfaceModal component', () => {
 
     // assert that the error message is shown
     expect(
-      await waitFor(() => screen.findByLabelText(errorMessage))
+      await waitFor(() => screen.findByLabelText(errorMessage)),
     ).toBeInTheDocument();
 
     // assert that onSave callback was not called

--- a/src/curated-corpus/components/ScheduleHistory/ScheduleHistory.test.tsx
+++ b/src/curated-corpus/components/ScheduleHistory/ScheduleHistory.test.tsx
@@ -13,7 +13,7 @@ describe('The ScheduleHistory component', () => {
         <ThemeProvider theme={theme}>
           <ScheduleHistory data={[]} />
         </ThemeProvider>
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // the button when clicked shows us the recent scheduled runs

--- a/src/curated-corpus/components/ScheduleHistoryEntries/ScheduleHistoryEntries.test.tsx
+++ b/src/curated-corpus/components/ScheduleHistoryEntries/ScheduleHistoryEntries.test.tsx
@@ -30,21 +30,21 @@ describe('The ScheduleHistoryEntries component', () => {
 
   it('should render two recent scheduled run items', async () => {
     render(
-      <ScheduleHistoryEntries data={approvedItemScheduleSurfaceHistory} />
+      <ScheduleHistoryEntries data={approvedItemScheduleSurfaceHistory} />,
     );
 
     // fetch details for the first scheduled run item below
     const firstScheduledRunCurator = screen.getByText(
       `${getCuratorNameFromLdap(
-        approvedItemScheduleSurfaceHistory[0].createdBy
-      )}`
+        approvedItemScheduleSurfaceHistory[0].createdBy,
+      )}`,
     );
     const firstScheduledRunDate = screen.getByText('August 1, 2022');
 
     const firstScheduledRunSurface = screen.getByText(
       `${getScheduledSurfaceName(
-        approvedItemScheduleSurfaceHistory[0].scheduledSurfaceGuid
-      )}`
+        approvedItemScheduleSurfaceHistory[0].scheduledSurfaceGuid,
+      )}`,
     );
 
     // assert that the first scheduled run item was rendered
@@ -55,15 +55,15 @@ describe('The ScheduleHistoryEntries component', () => {
     // fetch details for the second scheduled run item below
     const secondScheduledRunCurator = screen.getByText(
       `${getCuratorNameFromLdap(
-        approvedItemScheduleSurfaceHistory[1].createdBy
-      )}`
+        approvedItemScheduleSurfaceHistory[1].createdBy,
+      )}`,
     );
     const secondScheduledRunDate = screen.getByText('August 2, 2022');
 
     const secondScheduledRunSurface = screen.getByText(
       `${getScheduledSurfaceName(
-        approvedItemScheduleSurfaceHistory[1].scheduledSurfaceGuid
-      )}`
+        approvedItemScheduleSurfaceHistory[1].scheduledSurfaceGuid,
+      )}`,
     );
 
     // assert that the second scheduled run item was rendered

--- a/src/curated-corpus/components/ScheduleHistoryModal/ScheduleHistoryModal.test.tsx
+++ b/src/curated-corpus/components/ScheduleHistoryModal/ScheduleHistoryModal.test.tsx
@@ -42,7 +42,7 @@ describe('The ScheduleHistoryModal component', () => {
             toggleModal={toggleModal}
           />
         </ThemeProvider>
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // assert that title has rendered

--- a/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.test.tsx
+++ b/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.test.tsx
@@ -38,7 +38,7 @@ describe('The ScheduleItemForm component', () => {
         onSubmit={handleSubmit}
         scheduledSurfaces={scheduledSurfaces}
         approvedItemExternalId={'123abc'}
-      />
+      />,
     );
 
     // there is at least a form and nothing falls over
@@ -54,7 +54,7 @@ describe('The ScheduleItemForm component', () => {
         onSubmit={handleSubmit}
         scheduledSurfaces={scheduledSurfaces}
         approvedItemExternalId={'123abc'}
-      />
+      />,
     );
 
     const buttons = screen.getAllByRole('button');
@@ -74,11 +74,11 @@ describe('The ScheduleItemForm component', () => {
         onSubmit={handleSubmit}
         scheduledSurfaces={scheduledSurfaces}
         approvedItemExternalId={'123abc'}
-      />
+      />,
     );
 
     const select = screen.getByLabelText(
-      'Choose a Scheduled Surface'
+      'Choose a Scheduled Surface',
     ) as HTMLSelectElement;
 
     // there should be an empty option and a single scheduled surface option
@@ -100,11 +100,11 @@ describe('The ScheduleItemForm component', () => {
           scheduledSurfaceGuid="NEW_TAB_EN_US"
           approvedItemExternalId={'123abc'}
         />
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     const select = screen.getByLabelText(
-      'Choose a Scheduled Surface'
+      'Choose a Scheduled Surface',
     ) as HTMLSelectElement;
 
     // there should be an empty option and a single scheduled surface option
@@ -126,11 +126,11 @@ describe('The ScheduleItemForm component', () => {
           scheduledSurfaces={[scheduledSurfaces[0]]}
           approvedItemExternalId={'123abc'}
         />
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     const select = screen.getByLabelText(
-      'Choose a Scheduled Surface'
+      'Choose a Scheduled Surface',
     ) as HTMLSelectElement;
 
     // there should be an empty option and a single scheduled surface option
@@ -151,7 +151,7 @@ describe('The ScheduleItemForm component', () => {
           scheduledSurfaces={[scheduledSurfaces[0]]}
           approvedItemExternalId={'123abc'}
         />
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     await waitFor(() => {
@@ -175,7 +175,7 @@ describe('The ScheduleItemForm component', () => {
           approvedItemExternalId={'123abc'}
           showManualScheduleReasons={true}
         />
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     await waitFor(() => {
@@ -199,7 +199,7 @@ describe('The ScheduleItemForm component', () => {
           approvedItemExternalId={'123abc'}
           showManualScheduleReasons={true}
         />
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     await waitFor(() => {
@@ -207,7 +207,7 @@ describe('The ScheduleItemForm component', () => {
     });
 
     const errorMessage = screen.getByText(
-      /Please choose at least one reason to schedule this item manually./i
+      /Please choose at least one reason to schedule this item manually./i,
     );
     expect(errorMessage).toBeVisible();
     expect(handleSubmit).not.toHaveBeenCalled();
@@ -226,7 +226,7 @@ describe('The ScheduleItemForm component', () => {
           showManualScheduleReasons={true}
           expandSummary={true}
         />
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // Wait for the summary to load, then expect to see the main headings
@@ -251,7 +251,7 @@ describe('The ScheduleItemForm component', () => {
           showManualScheduleReasons={true}
           expandSummary={false}
         />
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // Wait for the summary to load, then expect to see the main headings
@@ -279,7 +279,7 @@ describe('The ScheduleItemForm component', () => {
           approvedItemExternalId={'123abc'}
           showManualScheduleReasons={true}
         />
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     const chosenReason = screen.getByLabelText(/under the radar/i);

--- a/src/curated-corpus/components/ScheduleItemFormConnector/ScheduleItemFormConnector.test.tsx
+++ b/src/curated-corpus/components/ScheduleItemFormConnector/ScheduleItemFormConnector.test.tsx
@@ -26,7 +26,7 @@ describe('ScheduleItemFormConnector', () => {
             onSubmit={jest.fn()}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // Wait for the form to load, as it needs to fetch a list of surfaces
@@ -35,7 +35,7 @@ describe('ScheduleItemFormConnector', () => {
 
     // Get the dropdown with available scheduled surfaces
     const surfaceSelect = screen.getByLabelText(
-      /choose a scheduled surface/i
+      /choose a scheduled surface/i,
     ) as HTMLSelectElement;
 
     const scheduledSurfaceValues = [
@@ -69,7 +69,7 @@ describe('ScheduleItemFormConnector', () => {
             onSubmit={jest.fn()}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // Wait for the form to load, as it needs to fetch a list of surfaces
@@ -78,7 +78,7 @@ describe('ScheduleItemFormConnector', () => {
 
     // Get the dropdown with available scheduled surfaces
     const surfaceSelect = screen.getByLabelText(
-      /choose a scheduled surface/i
+      /choose a scheduled surface/i,
     ) as HTMLSelectElement;
 
     const scheduledSurfaceValues = ['NEW_TAB_EN_US', 'NEW_TAB_DE_DE'];
@@ -104,7 +104,7 @@ describe('ScheduleItemFormConnector', () => {
             onSubmit={jest.fn()}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // Wait for the form to load, as it needs to fetch a list of surfaces
@@ -113,7 +113,7 @@ describe('ScheduleItemFormConnector', () => {
 
     // Get the dropdown with available scheduled surfaces
     const surfaceSelect = screen.getByLabelText(
-      /choose a scheduled surface/i
+      /choose a scheduled surface/i,
     ) as HTMLSelectElement;
 
     const scheduledSurfaceValues = ['POCKET_HITS_EN_US'];
@@ -137,7 +137,7 @@ describe('ScheduleItemFormConnector', () => {
             onSubmit={jest.fn()}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // Wait for the form to load, as it needs to fetch a list of surfaces
@@ -146,7 +146,7 @@ describe('ScheduleItemFormConnector', () => {
 
     // Get the dropdown with available scheduled surfaces
     const surfaceSelect = screen.getByLabelText(
-      /choose a scheduled surface/i
+      /choose a scheduled surface/i,
     ) as HTMLSelectElement;
 
     // Select a scheduled surface

--- a/src/curated-corpus/components/ScheduleItemModal/ScheduleItemModal.test.tsx
+++ b/src/curated-corpus/components/ScheduleItemModal/ScheduleItemModal.test.tsx
@@ -22,7 +22,7 @@ describe('ScheduleItemModal', () => {
       headingCopy?: string;
       isOpen?: boolean;
       toggleModal?: VoidFunction;
-    }
+    },
   ) => {
     render(
       <MockedProvider mocks={mocks}>
@@ -37,7 +37,7 @@ describe('ScheduleItemModal', () => {
             headingCopy={props.headingCopy ?? undefined}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
   };
 

--- a/src/curated-corpus/components/ScheduleSummaryConnector/ScheduleSummaryConnector.test.tsx
+++ b/src/curated-corpus/components/ScheduleSummaryConnector/ScheduleSummaryConnector.test.tsx
@@ -28,7 +28,7 @@ describe('The ScheduleSummaryConnector component', () => {
           refreshData={false}
           setRefreshData={jest.fn()}
         />
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     await waitFor(() => {
@@ -47,7 +47,7 @@ describe('The ScheduleSummaryConnector component', () => {
           refreshData={false}
           setRefreshData={jest.fn()}
         />
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     await waitFor(() => {
@@ -60,13 +60,13 @@ describe('The ScheduleSummaryConnector component', () => {
       // Let's also limit the DOM search to the topic table
       // (the second one in the component).
       expect(
-        within(tables[1]).getByText(getDisplayTopic(Topics.Politics))
+        within(tables[1]).getByText(getDisplayTopic(Topics.Politics)),
       ).toBeInTheDocument();
       expect(
-        within(tables[1]).getByText(getDisplayTopic(Topics.PersonalFinance))
+        within(tables[1]).getByText(getDisplayTopic(Topics.PersonalFinance)),
       ).toBeInTheDocument();
       expect(
-        within(tables[1]).getByText(getDisplayTopic(Topics.HealthFitness))
+        within(tables[1]).getByText(getDisplayTopic(Topics.HealthFitness)),
       ).toBeInTheDocument();
 
       // And all of these show a total of one for each topic.
@@ -83,7 +83,7 @@ describe('The ScheduleSummaryConnector component', () => {
           refreshData={false}
           setRefreshData={jest.fn()}
         />
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     await waitFor(() => {
@@ -92,12 +92,12 @@ describe('The ScheduleSummaryConnector component', () => {
 
       // Current mocks (three scheduled items) have two publishers
       expect(
-        within(tables[0]).getByText(/amazing inventions/i)
+        within(tables[0]).getByText(/amazing inventions/i),
       ).toBeInTheDocument();
       expect(within(tables[0]).getByText('2')).toBeInTheDocument();
 
       expect(
-        within(tables[0]).getByText(/fantastic computers/i)
+        within(tables[0]).getByText(/fantastic computers/i),
       ).toBeInTheDocument();
       expect(within(tables[0]).getByText('1')).toBeInTheDocument();
     });
@@ -114,12 +114,12 @@ describe('The ScheduleSummaryConnector component', () => {
           refreshData={false}
           setRefreshData={jest.fn()}
         />
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     await waitFor(() => {
       expect(
-        screen.getByText(/no stories have been scheduled for this date yet/i)
+        screen.getByText(/no stories have been scheduled for this date yet/i),
       ).toBeInTheDocument();
     });
   });

--- a/src/curated-corpus/components/ScheduleSummaryLayout/ScheduleSummaryLayout.test.tsx
+++ b/src/curated-corpus/components/ScheduleSummaryLayout/ScheduleSummaryLayout.test.tsx
@@ -24,24 +24,24 @@ describe('The ScheduleSummaryLayout component', () => {
 
     // The three scheduled items have two publishers
     expect(
-      within(publishers).getByText(/amazing inventions/i)
+      within(publishers).getByText(/amazing inventions/i),
     ).toBeInTheDocument();
     expect(within(publishers).getByText('2')).toBeInTheDocument();
 
     expect(
-      within(publishers).getByText(/fantastic computers/i)
+      within(publishers).getByText(/fantastic computers/i),
     ).toBeInTheDocument();
     expect(within(publishers).getByText('1')).toBeInTheDocument();
 
     // And there are three topics present
     expect(
-      within(topics).getByText(getDisplayTopic(Topics.Politics))
+      within(topics).getByText(getDisplayTopic(Topics.Politics)),
     ).toBeInTheDocument();
     expect(
-      within(topics).getByText(getDisplayTopic(Topics.PersonalFinance))
+      within(topics).getByText(getDisplayTopic(Topics.PersonalFinance)),
     ).toBeInTheDocument();
     expect(
-      within(topics).getByText(getDisplayTopic(Topics.HealthFitness))
+      within(topics).getByText(getDisplayTopic(Topics.HealthFitness)),
     ).toBeInTheDocument();
 
     // And all of these show a total of one for each topic.

--- a/src/curated-corpus/components/SidebarDatePicker/SidebarDatePicker.test.tsx
+++ b/src/curated-corpus/components/SidebarDatePicker/SidebarDatePicker.test.tsx
@@ -11,12 +11,12 @@ describe('SidebarDatePicker', () => {
       <SidebarDatePicker
         selectedDate={DateTime.fromFormat('2050-05-05', 'yyyy-MM-dd')}
         handleDateChange={jest.fn()}
-      ></SidebarDatePicker>
+      ></SidebarDatePicker>,
     );
 
     await waitFor(() => {
       const datePicker = screen.getByLabelText(
-        /choose a different date/i
+        /choose a different date/i,
       ) as HTMLInputElement;
 
       expect(datePicker).toBeInTheDocument();

--- a/src/curated-corpus/components/SidebarWrapper/SidebarWrapper.test.tsx
+++ b/src/curated-corpus/components/SidebarWrapper/SidebarWrapper.test.tsx
@@ -24,7 +24,7 @@ describe('The SidebarWrapper component', () => {
           setRefreshData={jest.fn()}
           setSidebarDate={jest.fn()}
         ></SidebarWrapper>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     await waitFor(() => {
@@ -32,7 +32,7 @@ describe('The SidebarWrapper component', () => {
       expect(
         // Regex because this phrase takes up two lines in the DOM
         // with extra whitespace/line break
-        screen.getByText(/scheduled for[\s\n]+?january 1, 2023/i)
+        screen.getByText(/scheduled for[\s\n]+?january 1, 2023/i),
       ).toBeInTheDocument();
     });
   });
@@ -47,12 +47,12 @@ describe('The SidebarWrapper component', () => {
           setRefreshData={jest.fn()}
           setSidebarDate={jest.fn()}
         ></SidebarWrapper>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     await waitFor(() => {
       const datePicker = screen.getByLabelText(
-        /choose a different date/i
+        /choose a different date/i,
       ) as HTMLInputElement;
 
       expect(datePicker).toBeInTheDocument();
@@ -70,7 +70,7 @@ describe('The SidebarWrapper component', () => {
           setRefreshData={jest.fn()}
           setSidebarDate={jest.fn()}
         ></SidebarWrapper>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     await waitFor(() => {

--- a/src/curated-corpus/components/SplitButton/SplitButton.test.tsx
+++ b/src/curated-corpus/components/SplitButton/SplitButton.test.tsx
@@ -28,7 +28,7 @@ describe('The SplitButton component', () => {
         icon={<FilterListIcon fontSize="large" data-testid="my-filter-icon" />}
         onMenuOptionClick={onClick}
         options={options}
-      />
+      />,
     );
 
     const icon = screen.getByTestId('my-filter-icon');

--- a/src/curated-corpus/components/SuggestedScheduleItemListCard/SuggestedScheduleItemListCard.test.tsx
+++ b/src/curated-corpus/components/SuggestedScheduleItemListCard/SuggestedScheduleItemListCard.test.tsx
@@ -28,7 +28,7 @@ describe('The SuggestedScheduleItemListCard component', () => {
         onMoveToBottom={onMoveToBottom}
         onReject={onReject}
         scheduledSurfaceGuid="NEW_TAB_EN_US"
-      />
+      />,
     );
 
     // The image is present and the alt text is the item title
@@ -59,7 +59,7 @@ describe('The SuggestedScheduleItemListCard component', () => {
         onMoveToBottom={onMoveToBottom}
         onReject={onReject}
         scheduledSurfaceGuid="NEW_TAB_EN_US"
-      />
+      />,
     );
 
     expect(screen.getByText(item.excerpt)).toBeInTheDocument();
@@ -77,7 +77,7 @@ describe('The SuggestedScheduleItemListCard component', () => {
         onMoveToBottom={onMoveToBottom}
         onReject={onReject}
         scheduledSurfaceGuid="NEW_TAB_EN_US"
-      />
+      />,
     );
 
     expect(screen.getByText(flattenAuthors(item.authors))).toBeInTheDocument();
@@ -100,7 +100,7 @@ describe('The SuggestedScheduleItemListCard component', () => {
         onMoveToBottom={onMoveToBottom}
         onReject={onReject}
         scheduledSurfaceGuid="NEW_TAB_EN_US"
-      />
+      />,
     );
 
     expect(screen.getByText('Agatha Christie')).toBeInTheDocument();

--- a/src/curated-corpus/components/actions/EditCorpusItemAction/EditCorpusItemAction.test.tsx
+++ b/src/curated-corpus/components/actions/EditCorpusItemAction/EditCorpusItemAction.test.tsx
@@ -28,7 +28,7 @@ describe('The EditCorpusItemAction', () => {
             actionScreen={ActionScreen.Corpus}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // Do we have the modal heading?
@@ -51,7 +51,7 @@ describe('The EditCorpusItemAction', () => {
             actionScreen={ActionScreen.Corpus}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // The most basic of integration tests - we simply send through
@@ -59,7 +59,7 @@ describe('The EditCorpusItemAction', () => {
     userEvent.click(screen.getByText(/save/i));
 
     expect(
-      await screen.findByText(/curated item .* successfully updated/i)
+      await screen.findByText(/curated item .* successfully updated/i),
     ).toBeInTheDocument();
   });
 
@@ -80,7 +80,7 @@ describe('The EditCorpusItemAction', () => {
             actionScreen={ActionScreen.Corpus}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // The most basic of integration tests - we simply send through
@@ -88,7 +88,7 @@ describe('The EditCorpusItemAction', () => {
     userEvent.click(screen.getByText(/save/i));
 
     expect(
-      await screen.findByText(/curated item .* successfully updated/i)
+      await screen.findByText(/curated item .* successfully updated/i),
     ).toBeInTheDocument();
   });
 

--- a/src/curated-corpus/components/actions/RejectAndUnscheduleItemAction/RejectAndUnscheduleItemAction.test.tsx
+++ b/src/curated-corpus/components/actions/RejectAndUnscheduleItemAction/RejectAndUnscheduleItemAction.test.tsx
@@ -29,7 +29,7 @@ describe('The RejectAndUnscheduleItemAction', () => {
             modalOpen={true}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // Do we have the modal heading
@@ -52,7 +52,7 @@ describe('The RejectAndUnscheduleItemAction', () => {
             modalOpen={true}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     const reason = screen.getByLabelText(/time sensitive/i);
@@ -60,7 +60,9 @@ describe('The RejectAndUnscheduleItemAction', () => {
     userEvent.click(screen.getByText(/save/i));
 
     expect(
-      await screen.findByText(/item successfully moved to the rejected corpus/i)
+      await screen.findByText(
+        /item successfully moved to the rejected corpus/i,
+      ),
     ).toBeInTheDocument();
   });
 });

--- a/src/curated-corpus/components/actions/RejectCorpusItemAction/RejectCorpusItemAction.test.tsx
+++ b/src/curated-corpus/components/actions/RejectCorpusItemAction/RejectCorpusItemAction.test.tsx
@@ -28,7 +28,7 @@ describe('The RejectCorpusItemAction', () => {
             modalOpen={true}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // Do we have the modal heading
@@ -51,7 +51,7 @@ describe('The RejectCorpusItemAction', () => {
             modalOpen={true}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     const reason = screen.getByLabelText(/time sensitive/i);
@@ -59,7 +59,9 @@ describe('The RejectCorpusItemAction', () => {
     userEvent.click(screen.getByText(/save/i));
 
     expect(
-      await screen.findByText(/item successfully moved to the rejected corpus/i)
+      await screen.findByText(
+        /item successfully moved to the rejected corpus/i,
+      ),
     ).toBeInTheDocument();
   });
 
@@ -93,7 +95,7 @@ describe('The RejectCorpusItemAction', () => {
             modalOpen={true}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     const reason = screen.getByLabelText(/time sensitive/i);
@@ -102,8 +104,8 @@ describe('The RejectCorpusItemAction', () => {
 
     expect(
       await screen.findByText(
-        /cannot remove item from approved corpus - scheduled entries exist/i
-      )
+        /cannot remove item from approved corpus - scheduled entries exist/i,
+      ),
     ).toBeInTheDocument();
   });
 });

--- a/src/curated-corpus/components/actions/RemoveProspectAction/RemoveProspectAction.test.tsx
+++ b/src/curated-corpus/components/actions/RemoveProspectAction/RemoveProspectAction.test.tsx
@@ -31,7 +31,7 @@ describe('The RemoveProspectAction', () => {
             onRemoveProspect={onRemoveProspect}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
   };
 
@@ -48,7 +48,7 @@ describe('The RemoveProspectAction', () => {
 
     // asserting that onRemoveProspect is called with the correct arguments - error message should be undefined for a successful mutation call
     await waitFor(() =>
-      expect(onRemoveProspect).toHaveBeenCalledWith(prospectId, undefined)
+      expect(onRemoveProspect).toHaveBeenCalledWith(prospectId, undefined),
     );
   });
 
@@ -73,7 +73,7 @@ describe('The RemoveProspectAction', () => {
 
     // asserting that onRemoveProspect is called with the correct arguments
     await waitFor(() =>
-      expect(onRemoveProspect).toHaveBeenCalledWith(prospectId, errorMessage)
+      expect(onRemoveProspect).toHaveBeenCalledWith(prospectId, errorMessage),
     );
   });
 });

--- a/src/curated-corpus/components/actions/ScheduleCorpusItemAction/ScheduleCorpusItemAction.test.tsx
+++ b/src/curated-corpus/components/actions/ScheduleCorpusItemAction/ScheduleCorpusItemAction.test.tsx
@@ -34,7 +34,7 @@ describe('The ScheduleCorpusItemAction', () => {
             modalOpen={true}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // Do we have the modal heading
@@ -58,7 +58,7 @@ describe('The ScheduleCorpusItemAction', () => {
       mock_AllScheduledSurfaces,
       mock_scheduledItemsWithParams(
         chosenDate.toFormat('yyyy-MM-dd'),
-        chosenSurfaceGuid
+        chosenSurfaceGuid,
       ),
       successMock(chosenDate.toFormat('yyyy-MM-dd'), chosenSurfaceGuid),
     ];
@@ -73,7 +73,7 @@ describe('The ScheduleCorpusItemAction', () => {
             modalOpen={true}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // Wait for the form to load, as it needs to fetch a list of surfaces
@@ -82,7 +82,7 @@ describe('The ScheduleCorpusItemAction', () => {
 
     // Get the dropdown with available scheduled surfaces
     const surfaceSelect = screen.getByLabelText(
-      /choose a scheduled surface/i
+      /choose a scheduled surface/i,
     ) as HTMLSelectElement;
 
     // Select a scheduled surface
@@ -113,7 +113,7 @@ describe('The ScheduleCorpusItemAction', () => {
     // Testing for the success toast notification. Omitting the date from
     // the text tested for as it has caused so many false alarms on CI.
     expect(
-      await screen.findByText(/Item scheduled successfully/i)
+      await screen.findByText(/Item scheduled successfully/i),
     ).toBeInTheDocument();
   });
 

--- a/src/curated-corpus/pages/RejectedPage/RejectedPage.test.tsx
+++ b/src/curated-corpus/pages/RejectedPage/RejectedPage.test.tsx
@@ -18,7 +18,7 @@ describe('The RejectedPage', () => {
       render(
         <MockedProvider mocks={mocks}>
           <RejectedPage />
-        </MockedProvider>
+        </MockedProvider>,
       );
     });
 
@@ -42,7 +42,7 @@ describe('The RejectedPage', () => {
   it.todo('renders rejected items with a combination of filters applied');
 
   it.todo(
-    'displays a full list of items after filtering and resetting filters'
+    'displays a full list of items after filtering and resetting filters',
   );
 
   it.todo('shows the next page of results');

--- a/src/moderation/components/ShareableListCard/ShareableListCard.test.tsx
+++ b/src/moderation/components/ShareableListCard/ShareableListCard.test.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { dateFormat, ShareableListCard } from './ShareableListCard';
 import {
-  ShareableListComplete, ShareableListModerationReason,
+  ShareableListComplete,
+  ShareableListModerationReason,
   ShareableListModerationStatus,
-  ShareableListVisibility
+  ShareableListVisibility,
 } from '../../../api/generatedTypes';
 import { DateTime } from 'luxon';
 

--- a/src/moderation/components/ShareableListFormConnector/ShareableListFormConnector.test.tsx
+++ b/src/moderation/components/ShareableListFormConnector/ShareableListFormConnector.test.tsx
@@ -30,7 +30,7 @@ describe('ShareableListFormConnector -> Hiding List', () => {
             hideList={true}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // Wait for the form to load
@@ -70,7 +70,7 @@ describe('ShareableListFormConnector -> Hiding List', () => {
             hideList={true}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // grab save button
@@ -86,7 +86,7 @@ describe('ShareableListFormConnector -> Hiding List', () => {
     });
     // should resolve in error
     expect(
-      screen.getByText('Please choose a reason for hiding this list.')
+      screen.getByText('Please choose a reason for hiding this list.'),
     ).toBeInTheDocument();
   });
 
@@ -103,7 +103,7 @@ describe('ShareableListFormConnector -> Hiding List', () => {
             hideList={true}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // grab save button
@@ -142,7 +142,7 @@ describe('ShareableListFormConnector -> Hiding List', () => {
             hideList={true}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // grab cancel button
@@ -177,7 +177,7 @@ describe('ShareableListFormConnector -> Restoring List', () => {
             restoreList={true}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // Wait for the form to load
@@ -213,7 +213,7 @@ describe('ShareableListFormConnector -> Restoring List', () => {
             restoreList={true}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // grab save button
@@ -229,7 +229,7 @@ describe('ShareableListFormConnector -> Restoring List', () => {
     });
     // should resolve in error
     expect(
-      screen.getByText('Please enter a reason for restoring this list.')
+      screen.getByText('Please enter a reason for restoring this list.'),
     ).toBeInTheDocument();
   });
 
@@ -246,7 +246,7 @@ describe('ShareableListFormConnector -> Restoring List', () => {
             restoreList={true}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // grab save button
@@ -278,7 +278,7 @@ describe('ShareableListFormConnector -> Restoring List', () => {
             restoreList={true}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // grab cancel button

--- a/src/moderation/components/ShareableListItemCard/ShareableListItemCard.test.tsx
+++ b/src/moderation/components/ShareableListItemCard/ShareableListItemCard.test.tsx
@@ -24,7 +24,7 @@ describe('The ShareableListItemCard component', () => {
     render(
       <MemoryRouter>
         <ShareableListItemCard listItem={listItem} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // The link to the story is present and well-formed
@@ -32,11 +32,11 @@ describe('The ShareableListItemCard component', () => {
     expect(linkToStory).toBeInTheDocument();
     expect(linkToStory).toHaveAttribute(
       'href',
-      expect.stringMatching(listItem.url)
+      expect.stringMatching(listItem.url),
     );
     expect(linkToStory).toHaveAttribute(
       'target',
-      expect.stringMatching('_blank')
+      expect.stringMatching('_blank'),
     );
 
     // Asserting presence of props here as most fields on a list item are optional
@@ -68,7 +68,7 @@ describe('The ShareableListItemCard component', () => {
     render(
       <MemoryRouter>
         <ShareableListItemCard listItem={itemNoProps} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // Asserting presence of props here as most fields on a list item are optional

--- a/src/moderation/components/ShareableListModal/ShareableListModal.test.tsx
+++ b/src/moderation/components/ShareableListModal/ShareableListModal.test.tsx
@@ -6,7 +6,7 @@ import { ShareableListModal } from './ShareableListModal';
 import {
   ShareableListComplete,
   ShareableListModerationStatus,
-  ShareableListVisibility
+  ShareableListVisibility,
 } from '../../../api/generatedTypes';
 
 describe('The ShareableListModal component', () => {
@@ -39,7 +39,7 @@ describe('The ShareableListModal component', () => {
             hideList={true} // this modal is in charge of moderating a list (hide), so passing flag
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // using the modal heading to fetch it
@@ -67,7 +67,7 @@ describe('The ShareableListModal component', () => {
             restoreList={true} // this modal is in charge of moderating a list (hide), so passing flag
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     // using the modal heading to fetch it

--- a/src/moderation/components/ShareableListModerationForm/ShareableListModerationForm.test.tsx
+++ b/src/moderation/components/ShareableListModerationForm/ShareableListModerationForm.test.tsx
@@ -22,7 +22,7 @@ describe('The ShareableListModerationForm component', () => {
         onCancel={onCancel}
         isLoaderShowing={false}
         shareableList={visibleList}
-      />
+      />,
     );
 
     // Check if form input and buttons are rendered
@@ -47,14 +47,14 @@ describe('The ShareableListModerationForm component', () => {
             shareableList={visibleList}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     const saveButton = screen.getByText(/save/i);
 
     userEvent.click(saveButton);
     const emptyInputError = await screen.findByText(
-      /Please choose a reason for hiding this list./i
+      /Please choose a reason for hiding this list./i,
     );
 
     expect(emptyInputError).toBeInTheDocument();
@@ -72,7 +72,7 @@ describe('The ShareableListModerationForm component', () => {
             shareableList={visibleList}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     const saveButton = screen.getByText(/save/i);
@@ -105,7 +105,7 @@ describe('The ShareableListModerationForm component', () => {
             shareableList={visibleList}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     const saveButton = screen.getByText(/save/i);
@@ -132,7 +132,7 @@ describe('The ShareableListModerationForm component', () => {
             shareableList={visibleList}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     const cancelButton = screen.getByText(/cancel/i);

--- a/src/moderation/components/ShareableListRestorationForm/ShareableListRestorationForm.test.tsx
+++ b/src/moderation/components/ShareableListRestorationForm/ShareableListRestorationForm.test.tsx
@@ -22,7 +22,7 @@ describe('The ShareableListRestorationForm component', () => {
         onCancel={onCancel}
         isLoaderShowing={false}
         shareableList={hiddenList}
-      />
+      />,
     );
 
     // Check if form input and buttons are rendered
@@ -47,14 +47,14 @@ describe('The ShareableListRestorationForm component', () => {
             shareableList={hiddenList}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     const saveButton = screen.getByText(/save/i);
 
     userEvent.click(saveButton);
     const emptyInputError = await screen.findByText(
-      /Please enter a reason for restoring this list./i
+      /Please enter a reason for restoring this list./i,
     );
 
     expect(emptyInputError).toBeInTheDocument();
@@ -72,7 +72,7 @@ describe('The ShareableListRestorationForm component', () => {
             shareableList={hiddenList}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     const saveButton = screen.getByText(/save/i);
@@ -99,7 +99,7 @@ describe('The ShareableListRestorationForm component', () => {
             shareableList={hiddenList}
           />
         </SnackbarProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     const cancelButton = screen.getByText(/cancel/i);

--- a/src/moderation/components/ShareableListsSearchForm/ShareableListsSearchForm.test.tsx
+++ b/src/moderation/components/ShareableListsSearchForm/ShareableListsSearchForm.test.tsx
@@ -19,7 +19,7 @@ describe('The ShareableListsSearchForm component', () => {
             <ShareableListsSearchForm onSubmit={onSubmit} />
           </SnackbarProvider>
         </ThemeProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     const id = screen.getByLabelText(/List ID/);
@@ -34,7 +34,7 @@ describe('The ShareableListsSearchForm component', () => {
             <ShareableListsSearchForm onSubmit={onSubmit} />
           </SnackbarProvider>
         </ThemeProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     const searchButton = screen.getByText(/Search/);
@@ -51,7 +51,7 @@ describe('The ShareableListsSearchForm component', () => {
             <ShareableListsSearchForm onSubmit={onSubmit} />
           </SnackbarProvider>
         </ThemeProvider>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     const id = screen.getByLabelText(/List ID/);


### PR DESCRIPTION
## Goal

fix local npm lint scripts

- also run lint-fix and add the fixed files

## Test Locally

pull down the latest `main` and run `npm run lint-check`. for me, this reported one error in a file in `node_modules` - which is a directory it shouldn't even check. it also does not report the errors that my fix here does.

still on the `main` branch, update the `package.json` lint scripts to match the ones in this PR and run them. you should get the correct output (like 80 files needing fixing).

## Implementation Decisions

does anyone know why we were running `tsc` before the lint scripts? why would we need to compile to only lint `.ts(x)` files?

also - unclear why the files caught _here_ are no being caught by the github linter. other repositories are experiencing similar local/github linting discrepancies - wonder if some downstream package got changed...