### PR TITLE
MC-1556: Ensure ‘Coronavirus’ is not available as a Topic when adding an Item

### DIFF
--- a/src/curated-corpus/helpers/definitions.ts
+++ b/src/curated-corpus/helpers/definitions.ts
@@ -17,7 +17,6 @@ export interface DropdownOption {
 export const topics: DropdownOption[] = [
   { code: Topics.Business, name: 'Business' },
   { code: Topics.Career, name: 'Career' },
-  // { code: Topics.Coronavirus, name: 'Coronavirus' },
   { code: Topics.Education, name: 'Education' },
   { code: Topics.Entertainment, name: 'Entertainment' },
   { code: Topics.Food, name: 'Food' },

--- a/src/curated-corpus/helpers/definitions.ts
+++ b/src/curated-corpus/helpers/definitions.ts
@@ -17,7 +17,7 @@ export interface DropdownOption {
 export const topics: DropdownOption[] = [
   { code: Topics.Business, name: 'Business' },
   { code: Topics.Career, name: 'Career' },
-  { code: Topics.Coronavirus, name: 'Coronavirus' },
+  // { code: Topics.Coronavirus, name: 'Coronavirus' },
   { code: Topics.Education, name: 'Education' },
   { code: Topics.Entertainment, name: 'Entertainment' },
   { code: Topics.Food, name: 'Food' },

--- a/src/curated-corpus/helpers/topics.test.ts
+++ b/src/curated-corpus/helpers/topics.test.ts
@@ -43,7 +43,7 @@ describe('helper functions related to topics', () => {
       expect(topics).to.be.an('array');
       // However, we're getting the entire list of topics here,
       // not just the ones stories belong to
-      expect(topics).to.have.lengthOf(17);
+      expect(topics).to.have.lengthOf(16);
 
       // And we expect to see the story topics, with the correct counts
       expect(topics).to.contain.deep.members([
@@ -94,7 +94,7 @@ describe('helper functions related to topics', () => {
 
     it('returns a full list of topics if requested', () => {
       const topics = getGroupedTopicData(data);
-      expect(topics).to.be.an('array').with.lengthOf(17);
+      expect(topics).to.be.an('array').with.lengthOf(16);
     });
   });
 });

--- a/src/curated-corpus/helpers/topics.test.ts
+++ b/src/curated-corpus/helpers/topics.test.ts
@@ -19,6 +19,11 @@ describe('helper functions related to topics', () => {
       expect(displayTopic).to.equal('N/A');
     });
 
+    it('returns "N/A" if topic is Coronavirus', () => {
+      const displayTopic = getDisplayTopic('Coronavirus');
+      expect(displayTopic).to.equal('N/A');
+    });
+
     it('returns "N/A" if topic is not part of shared data topic list', () => {
       const displayTopic = getDisplayTopic('BEST_BOOKS');
       expect(displayTopic).to.equal('N/A');
@@ -85,11 +90,6 @@ describe('helper functions related to topics', () => {
     it('returns an abbreviated list if not all topics are requested', () => {
       const topics = getGroupedTopicData(data, false);
       expect(topics).to.be.an('array').with.lengthOf(5);
-    });
-
-    it('returns a list of topics without "Coronavirus" if requested', () => {
-      const topics = getGroupedTopicData(data, true, false);
-      expect(topics).to.be.an('array').with.lengthOf(16);
     });
 
     it('returns a full list of topics if requested', () => {


### PR DESCRIPTION
## Goal

Upon adding, editing an item, ensure "Coronavirus" is not in the Topics list. For existing items with "Coronavirus" topic, the topic will be displayed as "N/A"

## Todos

- [x] deploy to dev

## Reference

Tickets:

- https://mozilla-hub.atlassian.net/browse/MC-1556
