### PR TITLE
feat(scheduling): MC-1273, MC-1274 Add 'ML-Scheduled' to filters and scheduled item card

### DIFF
--- a/src/_shared/components/CorpusItemCardImage/CorpusItemCardImage.test.tsx
+++ b/src/_shared/components/CorpusItemCardImage/CorpusItemCardImage.test.tsx
@@ -87,6 +87,22 @@ describe('The CorpusItemCardImage component', () => {
     expect(screen.getByText(/syndicated/i)).toBeInTheDocument();
   });
 
+  it('should render ML-syndicated label if item is both ML-scheduled and syndicated', () => {
+    const syndicatedItem = { ...item, isSyndicated: true };
+
+    render(
+      <CorpusItemCardImage
+        item={syndicatedItem}
+        isMlScheduled={true}
+        currentScheduledDate={currentScheduledDate}
+        scheduledSurfaceGuid="NEW_TAB_EN_US"
+        toggleScheduleHistoryModal={toggleScheduleHistoryModal}
+      />,
+    );
+
+    expect(screen.getByText(/ML-syndicated/i)).toBeInTheDocument();
+  });
+
   it('should render last scheduled label if item has this prop', () => {
     item = {
       ...item,

--- a/src/_shared/components/CorpusItemCardImage/CorpusItemCardImage.tsx
+++ b/src/_shared/components/CorpusItemCardImage/CorpusItemCardImage.tsx
@@ -79,7 +79,9 @@ const getTopRightLabel = (
     return (
       <>
         <AutoFixHighOutlinedIcon fontSize="small" />
-        <Typography variant="caption">ML</Typography>
+        <Typography variant="caption">
+          {item.isSyndicated ? 'ML-Syndicated' : 'ML'}
+        </Typography>
       </>
     );
   }

--- a/src/curated-corpus/components/ScheduleDayData/ScheduleDayData.tsx
+++ b/src/curated-corpus/components/ScheduleDayData/ScheduleDayData.tsx
@@ -163,6 +163,9 @@ export const ScheduleDayData: React.FC<ScheduleDayDataProps> = (
                 filters.publishers === item.approvedItem.publisher ||
                 (filters.types === 'Ml' &&
                   item.source === ScheduledItemSource.Ml) ||
+                (filters.types == 'ML-Syndicated' &&
+                  item.source === ScheduledItemSource.Ml &&
+                  item.approvedItem.isSyndicated) ||
                 (filters.types === 'Collections' &&
                   item.approvedItem.isCollection) ||
                 (filters.types === 'Syndicated' &&

--- a/src/curated-corpus/components/ScheduleDayFilterRow/ScheduleDayFilterRow.tsx
+++ b/src/curated-corpus/components/ScheduleDayFilterRow/ScheduleDayFilterRow.tsx
@@ -67,6 +67,14 @@ export const ScheduleDayFilterRow: React.FC<ScheduleDayFilterRowProps> = (
       ).length,
     },
     {
+      name: 'ML-Syndicated',
+      count: scheduledItems.filter(
+        (item) =>
+          item.source === ScheduledItemSource.Ml &&
+          item.approvedItem.isSyndicated,
+      ).length,
+    },
+    {
       name: 'Syndicated',
       count: scheduledItems.filter((item) => item.approvedItem.isSyndicated)
         .length,

--- a/src/curated-corpus/components/ScheduleDayFilterRow/ScheduleDayFilterRow.tsx
+++ b/src/curated-corpus/components/ScheduleDayFilterRow/ScheduleDayFilterRow.tsx
@@ -61,9 +61,13 @@ export const ScheduleDayFilterRow: React.FC<ScheduleDayFilterRowProps> = (
   // Round up all the different types of scheduled items we're interested in
   const typeList = [
     {
+      // For ML items, exclude ML-scheduled items that are also syndicated
+      // (these are shown in the next filter option, "ML-Syndicated")
       name: 'Ml',
       count: scheduledItems.filter(
-        (item) => item.source === ScheduledItemSource.Ml,
+        (item) =>
+          item.source === ScheduledItemSource.Ml &&
+          !item.approvedItem.isSyndicated,
       ).length,
     },
     {

--- a/src/curated-corpus/components/ScheduleDayHeading/ScheduleDayHeading.tsx
+++ b/src/curated-corpus/components/ScheduleDayHeading/ScheduleDayHeading.tsx
@@ -5,10 +5,7 @@ import { ScheduleDayFilterOptions, ScheduleDayFilterRow } from '../';
 import AddIcon from '@mui/icons-material/Add';
 import { curationPalette } from '../../../theme';
 import { DateTime } from 'luxon';
-import {
-  ScheduledCorpusItemsResult,
-  ScheduledItemSource,
-} from '../../../api/generatedTypes';
+import { ScheduledCorpusItemsResult } from '../../../api/generatedTypes';
 
 interface ScheduleDayHeadingProps {
   /**
@@ -39,13 +36,6 @@ export const ScheduleDayHeading: React.FC<ScheduleDayHeadingProps> = (
 ): ReactElement => {
   const { onAddItem, data, setFilters } = props;
 
-  // Figure out how many items are both ML-scheduled and Syndicated, since
-  // it's not available from the graph as a ready-to-use data point
-  const mlSyndicatedCount = data.items.filter(
-    (item) =>
-      item.source === ScheduledItemSource.Ml && item.approvedItem.isSyndicated,
-  ).length;
-
   return (
     <>
       <Grid
@@ -58,7 +48,7 @@ export const ScheduleDayHeading: React.FC<ScheduleDayHeadingProps> = (
         <Grid item xs={12}>
           <Typography
             sx={{
-              fontSize: '1.5rem',
+              fontSize: '1.25rem',
               fontWeight: 500,
               textTransform: 'capitalize',
               color: curationPalette.pocketBlack,
@@ -67,8 +57,7 @@ export const ScheduleDayHeading: React.FC<ScheduleDayHeadingProps> = (
             {DateTime.fromFormat(data.scheduledDate, 'yyyy-MM-dd')
               .setLocale('en')
               .toLocaleString(DateTime.DATE_FULL)}{' '}
-            {` (${mlSyndicatedCount} ML-syndicated, `}
-            {`${data.syndicatedCount} syndicated, ${data.totalCount} total)`}
+            {` (${data.syndicatedCount}/${data.totalCount} syndicated)`}
           </Typography>
         </Grid>
         <Grid item xs={12}>

--- a/src/curated-corpus/components/ScheduleDayHeading/ScheduleDayHeading.tsx
+++ b/src/curated-corpus/components/ScheduleDayHeading/ScheduleDayHeading.tsx
@@ -5,7 +5,10 @@ import { ScheduleDayFilterOptions, ScheduleDayFilterRow } from '../';
 import AddIcon from '@mui/icons-material/Add';
 import { curationPalette } from '../../../theme';
 import { DateTime } from 'luxon';
-import { ScheduledCorpusItemsResult } from '../../../api/generatedTypes';
+import {
+  ScheduledCorpusItemsResult,
+  ScheduledItemSource,
+} from '../../../api/generatedTypes';
 
 interface ScheduleDayHeadingProps {
   /**
@@ -36,6 +39,13 @@ export const ScheduleDayHeading: React.FC<ScheduleDayHeadingProps> = (
 ): ReactElement => {
   const { onAddItem, data, setFilters } = props;
 
+  // Figure out how many items are both ML-scheduled and Syndicated, since
+  // it's not available from the graph as a ready-to-use data point
+  const mlSyndicatedCount = data.items.filter(
+    (item) =>
+      item.source === ScheduledItemSource.Ml && item.approvedItem.isSyndicated,
+  ).length;
+
   return (
     <>
       <Grid
@@ -45,10 +55,10 @@ export const ScheduleDayHeading: React.FC<ScheduleDayHeadingProps> = (
         rowSpacing={3}
         justifyContent="space-between"
       >
-        <Grid item xs={5}>
+        <Grid item xs={12}>
           <Typography
             sx={{
-              fontSize: '1.25rem',
+              fontSize: '1.5rem',
               fontWeight: 500,
               textTransform: 'capitalize',
               color: curationPalette.pocketBlack,
@@ -57,10 +67,11 @@ export const ScheduleDayHeading: React.FC<ScheduleDayHeadingProps> = (
             {DateTime.fromFormat(data.scheduledDate, 'yyyy-MM-dd')
               .setLocale('en')
               .toLocaleString(DateTime.DATE_FULL)}{' '}
-            {` (${data.syndicatedCount}/${data.totalCount} syndicated)`}
+            {` (${mlSyndicatedCount} ML-syndicated, `}
+            {`${data.syndicatedCount} syndicated, ${data.totalCount} total)`}
           </Typography>
         </Grid>
-        <Grid item xs={7}>
+        <Grid item xs={12}>
           <Stack
             direction="row"
             alignItems="center"


### PR DESCRIPTION
## Goal

- Add a new filter ("ML-Syndicated") to the "Types" filter dropdown. This is where ML-scheduled syndicated stories are now grouped to, separate to other ML stories. 
- Tweak card labels to show "ML-Syndicated" with a magic wand icon where ML-scheduled stories are syndicated, and keep the "ML" tag for other ML-scheduled items.
- Add/update tests for new functionality.

## Screenshots

Note: demo is up on Dev.

<img width="1483" alt="ml-syndicated filter" src="https://github.com/Pocket/curation-admin-tools/assets/22447785/5c3b6fde-44af-487f-9424-966dbee1c379">


## Reference

Tickets:

- https://mozilla-hub.atlassian.net/browse/MC-1273
- https://mozilla-hub.atlassian.net/browse/MC-1274
