### PR TITLE
feat(corpus): [MC-1446] Add new 'Publisher Request' rejection reason

### DIFF
--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -1846,6 +1846,7 @@ export enum RejectionReason {
   Paywall = 'PAYWALL',
   PoliticalOpinion = 'POLITICAL_OPINION',
   PublisherQuality = 'PUBLISHER_QUALITY',
+  PublisherRequest = 'PUBLISHER_REQUEST',
   TimeSensitive = 'TIME_SENSITIVE',
 }
 

--- a/src/curated-corpus/components/RejectItemForm/RejectItemForm.test.tsx
+++ b/src/curated-corpus/components/RejectItemForm/RejectItemForm.test.tsx
@@ -18,9 +18,9 @@ describe('The RejectItemForm component', () => {
     render(<RejectItemForm onSubmit={handleSubmit} />);
 
     const checkboxes = screen.getAllByRole('checkbox');
-    // We have six rejection reasons. They come from an enum in the Curated Corpus
+    // We have seven rejection reasons. They come from an enum in the Curated Corpus
     // API schema - RejectionReason and are available through the codegen types.
-    expect(checkboxes).toHaveLength(6);
+    expect(checkboxes).toHaveLength(7);
 
     const buttons = screen.getAllByRole('button');
     // "Save" and "Cancel" buttons are expected here.

--- a/src/curated-corpus/components/RejectItemForm/RejectItemForm.tsx
+++ b/src/curated-corpus/components/RejectItemForm/RejectItemForm.tsx
@@ -38,6 +38,7 @@ export const RejectItemForm: React.FC<
       [RejectionReason.OffensiveMaterial]: false,
       [RejectionReason.TimeSensitive]: false,
       [RejectionReason.Misinformation]: false,
+      [RejectionReason.PublisherRequest]: false,
       [RejectionReason.Other]: false,
       reason: '',
     },
@@ -97,10 +98,6 @@ export const RejectItemForm: React.FC<
               }
               label="Offensive material"
             />
-          </FormGroup>
-        </Grid>
-        <Grid item xs={12} sm={6}>
-          <FormGroup>
             <FormControlLabel
               control={
                 <Checkbox
@@ -112,6 +109,10 @@ export const RejectItemForm: React.FC<
               }
               label="Time sensitive"
             />
+          </FormGroup>
+        </Grid>
+        <Grid item xs={12} sm={6}>
+          <FormGroup>
             <FormControlLabel
               control={
                 <Checkbox
@@ -122,6 +123,17 @@ export const RejectItemForm: React.FC<
                 />
               }
               label="Misinformation"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  color="primary"
+                  {...formik.getFieldProps({
+                    name: RejectionReason.PublisherRequest,
+                  })}
+                />
+              }
+              label="Publisher Request"
             />
             <FormControlLabel
               control={

--- a/src/curated-corpus/components/RejectItemForm/RejectItemForm.validation.tsx
+++ b/src/curated-corpus/components/RejectItemForm/RejectItemForm.validation.tsx
@@ -8,6 +8,7 @@ export const validationSchema = yup
     [RejectionReason.OffensiveMaterial]: yup.boolean(),
     [RejectionReason.TimeSensitive]: yup.boolean(),
     [RejectionReason.Misinformation]: yup.boolean(),
+    [RejectionReason.PublisherRequest]: yup.boolean(),
     [RejectionReason.Other]: yup.boolean(),
   })
   .test('reason', '', (obj) => {
@@ -18,6 +19,7 @@ export const validationSchema = yup
       obj[RejectionReason.OffensiveMaterial] ||
       obj[RejectionReason.TimeSensitive] ||
       obj[RejectionReason.Misinformation] ||
+      obj[RejectionReason.PublisherRequest] ||
       obj[RejectionReason.Other]
     ) {
       return true;


### PR DESCRIPTION
## Goal

Add the new rejection reason (`Publisher Request`) to Curation Tools frontend so that curators can start using it where necessary. 

Testing: I have verified it works after deploying the backend change to Dev.

## Follow-up

There are two more reasons available on the backend that we're NOT using on the frontend. These are `COMMERCIAL` and `PUBLISHER_QUALITY`. Should we add them, too?

## Screenshots

<img width="987" alt="new-rejection-reason" src="https://github.com/user-attachments/assets/b390f4c7-23f1-4c25-9616-59a400d1214d">
 
## Reference

https://mozilla-hub.atlassian.net/browse/MC-1446