### PR TITLE
fix(scheduling): [MC-1554] Fix same day scheduling from Schedule view

### DIFF
--- a/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.test.tsx
+++ b/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.test.tsx
@@ -19,7 +19,7 @@ describe('The ScheduleItemForm component', () => {
       prospectTypes: [
         ProspectType.Timespent,
         ProspectType.TopSaved,
-        ProspectType.SyndicatedNew,
+        ProspectType.PublisherSubmitted,
       ],
     },
     {

--- a/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.validation.tsx
+++ b/src/curated-corpus/components/ScheduleItemForm/ScheduleItemForm.validation.tsx
@@ -35,9 +35,18 @@ export const getValidationSchema = (
 
       scheduledDate: yup
         .date()
-        .min(DateTime.local())
-        .max(DateTime.local().plus({ days: 60 }))
-        .required('Please choose a date no more than 60 days in advance.')
+        .min(
+          // Rewind back to the start of the day locally so that curators
+          // are not unintentionally prevented from scheduling stories
+          // for the current date.
+          DateTime.local().startOf('day'),
+          'Stories cannot be scheduled in the past.',
+        )
+        .max(
+          DateTime.local().plus({ days: 60 }),
+          'Please choose a date no more than 60 days in advance.',
+        )
+        .required('This field is required.')
         .nullable(),
 
       [ManualScheduleReason.Evergreen]: yup.boolean(),


### PR DESCRIPTION
## Goal

Fix a bug described in the title of this PR.

- Updated validation rules for `scheduledDate` to evaluate today's timestamp that is the equivalent of the start of the day, and not any random time that occasionally prevented curators from schedulind.

- Updated validation messages to provide feedback to users when form validation fails.

- Removed an outdated prospect source from tests.

## Reference

https://mozilla-hub.atlassian.net/browse/MC-1554