### PR TITLE
feat(corpus): [MC-1502] Filter schedule view by 'time-sensitive' on all surfaces

### DIFF
--- a/src/curated-corpus/components/ScheduleDayData/ScheduleDayData.tsx
+++ b/src/curated-corpus/components/ScheduleDayData/ScheduleDayData.tsx
@@ -170,7 +170,9 @@ export const ScheduleDayData: React.FC<ScheduleDayDataProps> = (
                 (filters.types === 'Collections' &&
                   item.approvedItem.isCollection) ||
                 (filters.types === 'Syndicated' &&
-                  item.approvedItem.isSyndicated)
+                  item.approvedItem.isSyndicated) ||
+                (filters.types === 'Time-sensitive' &&
+                  item.approvedItem.isTimeSensitive)
               ) {
                 return (
                   <ScheduledItemCardWrapper

--- a/src/curated-corpus/components/ScheduleDayFilterRow/ScheduleDayFilterRow.tsx
+++ b/src/curated-corpus/components/ScheduleDayFilterRow/ScheduleDayFilterRow.tsx
@@ -88,6 +88,11 @@ export const ScheduleDayFilterRow: React.FC<ScheduleDayFilterRowProps> = (
       count: scheduledItems.filter((item) => item.approvedItem.isCollection)
         .length,
     },
+    {
+      name: 'Time-sensitive',
+      count: scheduledItems.filter((item) => item.approvedItem.isTimeSensitive)
+        .length,
+    },
   ];
 
   return (


### PR DESCRIPTION
## Goal

Add a filter for the `isTimeSensitive` property of corpus items so that curators can narrow down the list of scheduled items to just the time-sensitive ones. Note: no updates to tests as we don't test for the presence of each and every dropdown option in the filters; otherwise filter-related test coverage is good.

## Demo

Note: deployed to Dev for a more easily accessible demo. Screenshot below:

<img width="1476" alt="schedule-time-sensitive" src="https://github.com/user-attachments/assets/e3f96ad5-a955-45b6-b103-14d8cadd9d42">


## Reference

https://mozilla-hub.atlassian.net/browse/MC-1502