### PR TITLE
MC-1583:"Fix Title” for English titles not capitalizing first word after single quote or colon

### DIFF
--- a/src/_shared/utils/applyApTitleCase.test.ts
+++ b/src/_shared/utils/applyApTitleCase.test.ts
@@ -1,4 +1,4 @@
-import { applyApTitleCase } from './applyApTitleCase';
+import { applyApTitleCase, lowercaseAfterApostrophe } from './applyApTitleCase';
 
 // examples taken from https://www.grammarly.com/blog/capitalization-in-the-titles/
 // tested at https://headlinecapitalization.com/ (AP style)
@@ -136,5 +136,16 @@ describe('applyApTitleCase', () => {
     sentencesWithContractions.forEach((swc) => {
       expect(applyApTitleCase(swc.result)).toEqual(swc.expected);
     });
+  });
+});
+
+describe('lowercaseAfterApostrophe', () => {
+  it('lowercase letter after apostrophe & return new string', () => {
+    const result = lowercaseAfterApostrophe("foo'S");
+    expect(result).toEqual("foo's");
+  });
+  it('lowercase letter after apostrophe, ignore string in quotes, & return new string', () => {
+    const result = lowercaseAfterApostrophe("'Foo' foo'S DaY's");
+    expect(result).toEqual("'Foo' foo's DaY's");
   });
 });

--- a/src/_shared/utils/applyApTitleCase.test.ts
+++ b/src/_shared/utils/applyApTitleCase.test.ts
@@ -113,4 +113,28 @@ describe('applyApTitleCase', () => {
       expect(applyApTitleCase(swc.result)).toEqual(swc.expected);
     });
   });
+
+  it('should differentiate between strings in quotes and apostrophe', () => {
+    const sentencesWithContractions = [
+      {
+        result: "Here's what you haven't noticed 'foo bar' foo'S",
+        expected: "Here's What You Haven't Noticed 'Foo Bar' Foo's",
+      },
+    ];
+    sentencesWithContractions.forEach((swc) => {
+      expect(applyApTitleCase(swc.result)).toEqual(swc.expected);
+    });
+  });
+
+  it('should capitalize after a colon (:)', () => {
+    const sentencesWithContractions = [
+      {
+        result: "Here's what you haven't noticed 'foo bar' foo'S: foo Bar",
+        expected: "Here's What You Haven't Noticed 'Foo Bar' Foo'S: Foo Bar",
+      },
+    ];
+    sentencesWithContractions.forEach((swc) => {
+      expect(applyApTitleCase(swc.result)).toEqual(swc.expected);
+    });
+  });
 });

--- a/src/_shared/utils/applyApTitleCase.ts
+++ b/src/_shared/utils/applyApTitleCase.ts
@@ -1,17 +1,24 @@
 export const STOP_WORDS =
   'a an and at but by for in nor of on or the to up yet';
 
+// Matches a colon (:) and 0+ white spaces following after
+// Matches 1+ white spaces
+// Matches special chars (i.e. hyphens, quotes, etc)
 export const SEPARATORS = /(:\s*|\s+|[-‑–—,:;!?()“”'‘"])/; // Include curly quotes as separators
 
 export const stop = STOP_WORDS.split(' ');
 
 /**
  * Format a string: Capture the letter after an apostrophe at the end of a
- * sentence (without requiring a space) or with a white space following the letter
+ * sentence (without requiring a space) or with a white space following the letter.
+ * Lowercase the captured letter & return the formatted string.
  * @param input
  * @returns {string}
  */
 export const lowercaseAfterApostrophe = (input: string): string => {
+  // matches a char (num or letter) right after an apostrophe,
+  // only if the apostrophe is preceded by a char & is followed
+  // by a space or end of the str.
   const regex = /(?<=\w)'(\w)(?=\s|$)/g;
 
   return input.replace(regex, (match, p1) => {

--- a/src/_shared/utils/applyApTitleCase.ts
+++ b/src/_shared/utils/applyApTitleCase.ts
@@ -66,8 +66,8 @@ export const applyApTitleCase = (value: string): string => {
         index > 0 &&
         (allWords[index - 1] === "'" ||
           allWords[index - 1] === '"' ||
-          allWords[index - 1] === '\u2018' ||
-          allWords[index - 1] === '\u201C');
+          allWords[index - 1] === '\u2018' || // Opening single quote ’
+          allWords[index - 1] === '\u201C'); // Opening double quote “
 
       if (
         index === 0 || // first word


### PR DESCRIPTION
## Goal

Fix the capitalization rules for english titles:
* Capitalize the word "so" (remove as a stop word)
* Capitalize the first word (regardless if it is a stop word) after a quote: `'the day'` -> `'The Day'`
* Ensure there is a difference between a quote and apostrophe: `'the day' day'S` -> `'The Day' Day's`
* Capitalize word after a colon (:): '`the day' day's: day` -> `'The Day' Day's: Day`

Final result: `Amorim aims to 'prove something' at Manchester United after agreeing deal: read the day's 'news'` -> `Amorim Aims to ‘Prove Something’ at Manchester United After Agreeing Deal: Read the Day’s ‘News’`
 
## Todos

- [x] deploy to dev

## Reference

Tickets:

- https://mozilla-hub.atlassian.net/browse/MC-1583

