### PR TITLE
Mc 1404 create prospecting source for publisher air table suggestions

### DIFF
--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -1562,7 +1562,7 @@ export enum ProspectType {
   CountsModeled = 'COUNTS_MODELED',
   Dismissed = 'DISMISSED',
   DomainAllowlist = 'DOMAIN_ALLOWLIST',
-  ExternalEditorial = 'EXTERNAL_EDITORIAL',
+  PublisherSubmitted = 'PUBLISHER_SUBMITTED',
   Recommended = 'RECOMMENDED',
   RssLogistic = 'RSS_LOGISTIC',
   RssLogisticRecent = 'RSS_LOGISTIC_RECENT',

--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -626,6 +626,17 @@ export type CreateRejectedCorpusItemInput = {
   url: Scalars['Url'];
 };
 
+/**
+ * Input data for marking the given scheduled surface as reviewed
+ * by human curators for a given date.
+ */
+export type CreateScheduleReviewInput = {
+  /** The date of the schedule that was reviewed, in YYYY-MM-DD format. */
+  scheduledDate: Scalars['Date'];
+  /** The GUID of the scheduledSurface that was reviewed. */
+  scheduledSurfaceGuid: Scalars['ID'];
+};
+
 /** Input data for creating a scheduled entry for an Approved Item on a Scheduled Surface. */
 export type CreateScheduledCorpusItemInput = {
   /**
@@ -1155,6 +1166,8 @@ export type Mutation = {
   createLabel: Label;
   /** Creates a Rejected Item. */
   createRejectedCorpusItem: RejectedCorpusItem;
+  /** Marks the given scheduled surface as reviewed by human curators for a given date. */
+  createScheduleReview: ScheduleReview;
   /** Creates a Scheduled Surface Scheduled Item. */
   createScheduledCorpusItem: ScheduledCorpusItem;
   /** Deletes a CollectionPartnerAssociation. */
@@ -1280,6 +1293,10 @@ export type MutationCreateLabelArgs = {
 
 export type MutationCreateRejectedCorpusItemArgs = {
   data: CreateRejectedCorpusItemInput;
+};
+
+export type MutationCreateScheduleReviewArgs = {
+  data: CreateScheduleReviewInput;
 };
 
 export type MutationCreateScheduledCorpusItemArgs = {
@@ -1545,6 +1562,7 @@ export enum ProspectType {
   CountsModeled = 'COUNTS_MODELED',
   Dismissed = 'DISMISSED',
   DomainAllowlist = 'DOMAIN_ALLOWLIST',
+  ExternalEditorial = 'EXTERNAL_EDITORIAL',
   Recommended = 'RECOMMENDED',
   RssLogistic = 'RSS_LOGISTIC',
   RssLogisticRecent = 'RSS_LOGISTIC_RECENT',
@@ -1889,6 +1907,19 @@ export type RescheduleScheduledCorpusItemInput = {
   source: ScheduledItemSource;
 };
 
+/** Contains information about the human curator who reviewed the schedule for a given date and scheduled surface. */
+export type ScheduleReview = {
+  __typename?: 'ScheduleReview';
+  /** A Unix timestamp of when the scheduled was last reviewed. */
+  reviewedAt: Scalars['Date'];
+  /** A single sign-on user identifier of the user who reviewed the schedule. */
+  reviewedBy: Scalars['String'];
+  /** The date of the schedule that was reviewed, in YYYY-MM-DD format. */
+  scheduledDate: Scalars['Date'];
+  /** The GUID of the scheduledSurface that was reviewed. */
+  scheduledSurfaceGuid: Scalars['ID'];
+};
+
 /**
  * A scheduled entry for an Approved Item to appear on a Scheduled Surface.
  * For example, a story that is scheduled to appear on December 31st, 2021 on the New Tab in Firefox for the US audience.
@@ -1935,6 +1966,8 @@ export type ScheduledCorpusItemsResult = {
   collectionCount: Scalars['Int'];
   /** An array of items for a given Scheduled Surface */
   items: Array<ScheduledCorpusItem>;
+  /** The human review status of the schedule for the given scheduledSurfaceGuid & scheduledDate. */
+  scheduleReview?: Maybe<ScheduleReview>;
   /** The date items are scheduled for, in YYYY-MM-DD format. */
   scheduledDate: Scalars['Date'];
   /** The number of syndicated articles for the scheduled date. */
@@ -2104,6 +2137,7 @@ export enum Topics {
   Food = 'FOOD',
   Gaming = 'GAMING',
   HealthFitness = 'HEALTH_FITNESS',
+  Home = 'HOME',
   Parenting = 'PARENTING',
   PersonalFinance = 'PERSONAL_FINANCE',
   Politics = 'POLITICS',

--- a/src/curated-corpus/integration-test-mocks/getScheduledSurfacesForUser.ts
+++ b/src/curated-corpus/integration-test-mocks/getScheduledSurfacesForUser.ts
@@ -23,7 +23,7 @@ const allScheduledSurfaces: ScheduledSurface[] = [
       ProspectType.RssLogistic,
       ProspectType.RssLogisticRecent,
       ProspectType.SlateSchedulerV2,
-      ProspectType.ExternalEditorial,
+      ProspectType.PublisherSubmitted,
     ],
   },
   {
@@ -36,7 +36,7 @@ const allScheduledSurfaces: ScheduledSurface[] = [
       ProspectType.DomainAllowlist,
       ProspectType.Dismissed,
       ProspectType.TitleUrlModeled,
-      ProspectType.ExternalEditorial,
+      ProspectType.PublisherSubmitted,
     ],
   },
   {

--- a/src/curated-corpus/integration-test-mocks/getScheduledSurfacesForUser.ts
+++ b/src/curated-corpus/integration-test-mocks/getScheduledSurfacesForUser.ts
@@ -17,8 +17,6 @@ const allScheduledSurfaces: ScheduledSurface[] = [
       ProspectType.TopSaved,
       ProspectType.DomainAllowlist,
       ProspectType.Dismissed,
-      ProspectType.SyndicatedRerun,
-      ProspectType.SyndicatedNew,
       ProspectType.CountsModeled,
       ProspectType.TimespentModeled,
       ProspectType.TitleUrlModeled,

--- a/src/curated-corpus/integration-test-mocks/getScheduledSurfacesForUser.ts
+++ b/src/curated-corpus/integration-test-mocks/getScheduledSurfacesForUser.ts
@@ -1,6 +1,6 @@
-import { ProspectType, ScheduledSurface } from '../../api/generatedTypes';
-import { getScheduledSurfacesForUser } from '../../api/queries/getScheduledSurfacesForUser';
-import { constructMock } from './utils';
+import {ProspectType, ScheduledSurface} from '../../api/generatedTypes';
+import {getScheduledSurfacesForUser} from '../../api/queries/getScheduledSurfacesForUser';
+import {constructMock} from './utils';
 
 /**
  * The source array with all the scheduled surfaces available in the Curation Tool.
@@ -25,6 +25,7 @@ const allScheduledSurfaces: ScheduledSurface[] = [
       ProspectType.RssLogistic,
       ProspectType.RssLogisticRecent,
       ProspectType.SlateSchedulerV2,
+      ProspectType.ExternalEditorial,
     ],
   },
   {
@@ -37,6 +38,7 @@ const allScheduledSurfaces: ScheduledSurface[] = [
       ProspectType.DomainAllowlist,
       ProspectType.Dismissed,
       ProspectType.TitleUrlModeled,
+      ProspectType.ExternalEditorial,
     ],
   },
   {

--- a/src/curated-corpus/integration-test-mocks/getScheduledSurfacesForUser.ts
+++ b/src/curated-corpus/integration-test-mocks/getScheduledSurfacesForUser.ts
@@ -1,6 +1,6 @@
-import {ProspectType, ScheduledSurface} from '../../api/generatedTypes';
-import {getScheduledSurfacesForUser} from '../../api/queries/getScheduledSurfacesForUser';
-import {constructMock} from './utils';
+import { ProspectType, ScheduledSurface } from '../../api/generatedTypes';
+import { getScheduledSurfacesForUser } from '../../api/queries/getScheduledSurfacesForUser';
+import { constructMock } from './utils';
 
 /**
  * The source array with all the scheduled surfaces available in the Curation Tool.


### PR DESCRIPTION
## Goal

What changed? What is the business/product goal?
The Editors would like to have easy access to stories suggested by external publishers. 
They are currently being submitted via airtable.

We already have ingestion in our German auto-scheduler, so we are leveraging that to output a new prospect feed in this PR
https://github.com/MozillaSocial/ml-services/pull/430

New type is added in https://github.com/Pocket/content-monorepo/pull/213

References to deprecated Syndication prospect feed are removed as well.


## Implementation Decisions

Named the prospect source ExternalEditorial so users know these are external links and thus unvetted. 

Only URLs from previously published domains are sent to this feed. We might consider additional security checks in the future.

## Deployment steps
- [x] Deployed to dev?

## References

JIRA ticket:
[
- Link to JIRA ticket](https://mozilla-hub.atlassian.net/browse/MC-1404)

Issue:

- Link to GitHub issue

Documentation:

- Project doc
- https://mozilla-hub.atlassian.net/wiki/spaces/MozSocial/pages/762642732/Airtable+Editor+Submission+Specification
