### PR TITLE
MC-1594: Fix English title apostrophe formatting

### DIFF
--- a/src/_shared/utils/applyApTitleCase.test.ts
+++ b/src/_shared/utils/applyApTitleCase.test.ts
@@ -130,7 +130,7 @@ describe('applyApTitleCase', () => {
     const sentencesWithContractions = [
       {
         result: "Here's what you haven't noticed 'foo bar' foo'S: foo Bar",
-        expected: "Here's What You Haven't Noticed 'Foo Bar' Foo'S: Foo Bar",
+        expected: "Here's What You Haven't Noticed 'Foo Bar' Foo's: Foo Bar",
       },
     ];
     sentencesWithContractions.forEach((swc) => {
@@ -145,7 +145,9 @@ describe('lowercaseAfterApostrophe', () => {
     expect(result).toEqual("foo's");
   });
   it('lowercase letter after apostrophe, ignore string in quotes, & return new string', () => {
-    const result = lowercaseAfterApostrophe("'Foo' foo'S DaY's");
-    expect(result).toEqual("'Foo' foo's DaY's");
+    const result = lowercaseAfterApostrophe(
+      "'Foo' foo'S DaY's You'Ll 'foo Bar foo'Ss'",
+    );
+    expect(result).toEqual("'Foo' foo's DaY's You'll 'foo Bar foo'ss'");
   });
 });

--- a/src/_shared/utils/applyApTitleCase.ts
+++ b/src/_shared/utils/applyApTitleCase.ts
@@ -9,20 +9,18 @@ export const SEPARATORS = /(:\s*|\s+|[-‑–—,:;!?()“”'‘"])/; // Includ
 export const stop = STOP_WORDS.split(' ');
 
 /**
- * Format a string: Capture the letter after an apostrophe at the end of a
- * sentence (without requiring a space) or with a white space following the letter.
+ * Format a string: Match the letter after an apostrophe & capture the apostrophe and matched char.
  * Lowercase the captured letter & return the formatted string.
  * @param input
  * @returns {string}
  */
 export const lowercaseAfterApostrophe = (input: string): string => {
-  // matches a char (num or letter) right after an apostrophe,
-  // only if the apostrophe is preceded by a char & is followed
-  // by a space or end of the str.
-  const regex = /(?<=\w)'(\w)(?=\s|$)/g;
+  // matches an apostrophe followed by a char
+  // ensures only the first char after the apostrophe is converted to lowercase
+  const regex = /(?<=\w)(')(\w)/g;
 
-  return input.replace(regex, (match, p1) => {
-    return `'${p1.toLowerCase()}`; // Replace with the apostrophe and the lowercase letter
+  return input.replace(regex, (match, p1, char) => {
+    return `'${char.toLowerCase()}`; // Lowercase the first char after the apostrophe
   });
 };
 


### PR DESCRIPTION
## Goal

Fix the apostrophe formatting for English titles. Currently, words with an apostrophe + 1 letter following the apostrophe have been formatted correctly:`bat'S` -> `bat's`.

Words with 2+ letters following an apostrophe were not formatted correctly: `you'll` -> `You'Ll`.
Desired output: `you'll` -> `You'll`

## Todos
- [x] deploy to dev

## Reference

Tickets:

- https://mozilla-hub.atlassian.net/browse/MC-1594