### PR TITLE
fix(filters): [MC-1273] Make sure ML-filtered items don't include Syndicated items

### DIFF
--- a/src/curated-corpus/components/ScheduleDayData/ScheduleDayData.tsx
+++ b/src/curated-corpus/components/ScheduleDayData/ScheduleDayData.tsx
@@ -162,7 +162,8 @@ export const ScheduleDayData: React.FC<ScheduleDayDataProps> = (
                 filters.topics === getDisplayTopic(item.approvedItem.topic) ||
                 filters.publishers === item.approvedItem.publisher ||
                 (filters.types === 'Ml' &&
-                  item.source === ScheduledItemSource.Ml) ||
+                  item.source === ScheduledItemSource.Ml &&
+                  !item.approvedItem.isSyndicated) ||
                 (filters.types == 'ML-Syndicated' &&
                   item.source === ScheduledItemSource.Ml &&
                   item.approvedItem.isSyndicated) ||


### PR DESCRIPTION
## Goal

It appears the initial PR that added filters to the Schedule page did not filter out ML-Syndicated items out of the ML filter 
correctly. The dropdown numbers shown were correct, however the actual filters were not applied correctly. 

I _think_ this is because we didn't have enough data to test on Dev with, and that is why the bug must have slipped through. With the data we had at the time, everything looked to be working as expected. 
## Todos

## Reference

https://mozilla-hub.atlassian.net/browse/MC-1273?focusedCommentId=919426
