### PR TITLE
chore: update generated types to remove syndicated prospect sources

### DIFF
--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -1549,8 +1549,6 @@ export enum ProspectType {
   RssLogistic = 'RSS_LOGISTIC',
   RssLogisticRecent = 'RSS_LOGISTIC_RECENT',
   SlateSchedulerV2 = 'SLATE_SCHEDULER_V2',
-  SyndicatedNew = 'SYNDICATED_NEW',
-  SyndicatedRerun = 'SYNDICATED_RERUN',
   Timespent = 'TIMESPENT',
   TimespentModeled = 'TIMESPENT_MODELED',
   TitleUrlModeled = 'TITLE_URL_MODELED',

--- a/src/curated-corpus/helpers/prospects.test.ts
+++ b/src/curated-corpus/helpers/prospects.test.ts
@@ -40,7 +40,7 @@ describe('helper functions related to prospects', () => {
     });
 
     it('returns a cut-down list of prospect types if only some are available for given Scheduled Surface', () => {
-      const types: ProspectType[] = [ProspectType.SyndicatedNew];
+      const types: ProspectType[] = [ProspectType.Recommended];
 
       const options = getProspectFilterOptions(types);
 
@@ -50,8 +50,8 @@ describe('helper functions related to prospects', () => {
       expect(options[0].code).to.be.an.empty.string;
       expect(options[0].name).to.equal('All Sources');
 
-      expect(options[1].code).to.equal(ProspectType.SyndicatedNew);
-      expect(options[1].name).to.equal('SyndicatedNew');
+      expect(options[1].code).to.equal(ProspectType.Recommended);
+      expect(options[1].name).to.equal('Recommended');
     });
   });
 


### PR DESCRIPTION
## Goal

update generated types to remove syndicated prospect sources

- syndicated prospect sources have been deprecated by ML

## Reference

Tickets:

- https://mozilla-hub.atlassian.net/browse/MC-1357