### PR TITLE
feat(topics): Add new 'Home' topic as an option in the tool

### DIFF
--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -1889,6 +1889,19 @@ export type RescheduleScheduledCorpusItemInput = {
   source: ScheduledItemSource;
 };
 
+/** Contains information about the human curator who reviewed the schedule for a given date and scheduled surface. */
+export type ScheduleReview = {
+  __typename?: 'ScheduleReview';
+  /** A Unix timestamp of when the scheduled was last reviewed. */
+  reviewedAt: Scalars['Date'];
+  /** A single sign-on user identifier of the user who reviewed the schedule. */
+  reviewedBy: Scalars['String'];
+  /** The date of the schedule that was reviewed, in YYYY-MM-DD format. */
+  scheduledDate: Scalars['Date'];
+  /** The GUID of the scheduledSurface that was reviewed. */
+  scheduledSurfaceGuid: Scalars['ID'];
+};
+
 /**
  * A scheduled entry for an Approved Item to appear on a Scheduled Surface.
  * For example, a story that is scheduled to appear on December 31st, 2021 on the New Tab in Firefox for the US audience.
@@ -1935,6 +1948,8 @@ export type ScheduledCorpusItemsResult = {
   collectionCount: Scalars['Int'];
   /** An array of items for a given Scheduled Surface */
   items: Array<ScheduledCorpusItem>;
+  /** The human review status of the schedule for the given scheduledSurfaceGuid & scheduledDate. */
+  scheduleReview?: Maybe<ScheduleReview>;
   /** The date items are scheduled for, in YYYY-MM-DD format. */
   scheduledDate: Scalars['Date'];
   /** The number of syndicated articles for the scheduled date. */
@@ -2104,6 +2119,7 @@ export enum Topics {
   Food = 'FOOD',
   Gaming = 'GAMING',
   HealthFitness = 'HEALTH_FITNESS',
+  Home = 'HOME',
   Parenting = 'PARENTING',
   PersonalFinance = 'PERSONAL_FINANCE',
   Politics = 'POLITICS',

--- a/src/curated-corpus/helpers/definitions.ts
+++ b/src/curated-corpus/helpers/definitions.ts
@@ -13,7 +13,7 @@ export interface DropdownOption {
   code: string;
   name: string;
 }
-// This is a list of topics. The 15 "standard" topics + coronavirus.
+// This is a list of topics. The 16 "standard" topics + coronavirus.
 export const topics: DropdownOption[] = [
   { code: Topics.Business, name: 'Business' },
   { code: Topics.Career, name: 'Career' },
@@ -23,6 +23,7 @@ export const topics: DropdownOption[] = [
   { code: Topics.Food, name: 'Food' },
   { code: Topics.Gaming, name: 'Gaming' },
   { code: Topics.HealthFitness, name: 'Health & Fitness' },
+  { code: Topics.Home, name: 'Home' },
   { code: Topics.Parenting, name: 'Parenting' },
   { code: Topics.PersonalFinance, name: 'Personal Finance' },
   { code: Topics.Politics, name: 'Politics' },

--- a/src/curated-corpus/helpers/topics.test.ts
+++ b/src/curated-corpus/helpers/topics.test.ts
@@ -43,7 +43,7 @@ describe('helper functions related to topics', () => {
       expect(topics).to.be.an('array');
       // However, we're getting the entire list of topics here,
       // not just the ones stories belong to
-      expect(topics).to.have.lengthOf(16);
+      expect(topics).to.have.lengthOf(17);
 
       // And we expect to see the story topics, with the correct counts
       expect(topics).to.contain.deep.members([

--- a/src/curated-corpus/helpers/topics.test.ts
+++ b/src/curated-corpus/helpers/topics.test.ts
@@ -89,7 +89,7 @@ describe('helper functions related to topics', () => {
 
     it('returns a list of topics without "Coronavirus" if requested', () => {
       const topics = getGroupedTopicData(data, true, false);
-      expect(topics).to.be.an('array').with.lengthOf(15);
+      expect(topics).to.be.an('array').with.lengthOf(16);
     });
 
     it('returns a full list of topics if requested', () => {

--- a/src/curated-corpus/helpers/topics.test.ts
+++ b/src/curated-corpus/helpers/topics.test.ts
@@ -94,7 +94,7 @@ describe('helper functions related to topics', () => {
 
     it('returns a full list of topics if requested', () => {
       const topics = getGroupedTopicData(data);
-      expect(topics).to.be.an('array').with.lengthOf(16);
+      expect(topics).to.be.an('array').with.lengthOf(17);
     });
   });
 });


### PR DESCRIPTION
# DO NOT DEPLOY

See notes in https://mozilla-hub.atlassian.net/browse/MC-1248 for when this feature is going to production.

## Goal

Allow the curators to categorise stories as belonging to the brand new "Home" category. 

## Implementation details

- Note: with regenerating types, a handful of unrelated schema changes have sneaked through. I think that is fine - we'll use them in the near future anyway. It's also possible that these schema changes will be merged to `main` earlier than this PR is deployed, in which case the changes will be removed from this PR.

### Tested manually:

- [x] Adding a new corpus item manually with "Home" as topic
- [x] Editing an existing item to set the topic to "Home"
- [x] Adding a prospect to the corpus with "Home" as topic
- [x] Scheduled item cards - topic is displayed correctly (see screenshot below)

<img width="323" alt="home-article" src="https://github.com/user-attachments/assets/81387532-9161-4f17-a962-1ccb4c30cd18">


## Reference

https://mozilla-hub.atlassian.net/browse/MC-1251
