### PR TITLE
feat: add grade buttons to scheduled item cards

### DIFF
--- a/src/_shared/components/CardActionButtonRow/CardActionButtonRow.test.tsx
+++ b/src/_shared/components/CardActionButtonRow/CardActionButtonRow.test.tsx
@@ -4,22 +4,27 @@ import userEvent from '@testing-library/user-event';
 
 import { CardActionButtonRow } from './CardActionButtonRow';
 
+import { approvedCorpusItem } from '../../../curated-corpus/helpers/approvedItem';
+
 describe('The CardActionButtonRow component', () => {
   const onMoveToBottom = jest.fn();
   const onEdit = jest.fn();
   const onReschedule = jest.fn();
   const onUnschedule = jest.fn();
   const onReject = jest.fn();
+  const onGrade = jest.fn();
 
   //TODO update when reject button flow ready
   it('should render all four card action buttons and call their callbacks', () => {
     render(
       <CardActionButtonRow
+        item={approvedCorpusItem}
         onEdit={onEdit}
         onUnschedule={onUnschedule}
         onReschedule={onReschedule}
         onMoveToBottom={onMoveToBottom}
         onReject={onReject}
+        onGrade={onGrade}
       />,
     );
 

--- a/src/_shared/components/CardActionButtonRow/CardActionButtonRow.tsx
+++ b/src/_shared/components/CardActionButtonRow/CardActionButtonRow.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { IconButton, Tooltip } from '@mui/material';
+import {
+  IconButton,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
+} from '@mui/material';
 import { Stack } from '@mui/system';
 import ScheduleIcon from '@mui/icons-material/Schedule';
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
@@ -7,6 +12,11 @@ import EventBusyOutlinedIcon from '@mui/icons-material/EventBusyOutlined';
 import KeyboardDoubleArrowDownOutlinedIcon from '@mui/icons-material/KeyboardDoubleArrowDownOutlined';
 import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
 import { curationPalette } from '../../../theme';
+import {
+  ActionScreen,
+  ApprovedCorpusItem,
+  ApprovedItemGrade,
+} from '../../../api/generatedTypes';
 
 interface CardActionButtonRowProps {
   /**
@@ -33,6 +43,20 @@ interface CardActionButtonRowProps {
    * Callback for the "Reject" (trash) button
    */
   onReject: VoidFunction;
+
+  /**
+   * Callback for clicking a grade button
+   */
+  onGrade: (
+    item: ApprovedCorpusItem,
+    grade: ApprovedItemGrade,
+    actionScreen: ActionScreen,
+  ) => void;
+
+  /**
+   * The approved corpus item being graded
+   */
+  item: ApprovedCorpusItem;
 }
 
 export const CardActionButtonRow: React.FC<CardActionButtonRowProps> = (
@@ -89,6 +113,26 @@ export const CardActionButtonRow: React.FC<CardActionButtonRowProps> = (
             <ScheduleIcon />
           </IconButton>
         </Tooltip>
+      </Stack>
+
+      <Stack direction="row" justifyContent="flex-start">
+        <ToggleButtonGroup
+          size="small"
+          color="primary"
+          onChange={(event: React.MouseEvent, value: any) => {
+            props.onGrade(props.item, value[0], ActionScreen.Schedule);
+          }}
+        >
+          {Object.values(ApprovedItemGrade).map((grade) => (
+            <ToggleButton
+              key={grade}
+              value={grade}
+              selected={grade === props.item.grade}
+            >
+              {grade}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
       </Stack>
 
       <Stack direction="row" justifyContent="flex-start">

--- a/src/api/fragments/curatedItemData.ts
+++ b/src/api/fragments/curatedItemData.ts
@@ -22,6 +22,7 @@ export const CuratedItemData = gql`
     status
     source
     topic
+    grade
     isCollection
     isTimeSensitive
     isSyndicated

--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -76,6 +76,8 @@ export type ApprovedCorpusItem = {
   excerpt: Scalars['String'];
   /** An alternative primary key in UUID format that is generated on creation. */
   externalId: Scalars['ID'];
+  /** The quality grade associated with this CorpusItem. */
+  grade?: Maybe<ApprovedItemGrade>;
   /** True if the domain of the corpus item has been scheduled in the past. */
   hasTrustedDomain: Scalars['Boolean'];
   /**
@@ -195,6 +197,13 @@ export type ApprovedCorpusItemScheduledSurfaceHistoryFilters = {
    */
   scheduledSurfaceGuid?: InputMaybe<Scalars['ID']>;
 };
+
+/** Valid grade values for CorpusItem (public graph) and ApprovedItem (admin graph) */
+export enum ApprovedItemGrade {
+  A = 'A',
+  B = 'B',
+  C = 'C',
+}
 
 export type ArticleMarkdown = {
   __typename?: 'ArticleMarkdown';
@@ -485,6 +494,13 @@ export enum CorpusLanguage {
   It = 'IT',
 }
 
+/** A node in a CorpusSearchConnection result */
+export type CorpusSearchNode = {
+  __typename?: 'CorpusSearchNode';
+  /** The preview of the search result */
+  preview: PocketMetadata;
+};
+
 /** Input data for creating an Approved Item and optionally scheduling this item to appear on a Scheduled Surface. */
 export type CreateApprovedCorpusItemInput = {
   /** The UI screen where the approved corpus item is being created from. */
@@ -495,6 +511,8 @@ export type CreateApprovedCorpusItemInput = {
   datePublished?: InputMaybe<Scalars['Date']>;
   /** The excerpt of the Approved Item. */
   excerpt: Scalars['String'];
+  /** The quality grade associated with this CorpusItem. */
+  grade?: InputMaybe<ApprovedItemGrade>;
   /** The image URL for this item's accompanying picture. */
   imageUrl: Scalars['Url'];
   /** Whether this story is a Pocket Collection. */
@@ -524,10 +542,7 @@ export type CreateApprovedCorpusItemInput = {
   status: CuratedStatus;
   /** The title of the Approved Item. */
   title: Scalars['String'];
-  /**
-   * A topic this story best fits in.
-   * Temporarily a string value that will be provided by Prospect API, possibly an enum in the future.
-   */
+  /** A topic this story best fits in. */
   topic: Scalars['String'];
   /** The URL of the Approved Item. */
   url: Scalars['Url'];
@@ -972,15 +987,10 @@ export type ItemSummary = PocketMetadata & {
   id: Scalars['ID'];
   image?: Maybe<Image>;
   item?: Maybe<Item>;
-  source: ItemSummarySource;
+  source: PocketMetadataSource;
   title?: Maybe<Scalars['String']>;
   url: Scalars['Url'];
 };
-
-export enum ItemSummarySource {
-  Opengraph = 'OPENGRAPH',
-  PocketParser = 'POCKET_PARSER',
-}
 
 /** A label used to mark and categorize an Entity (e.g. Collection). */
 export type Label = {
@@ -1183,6 +1193,8 @@ export type Mutation = {
   rescheduleScheduledCorpusItem: ScheduledCorpusItem;
   /** Updates an Approved Item. */
   updateApprovedCorpusItem: ApprovedCorpusItem;
+  /** Updates the grade of an Approved Item */
+  updateApprovedCorpusItemGrade: ApprovedCorpusItem;
   /** Updates a Collection. */
   updateCollection: Collection;
   /** Updates a CollectionAuthor. */
@@ -1318,6 +1330,10 @@ export type MutationUpdateApprovedCorpusItemArgs = {
   data: UpdateApprovedCorpusItemInput;
 };
 
+export type MutationUpdateApprovedCorpusItemGradeArgs = {
+  data: UpdateApprovedCorpusItemGradeInput;
+};
+
 export type MutationUpdateCollectionArgs = {
   data: UpdateCollectionInput;
 };
@@ -1383,6 +1399,29 @@ export type NumberedListElement = ListElement & {
   /** Zero-indexed level, for handling nested lists. */
   level: Scalars['Int'];
 };
+
+export type OEmbed = PocketMetadata & {
+  __typename?: 'OEmbed';
+  authors?: Maybe<Array<Author>>;
+  datePublished?: Maybe<Scalars['ISOString']>;
+  domain?: Maybe<DomainMetadata>;
+  excerpt?: Maybe<Scalars['String']>;
+  htmlEmbed?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  image?: Maybe<Image>;
+  item?: Maybe<Item>;
+  source: PocketMetadataSource;
+  title?: Maybe<Scalars['String']>;
+  type?: Maybe<OEmbedType>;
+  url: Scalars['Url'];
+};
+
+export enum OEmbedType {
+  Link = 'LINK',
+  Photo = 'PHOTO',
+  Rich = 'RICH',
+  Video = 'VIDEO',
+}
 
 export type OpenGraphFields = {
   __typename?: 'OpenGraphFields';
@@ -1456,14 +1495,20 @@ export type PocketMetadata = {
   id: Scalars['ID'];
   image?: Maybe<Image>;
   item?: Maybe<Item>;
-  source: ItemSummarySource;
+  source: PocketMetadataSource;
   title?: Maybe<Scalars['String']>;
   url: Scalars['Url'];
 };
 
+export enum PocketMetadataSource {
+  Oembed = 'OEMBED',
+  Opengraph = 'OPENGRAPH',
+  PocketParser = 'POCKET_PARSER',
+}
+
 export type PocketShare = {
   __typename?: 'PocketShare';
-  preview?: Maybe<ItemSummary>;
+  preview?: Maybe<PocketMetadata>;
   targetUrl: Scalars['ValidUrl'];
 };
 
@@ -1570,8 +1615,8 @@ export type Query = {
    * Resolve Reader View links which might point to SavedItems that do not
    * exist, aren't in the Pocket User's list, or are requested by a logged-out
    * user (or user without a Pocket Account).
-   * Fetches data to create an interstitial page/modal so the visitor can click
-   * through to the shared site.
+   * Fetches data which clients can use to generate an appropriate fallback view
+   * that allows users to preview the content and access the original source site.
    */
   readerSlug: ReaderViewResult;
   searchCollections: CollectionsResult;
@@ -1669,13 +1714,28 @@ export type QuerySearchShareableListArgs = {
   externalId: Scalars['ID'];
 };
 
+/**
+ * Metadata of an Item in Pocket for preview purposes,
+ * or an ItemNotFound result if the record does not exist.
+ */
 export type ReaderFallback = ItemNotFound | ReaderInterstitial;
 
+/**
+ * Card preview data for Items resolved from reader view
+ * (getpocket.com/read/) links.
+ *
+ * Should be used to create a view if Reader Mode cannot
+ * be rendered (e.g. the link is visited by an anonymous
+ * Pocket user, or a Pocket User that does not have the
+ * underlying Item in their Saves). Due to legal obligations
+ * we can only display Reader Mode for SavedItems.
+ */
 export type ReaderInterstitial = {
   __typename?: 'ReaderInterstitial';
-  itemCard?: Maybe<ItemSummary>;
+  itemCard?: Maybe<PocketMetadata>;
 };
 
+/** Result for resolving a getpocket.com/read/<slug> link. */
 export type ReaderViewResult = {
   __typename?: 'ReaderViewResult';
   fallbackPage?: Maybe<ReaderFallback>;
@@ -2063,6 +2123,16 @@ export type UnMarseable = {
   html: Scalars['String'];
 };
 
+/** Input data for updating the grade of an Approved Item. */
+export type UpdateApprovedCorpusItemGradeInput = {
+  /** The UI screen where the approved corpus item is being graded from. */
+  actionScreen: ActionScreen;
+  /** Approved Item ID. */
+  externalId: Scalars['ID'];
+  /** The quality grade associated with this CorpusItem. */
+  grade: ApprovedItemGrade;
+};
+
 /** Input data for updating an Approved Item. */
 export type UpdateApprovedCorpusItemInput = {
   /**
@@ -2078,6 +2148,8 @@ export type UpdateApprovedCorpusItemInput = {
   excerpt: Scalars['String'];
   /** Approved Item ID. */
   externalId: Scalars['ID'];
+  /** The quality grade associated with this CorpusItem. */
+  grade?: InputMaybe<ApprovedItemGrade>;
   /** The image URL for this item's accompanying picture. */
   imageUrl: Scalars['Url'];
   /**
@@ -2093,10 +2165,7 @@ export type UpdateApprovedCorpusItemInput = {
   status: CuratedStatus;
   /** The title of the Approved Item. */
   title: Scalars['String'];
-  /**
-   * A topic this story best fits in.
-   * Temporarily a string value that will be provided by Prospect API, possibly an enum in the future.
-   */
+  /** A topic this story best fits in. */
   topic: Scalars['String'];
 };
 
@@ -2472,6 +2541,7 @@ export type CuratedItemDataFragment = {
   status: CuratedStatus;
   source: CorpusItemSource;
   topic: string;
+  grade?: ApprovedItemGrade | null;
   isCollection: boolean;
   isTimeSensitive: boolean;
   isSyndicated: boolean;
@@ -2628,6 +2698,7 @@ export type ScheduledItemDataFragment = {
     status: CuratedStatus;
     source: CorpusItemSource;
     topic: string;
+    grade?: ApprovedItemGrade | null;
     isCollection: boolean;
     isTimeSensitive: boolean;
     isSyndicated: boolean;
@@ -2686,6 +2757,7 @@ export type CreateApprovedCorpusItemMutation = {
     status: CuratedStatus;
     source: CorpusItemSource;
     topic: string;
+    grade?: ApprovedItemGrade | null;
     isCollection: boolean;
     isTimeSensitive: boolean;
     isSyndicated: boolean;
@@ -2915,6 +2987,7 @@ export type CreateScheduledCorpusItemMutation = {
       status: CuratedStatus;
       source: CorpusItemSource;
       topic: string;
+      grade?: ApprovedItemGrade | null;
       isCollection: boolean;
       isTimeSensitive: boolean;
       isSyndicated: boolean;
@@ -3016,6 +3089,7 @@ export type DeleteScheduledItemMutation = {
       status: CuratedStatus;
       source: CorpusItemSource;
       topic: string;
+      grade?: ApprovedItemGrade | null;
       isCollection: boolean;
       isTimeSensitive: boolean;
       isSyndicated: boolean;
@@ -3112,6 +3186,7 @@ export type RejectApprovedItemMutation = {
     status: CuratedStatus;
     source: CorpusItemSource;
     topic: string;
+    grade?: ApprovedItemGrade | null;
     isCollection: boolean;
     isTimeSensitive: boolean;
     isSyndicated: boolean;
@@ -3217,6 +3292,7 @@ export type RescheduleScheduledCorpusItemMutation = {
       status: CuratedStatus;
       source: CorpusItemSource;
       topic: string;
+      grade?: ApprovedItemGrade | null;
       isCollection: boolean;
       isTimeSensitive: boolean;
       isSyndicated: boolean;
@@ -3261,6 +3337,51 @@ export type UpdateApprovedCorpusItemMutation = {
     status: CuratedStatus;
     source: CorpusItemSource;
     topic: string;
+    grade?: ApprovedItemGrade | null;
+    isCollection: boolean;
+    isTimeSensitive: boolean;
+    isSyndicated: boolean;
+    createdBy: string;
+    createdAt: number;
+    updatedBy?: string | null;
+    updatedAt: number;
+    authors: Array<{
+      __typename?: 'CorpusItemAuthor';
+      name: string;
+      sortOrder: number;
+    }>;
+    scheduledSurfaceHistory: Array<{
+      __typename?: 'ApprovedCorpusItemScheduledSurfaceHistory';
+      externalId: string;
+      createdBy: string;
+      scheduledDate: any;
+      scheduledSurfaceGuid: string;
+    }>;
+  };
+};
+
+export type UpdateApprovedCorpusItemGradeMutationVariables = Exact<{
+  data: UpdateApprovedCorpusItemGradeInput;
+}>;
+
+export type UpdateApprovedCorpusItemGradeMutation = {
+  __typename?: 'Mutation';
+  updateApprovedCorpusItemGrade: {
+    __typename?: 'ApprovedCorpusItem';
+    externalId: string;
+    prospectId?: string | null;
+    title: string;
+    language: CorpusLanguage;
+    publisher: string;
+    datePublished?: any | null;
+    url: any;
+    hasTrustedDomain: boolean;
+    imageUrl: any;
+    excerpt: string;
+    status: CuratedStatus;
+    source: CorpusItemSource;
+    topic: string;
+    grade?: ApprovedItemGrade | null;
     isCollection: boolean;
     isTimeSensitive: boolean;
     isSyndicated: boolean;
@@ -3788,6 +3909,7 @@ export type GetApprovedItemByUrlQuery = {
     status: CuratedStatus;
     source: CorpusItemSource;
     topic: string;
+    grade?: ApprovedItemGrade | null;
     isCollection: boolean;
     isTimeSensitive: boolean;
     isSyndicated: boolean;
@@ -3845,6 +3967,7 @@ export type GetApprovedItemsQuery = {
         status: CuratedStatus;
         source: CorpusItemSource;
         topic: string;
+        grade?: ApprovedItemGrade | null;
         isCollection: boolean;
         isTimeSensitive: boolean;
         isSyndicated: boolean;
@@ -4364,6 +4487,7 @@ export type GetScheduledItemsQuery = {
         status: CuratedStatus;
         source: CorpusItemSource;
         topic: string;
+        grade?: ApprovedItemGrade | null;
         isCollection: boolean;
         isTimeSensitive: boolean;
         isSyndicated: boolean;
@@ -4833,6 +4957,7 @@ export const CuratedItemDataFragmentDoc = gql`
     status
     source
     topic
+    grade
     isCollection
     isTimeSensitive
     isSyndicated
@@ -4913,7 +5038,7 @@ export function useCreateApprovedCorpusItemMutation(
   baseOptions?: Apollo.MutationHookOptions<
     CreateApprovedCorpusItemMutation,
     CreateApprovedCorpusItemMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -4965,7 +5090,7 @@ export function useCreateCollectionMutation(
   baseOptions?: Apollo.MutationHookOptions<
     CreateCollectionMutation,
     CreateCollectionMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -5034,7 +5159,7 @@ export function useCreateCollectionAuthorMutation(
   baseOptions?: Apollo.MutationHookOptions<
     CreateCollectionAuthorMutation,
     CreateCollectionAuthorMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -5095,7 +5220,7 @@ export function useCreateCollectionPartnerMutation(
   baseOptions?: Apollo.MutationHookOptions<
     CreateCollectionPartnerMutation,
     CreateCollectionPartnerMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -5171,7 +5296,7 @@ export function useCreateCollectionPartnerAssociationMutation(
   baseOptions?: Apollo.MutationHookOptions<
     CreateCollectionPartnerAssociationMutation,
     CreateCollectionPartnerAssociationMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -5253,7 +5378,7 @@ export function useCreateCollectionStoryMutation(
   baseOptions?: Apollo.MutationHookOptions<
     CreateCollectionStoryMutation,
     CreateCollectionStoryMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -5304,12 +5429,12 @@ export function useCreateLabelMutation(
   baseOptions?: Apollo.MutationHookOptions<
     CreateLabelMutation,
     CreateLabelMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<CreateLabelMutation, CreateLabelMutationVariables>(
     CreateLabelDocument,
-    options
+    options,
   );
 }
 export type CreateLabelMutationHookResult = ReturnType<
@@ -5387,7 +5512,7 @@ export function useCreateScheduledCorpusItemMutation(
   baseOptions?: Apollo.MutationHookOptions<
     CreateScheduledCorpusItemMutation,
     CreateScheduledCorpusItemMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -5440,7 +5565,7 @@ export function useDeleteCollectionPartnerAssociationMutation(
   baseOptions?: Apollo.MutationHookOptions<
     DeleteCollectionPartnerAssociationMutation,
     DeleteCollectionPartnerAssociationMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -5492,7 +5617,7 @@ export function useDeleteCollectionStoryMutation(
   baseOptions?: Apollo.MutationHookOptions<
     DeleteCollectionStoryMutation,
     DeleteCollectionStoryMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -5551,7 +5676,7 @@ export function useDeleteScheduledItemMutation(
   baseOptions?: Apollo.MutationHookOptions<
     DeleteScheduledItemMutation,
     DeleteScheduledItemMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -5616,12 +5741,12 @@ export function useImageUploadMutation(
   baseOptions?: Apollo.MutationHookOptions<
     ImageUploadMutation,
     ImageUploadMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<ImageUploadMutation, ImageUploadMutationVariables>(
     ImageUploadDocument,
-    options
+    options,
   );
 }
 export type ImageUploadMutationHookResult = ReturnType<
@@ -5667,7 +5792,7 @@ export function useModerateShareableListMutation(
   baseOptions?: Apollo.MutationHookOptions<
     ModerateShareableListMutation,
     ModerateShareableListMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -5718,7 +5843,7 @@ export function useRejectApprovedItemMutation(
   baseOptions?: Apollo.MutationHookOptions<
     RejectApprovedItemMutation,
     RejectApprovedItemMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -5769,7 +5894,7 @@ export function useRejectProspectMutation(
   baseOptions?: Apollo.MutationHookOptions<
     RejectProspectMutation,
     RejectProspectMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -5820,7 +5945,7 @@ export function useRemoveProspectMutation(
   baseOptions?: Apollo.MutationHookOptions<
     RemoveProspectMutation,
     RemoveProspectMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -5886,7 +6011,7 @@ export function useRescheduleScheduledCorpusItemMutation(
   baseOptions?: Apollo.MutationHookOptions<
     RescheduleScheduledCorpusItemMutation,
     RescheduleScheduledCorpusItemMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -5938,7 +6063,7 @@ export function useUpdateApprovedCorpusItemMutation(
   baseOptions?: Apollo.MutationHookOptions<
     UpdateApprovedCorpusItemMutation,
     UpdateApprovedCorpusItemMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -5955,6 +6080,60 @@ export type UpdateApprovedCorpusItemMutationOptions =
   Apollo.BaseMutationOptions<
     UpdateApprovedCorpusItemMutation,
     UpdateApprovedCorpusItemMutationVariables
+  >;
+export const UpdateApprovedCorpusItemGradeDocument = gql`
+  mutation updateApprovedCorpusItemGrade(
+    $data: UpdateApprovedCorpusItemGradeInput!
+  ) {
+    updateApprovedCorpusItemGrade(data: $data) {
+      ...CuratedItemData
+    }
+  }
+  ${CuratedItemDataFragmentDoc}
+`;
+export type UpdateApprovedCorpusItemGradeMutationFn = Apollo.MutationFunction<
+  UpdateApprovedCorpusItemGradeMutation,
+  UpdateApprovedCorpusItemGradeMutationVariables
+>;
+
+/**
+ * __useUpdateApprovedCorpusItemGradeMutation__
+ *
+ * To run a mutation, you first call `useUpdateApprovedCorpusItemGradeMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateApprovedCorpusItemGradeMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateApprovedCorpusItemGradeMutation, { data, loading, error }] = useUpdateApprovedCorpusItemGradeMutation({
+ *   variables: {
+ *      data: // value for 'data'
+ *   },
+ * });
+ */
+export function useUpdateApprovedCorpusItemGradeMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    UpdateApprovedCorpusItemGradeMutation,
+    UpdateApprovedCorpusItemGradeMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    UpdateApprovedCorpusItemGradeMutation,
+    UpdateApprovedCorpusItemGradeMutationVariables
+  >(UpdateApprovedCorpusItemGradeDocument, options);
+}
+export type UpdateApprovedCorpusItemGradeMutationHookResult = ReturnType<
+  typeof useUpdateApprovedCorpusItemGradeMutation
+>;
+export type UpdateApprovedCorpusItemGradeMutationResult =
+  Apollo.MutationResult<UpdateApprovedCorpusItemGradeMutation>;
+export type UpdateApprovedCorpusItemGradeMutationOptions =
+  Apollo.BaseMutationOptions<
+    UpdateApprovedCorpusItemGradeMutation,
+    UpdateApprovedCorpusItemGradeMutationVariables
   >;
 export const UpdateCollectionDocument = gql`
   mutation updateCollection($data: UpdateCollectionInput!) {
@@ -5990,7 +6169,7 @@ export function useUpdateCollectionMutation(
   baseOptions?: Apollo.MutationHookOptions<
     UpdateCollectionMutation,
     UpdateCollectionMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -6062,7 +6241,7 @@ export function useUpdateCollectionAuthorMutation(
   baseOptions?: Apollo.MutationHookOptions<
     UpdateCollectionAuthorMutation,
     UpdateCollectionAuthorMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -6119,7 +6298,7 @@ export function useUpdateCollectionAuthorImageUrlMutation(
   baseOptions?: Apollo.MutationHookOptions<
     UpdateCollectionAuthorImageUrlMutation,
     UpdateCollectionAuthorImageUrlMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -6174,7 +6353,7 @@ export function useUpdateCollectionImageUrlMutation(
   baseOptions?: Apollo.MutationHookOptions<
     UpdateCollectionImageUrlMutation,
     UpdateCollectionImageUrlMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -6244,7 +6423,7 @@ export function useUpdateCollectionPartnerMutation(
   baseOptions?: Apollo.MutationHookOptions<
     UpdateCollectionPartnerMutation,
     UpdateCollectionPartnerMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -6320,7 +6499,7 @@ export function useUpdateCollectionPartnerAssociationMutation(
   baseOptions?: Apollo.MutationHookOptions<
     UpdateCollectionPartnerAssociationMutation,
     UpdateCollectionPartnerAssociationMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -6379,7 +6558,7 @@ export function useUpdateCollectionPartnerAssociationImageUrlMutation(
   baseOptions?: Apollo.MutationHookOptions<
     UpdateCollectionPartnerAssociationImageUrlMutation,
     UpdateCollectionPartnerAssociationImageUrlMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -6436,7 +6615,7 @@ export function useUpdateCollectionPartnerImageUrlMutation(
   baseOptions?: Apollo.MutationHookOptions<
     UpdateCollectionPartnerImageUrlMutation,
     UpdateCollectionPartnerImageUrlMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -6518,7 +6697,7 @@ export function useUpdateCollectionStoryMutation(
   baseOptions?: Apollo.MutationHookOptions<
     UpdateCollectionStoryMutation,
     UpdateCollectionStoryMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -6575,7 +6754,7 @@ export function useUpdateCollectionStoryImageUrlMutation(
   baseOptions?: Apollo.MutationHookOptions<
     UpdateCollectionStoryImageUrlMutation,
     UpdateCollectionStoryImageUrlMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -6633,7 +6812,7 @@ export function useUpdateCollectionStorySortOrderMutation(
   baseOptions?: Apollo.MutationHookOptions<
     UpdateCollectionStorySortOrderMutation,
     UpdateCollectionStorySortOrderMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -6685,12 +6864,12 @@ export function useUpdateLabelMutation(
   baseOptions?: Apollo.MutationHookOptions<
     UpdateLabelMutation,
     UpdateLabelMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<UpdateLabelMutation, UpdateLabelMutationVariables>(
     UpdateLabelDocument,
-    options
+    options,
   );
 }
 export type UpdateLabelMutationHookResult = ReturnType<
@@ -6740,7 +6919,7 @@ export function useUpdateProspectAsCuratedMutation(
   baseOptions?: Apollo.MutationHookOptions<
     UpdateProspectAsCuratedMutation,
     UpdateProspectAsCuratedMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -6790,7 +6969,7 @@ export function useUploadApprovedCorpusItemImageMutation(
   baseOptions?: Apollo.MutationHookOptions<
     UploadApprovedCorpusItemImageMutation,
     UploadApprovedCorpusItemImageMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -6841,7 +7020,7 @@ export function useApprovedCorpusItemByExternalIdQuery(
   baseOptions: Apollo.QueryHookOptions<
     ApprovedCorpusItemByExternalIdQuery,
     ApprovedCorpusItemByExternalIdQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
@@ -6853,7 +7032,7 @@ export function useApprovedCorpusItemByExternalIdLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     ApprovedCorpusItemByExternalIdQuery,
     ApprovedCorpusItemByExternalIdQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
@@ -6900,7 +7079,7 @@ export function useGetApprovedItemByUrlQuery(
   baseOptions: Apollo.QueryHookOptions<
     GetApprovedItemByUrlQuery,
     GetApprovedItemByUrlQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
@@ -6912,7 +7091,7 @@ export function useGetApprovedItemByUrlLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     GetApprovedItemByUrlQuery,
     GetApprovedItemByUrlQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
@@ -6975,19 +7154,19 @@ export function useGetApprovedItemsQuery(
   baseOptions?: Apollo.QueryHookOptions<
     GetApprovedItemsQuery,
     GetApprovedItemsQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<GetApprovedItemsQuery, GetApprovedItemsQueryVariables>(
     GetApprovedItemsDocument,
-    options
+    options,
   );
 }
 export function useGetApprovedItemsLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     GetApprovedItemsQuery,
     GetApprovedItemsQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
@@ -7034,24 +7213,24 @@ export function useGetAuthorByIdQuery(
   baseOptions: Apollo.QueryHookOptions<
     GetAuthorByIdQuery,
     GetAuthorByIdQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<GetAuthorByIdQuery, GetAuthorByIdQueryVariables>(
     GetAuthorByIdDocument,
-    options
+    options,
   );
 }
 export function useGetAuthorByIdLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     GetAuthorByIdQuery,
     GetAuthorByIdQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<GetAuthorByIdQuery, GetAuthorByIdQueryVariables>(
     GetAuthorByIdDocument,
-    options
+    options,
   );
 }
 export type GetAuthorByIdQueryHookResult = ReturnType<
@@ -7101,24 +7280,24 @@ export function useGetAuthorsQuery(
   baseOptions?: Apollo.QueryHookOptions<
     GetAuthorsQuery,
     GetAuthorsQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<GetAuthorsQuery, GetAuthorsQueryVariables>(
     GetAuthorsDocument,
-    options
+    options,
   );
 }
 export function useGetAuthorsLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     GetAuthorsQuery,
     GetAuthorsQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<GetAuthorsQuery, GetAuthorsQueryVariables>(
     GetAuthorsDocument,
-    options
+    options,
   );
 }
 export type GetAuthorsQueryHookResult = ReturnType<typeof useGetAuthorsQuery>;
@@ -7158,7 +7337,7 @@ export function useGetCollectionByExternalIdQuery(
   baseOptions: Apollo.QueryHookOptions<
     GetCollectionByExternalIdQuery,
     GetCollectionByExternalIdQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
@@ -7170,7 +7349,7 @@ export function useGetCollectionByExternalIdLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     GetCollectionByExternalIdQuery,
     GetCollectionByExternalIdQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
@@ -7217,7 +7396,7 @@ export function useGetCollectionPartnerQuery(
   baseOptions: Apollo.QueryHookOptions<
     GetCollectionPartnerQuery,
     GetCollectionPartnerQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
@@ -7229,7 +7408,7 @@ export function useGetCollectionPartnerLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     GetCollectionPartnerQuery,
     GetCollectionPartnerQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
@@ -7276,7 +7455,7 @@ export function useGetCollectionPartnerAssociationQuery(
   baseOptions: Apollo.QueryHookOptions<
     GetCollectionPartnerAssociationQuery,
     GetCollectionPartnerAssociationQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
@@ -7288,7 +7467,7 @@ export function useGetCollectionPartnerAssociationLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     GetCollectionPartnerAssociationQuery,
     GetCollectionPartnerAssociationQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
@@ -7343,7 +7522,7 @@ export function useGetCollectionPartnersQuery(
   baseOptions?: Apollo.QueryHookOptions<
     GetCollectionPartnersQuery,
     GetCollectionPartnersQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
@@ -7355,7 +7534,7 @@ export function useGetCollectionPartnersLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     GetCollectionPartnersQuery,
     GetCollectionPartnersQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
@@ -7405,7 +7584,7 @@ export function useGetCollectionStoriesQuery(
   baseOptions: Apollo.QueryHookOptions<
     GetCollectionStoriesQuery,
     GetCollectionStoriesQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
@@ -7417,7 +7596,7 @@ export function useGetCollectionStoriesLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     GetCollectionStoriesQuery,
     GetCollectionStoriesQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
@@ -7481,24 +7660,24 @@ export function useGetCollectionsQuery(
   baseOptions: Apollo.QueryHookOptions<
     GetCollectionsQuery,
     GetCollectionsQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<GetCollectionsQuery, GetCollectionsQueryVariables>(
     GetCollectionsDocument,
-    options
+    options,
   );
 }
 export function useGetCollectionsLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     GetCollectionsQuery,
     GetCollectionsQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<GetCollectionsQuery, GetCollectionsQueryVariables>(
     GetCollectionsDocument,
-    options
+    options,
   );
 }
 export type GetCollectionsQueryHookResult = ReturnType<
@@ -7563,7 +7742,7 @@ export function useGetInitialCollectionFormDataQuery(
   baseOptions?: Apollo.QueryHookOptions<
     GetInitialCollectionFormDataQuery,
     GetInitialCollectionFormDataQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
@@ -7575,7 +7754,7 @@ export function useGetInitialCollectionFormDataLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     GetInitialCollectionFormDataQuery,
     GetInitialCollectionFormDataQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
@@ -7621,7 +7800,7 @@ export function useGetOpenGraphFieldsQuery(
   baseOptions: Apollo.QueryHookOptions<
     GetOpenGraphFieldsQuery,
     GetOpenGraphFieldsQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
@@ -7633,7 +7812,7 @@ export function useGetOpenGraphFieldsLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     GetOpenGraphFieldsQuery,
     GetOpenGraphFieldsQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
@@ -7691,24 +7870,24 @@ export function useGetProspectsQuery(
   baseOptions: Apollo.QueryHookOptions<
     GetProspectsQuery,
     GetProspectsQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<GetProspectsQuery, GetProspectsQueryVariables>(
     GetProspectsDocument,
-    options
+    options,
   );
 }
 export function useGetProspectsLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     GetProspectsQuery,
     GetProspectsQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<GetProspectsQuery, GetProspectsQueryVariables>(
     GetProspectsDocument,
-    options
+    options,
   );
 }
 export type GetProspectsQueryHookResult = ReturnType<
@@ -7766,19 +7945,19 @@ export function useGetRejectedItemsQuery(
   baseOptions?: Apollo.QueryHookOptions<
     GetRejectedItemsQuery,
     GetRejectedItemsQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<GetRejectedItemsQuery, GetRejectedItemsQueryVariables>(
     GetRejectedItemsDocument,
-    options
+    options,
   );
 }
 export function useGetRejectedItemsLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     GetRejectedItemsQuery,
     GetRejectedItemsQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
@@ -7826,7 +8005,7 @@ export function useGetScheduledItemCountsQuery(
   baseOptions: Apollo.QueryHookOptions<
     GetScheduledItemCountsQuery,
     GetScheduledItemCountsQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
@@ -7838,7 +8017,7 @@ export function useGetScheduledItemCountsLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     GetScheduledItemCountsQuery,
     GetScheduledItemCountsQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
@@ -7891,7 +8070,7 @@ export function useGetScheduledItemsQuery(
   baseOptions: Apollo.QueryHookOptions<
     GetScheduledItemsQuery,
     GetScheduledItemsQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
@@ -7903,7 +8082,7 @@ export function useGetScheduledItemsLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     GetScheduledItemsQuery,
     GetScheduledItemsQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
@@ -7951,7 +8130,7 @@ export function useGetScheduledSurfacesForUserQuery(
   baseOptions?: Apollo.QueryHookOptions<
     GetScheduledSurfacesForUserQuery,
     GetScheduledSurfacesForUserQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
@@ -7963,7 +8142,7 @@ export function useGetScheduledSurfacesForUserLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     GetScheduledSurfacesForUserQuery,
     GetScheduledSurfacesForUserQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
@@ -8024,7 +8203,7 @@ export function useSearchCollectionsQuery(
   baseOptions: Apollo.QueryHookOptions<
     SearchCollectionsQuery,
     SearchCollectionsQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
@@ -8036,7 +8215,7 @@ export function useSearchCollectionsLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     SearchCollectionsQuery,
     SearchCollectionsQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
@@ -8096,7 +8275,7 @@ export function useGetStoryFromParserQuery(
   baseOptions: Apollo.QueryHookOptions<
     GetStoryFromParserQuery,
     GetStoryFromParserQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
@@ -8108,7 +8287,7 @@ export function useGetStoryFromParserLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     GetStoryFromParserQuery,
     GetStoryFromParserQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
@@ -8155,24 +8334,24 @@ export function useGetUrlMetadataQuery(
   baseOptions: Apollo.QueryHookOptions<
     GetUrlMetadataQuery,
     GetUrlMetadataQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<GetUrlMetadataQuery, GetUrlMetadataQueryVariables>(
     GetUrlMetadataDocument,
-    options
+    options,
   );
 }
 export function useGetUrlMetadataLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     GetUrlMetadataQuery,
     GetUrlMetadataQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<GetUrlMetadataQuery, GetUrlMetadataQueryVariables>(
     GetUrlMetadataDocument,
-    options
+    options,
   );
 }
 export type GetUrlMetadataQueryHookResult = ReturnType<
@@ -8210,21 +8389,21 @@ export const LabelsDocument = gql`
  * });
  */
 export function useLabelsQuery(
-  baseOptions?: Apollo.QueryHookOptions<LabelsQuery, LabelsQueryVariables>
+  baseOptions?: Apollo.QueryHookOptions<LabelsQuery, LabelsQueryVariables>,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<LabelsQuery, LabelsQueryVariables>(
     LabelsDocument,
-    options
+    options,
   );
 }
 export function useLabelsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<LabelsQuery, LabelsQueryVariables>
+  baseOptions?: Apollo.LazyQueryHookOptions<LabelsQuery, LabelsQueryVariables>,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<LabelsQuery, LabelsQueryVariables>(
     LabelsDocument,
-    options
+    options,
   );
 }
 export type LabelsQueryHookResult = ReturnType<typeof useLabelsQuery>;
@@ -8262,7 +8441,7 @@ export function useSearchShareableListQuery(
   baseOptions: Apollo.QueryHookOptions<
     SearchShareableListQuery,
     SearchShareableListQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
@@ -8274,7 +8453,7 @@ export function useSearchShareableListLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     SearchShareableListQuery,
     SearchShareableListQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<

--- a/src/api/mutations/updateApprovedItemGrade.ts
+++ b/src/api/mutations/updateApprovedItemGrade.ts
@@ -1,0 +1,13 @@
+import { gql } from '@apollo/client';
+import { CuratedItemData } from '../fragments/curatedItemData';
+
+export const updateApprovedItemGrade = gql`
+  mutation updateApprovedCorpusItemGrade(
+    $data: UpdateApprovedCorpusItemGradeInput!
+  ) {
+    updateApprovedCorpusItemGrade(data: $data) {
+      ...CuratedItemData
+    }
+  }
+  ${CuratedItemData}
+`;

--- a/src/curated-corpus/components/ScheduleDayData/ScheduleDayData.tsx
+++ b/src/curated-corpus/components/ScheduleDayData/ScheduleDayData.tsx
@@ -1,10 +1,14 @@
 import React, { ReactElement, useState } from 'react';
 import { Box, Grid } from '@mui/material';
 import {
+  ActionScreen,
+  ApprovedCorpusItem,
+  ApprovedItemGrade,
   ScheduledCorpusItem,
   ScheduledCorpusItemsResult,
   ScheduledItemSource,
   useRescheduleScheduledCorpusItemMutation,
+  useUpdateApprovedCorpusItemGradeMutation,
 } from '../../../api/generatedTypes';
 import {
   ScheduleDayFilterOptions,
@@ -96,6 +100,8 @@ export const ScheduleDayData: React.FC<ScheduleDayDataProps> = (
   // Prepare the "reschedule scheduled curated corpus item" mutation
   const [rescheduleItem] = useRescheduleScheduledCorpusItemMutation();
 
+  const [updateCorpusItemGrade] = useUpdateApprovedCorpusItemGradeMutation();
+
   /**
    * Pocket Hits items need to be returned in a pre-defined order. When the graph
    * is queried, scheduled items are returned sorted by the `updatedAt` value
@@ -120,6 +126,36 @@ export const ScheduleDayData: React.FC<ScheduleDayDataProps> = (
       rescheduleItem,
       { variables },
       `Success! Item moved to the bottom of the list.`,
+      undefined,
+      undefined,
+      refetch,
+    );
+  };
+
+  /**
+   * Assigns the given grade to the given item.
+   *
+   * @param item ApprovedCorpusItem
+   * @param grade ApprovedItemGrade
+   * @param actionScreen ActionScreen
+   */
+  const assignGradeToItem = (
+    item: ApprovedCorpusItem,
+    grade: ApprovedItemGrade,
+    actionScreen: ActionScreen,
+  ): void => {
+    const variables = {
+      data: {
+        externalId: item.externalId,
+        grade,
+        actionScreen,
+      },
+    };
+
+    runMutation(
+      updateCorpusItemGrade,
+      { variables },
+      `Curated item "${item.title.substring(0, 40)}..." successfully graded`,
       undefined,
       undefined,
       refetch,
@@ -204,6 +240,7 @@ export const ScheduleDayData: React.FC<ScheduleDayDataProps> = (
                         toggleRejectAndUnscheduleModal();
                       }
                     }}
+                    onGrade={assignGradeToItem}
                     currentScheduledDate={data.scheduledDate}
                     scheduledSurfaceGuid={currentScheduledSurfaceGuid}
                   />

--- a/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.tsx
+++ b/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.tsx
@@ -1,6 +1,9 @@
 import React, { ReactElement } from 'react';
 import { Grid } from '@mui/material';
 import {
+  ActionScreen,
+  ApprovedCorpusItem,
+  ApprovedItemGrade,
   ScheduledCorpusItem,
   ScheduledItemSource,
 } from '../../../api/generatedTypes';
@@ -40,6 +43,15 @@ interface ScheduledItemCardWrapperProps {
   onReject: VoidFunction;
 
   /**
+   * Callback for the "Grade" buttons
+   */
+  onGrade: (
+    item: ApprovedCorpusItem,
+    grade: ApprovedItemGrade,
+    actionScreen: ActionScreen,
+  ) => void;
+
+  /**
    * Current date that the schedule is being viewed for
    */
   currentScheduledDate: string;
@@ -60,6 +72,7 @@ export const ScheduledItemCardWrapper: React.FC<
     onReschedule,
     onEdit,
     onReject,
+    onGrade,
     currentScheduledDate,
     scheduledSurfaceGuid,
   } = props;
@@ -77,6 +90,7 @@ export const ScheduledItemCardWrapper: React.FC<
           onReschedule={onReschedule}
           onMoveToBottom={onMoveToBottom}
           onReject={onReject}
+          onGrade={onGrade}
         />
       </StyledScheduledItemCard>
     </Grid>

--- a/src/curated-corpus/components/SuggestedScheduleItemListCard/SuggestedScheduleItemListCard.tsx
+++ b/src/curated-corpus/components/SuggestedScheduleItemListCard/SuggestedScheduleItemListCard.tsx
@@ -2,7 +2,11 @@ import React, { ReactElement, useState } from 'react';
 import { Box, CardContent, Link, Typography } from '@mui/material';
 import { DateTime } from 'luxon';
 
-import { ApprovedCorpusItem } from '../../../api/generatedTypes';
+import {
+  ApprovedCorpusItem,
+  ApprovedItemGrade,
+  ActionScreen,
+} from '../../../api/generatedTypes';
 import { flattenAuthors } from '../../../_shared/utils/flattenAuthors';
 
 import { curationPalette } from '../../../theme';
@@ -57,6 +61,15 @@ interface SuggestedScheduleItemListCardProps {
    * Callback for the "Reject" (trash) button
    */
   onReject: VoidFunction;
+
+  /**
+   * Callback for the "Grade" buttons
+   */
+  onGrade: (
+    item: ApprovedCorpusItem,
+    grade: ApprovedItemGrade,
+    actionScreen: ActionScreen,
+  ) => void;
 }
 
 export const SuggestedScheduleItemListCard: React.FC<
@@ -72,6 +85,7 @@ export const SuggestedScheduleItemListCard: React.FC<
     onEdit,
     onMoveToBottom,
     onReject,
+    onGrade,
   } = props;
 
   const [isScheduleHistoryModalOpen, setScheduleHistoryModalOpen] =
@@ -178,6 +192,8 @@ export const SuggestedScheduleItemListCard: React.FC<
         onReschedule={onReschedule}
         onMoveToBottom={onMoveToBottom}
         onReject={onReject}
+        onGrade={onGrade}
+        item={item}
       />
     </>
   );

--- a/src/curated-corpus/helpers/approvedItem.ts
+++ b/src/curated-corpus/helpers/approvedItem.ts
@@ -1,5 +1,6 @@
 import {
   ApprovedCorpusItem,
+  ApprovedItemGrade,
   CorpusItemSource,
   CorpusLanguage,
   CuratedStatus,
@@ -19,6 +20,7 @@ export const approvedCorpusItem: ApprovedCorpusItem = {
   publisher: 'Amazing Inventions',
   datePublished: '2024-01-03',
   topic: Topics.HealthFitness,
+  grade: ApprovedItemGrade.A,
   source: CorpusItemSource.Prospect,
   status: CuratedStatus.Recommendation,
   isCollection: false,


### PR DESCRIPTION
## Goal

add grade buttons to scheduled item cards.

## Todos

- [ ] push the [backend PR](https://github.com/Pocket/content-monorepo/pull/185) to dev and test the full flow of data to snowplow
- [ ] add tests for the new buttons?

## Reference

Tickets:

- https://mozilla-hub.atlassian.net/browse/MC-1156