### PR TITLE
MC-1646: updating generated types

### DIFF
--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -541,7 +541,7 @@ export type CreateApprovedCorpusItemInput = {
   /** Optionally, specify the date this item should be appearing on a Scheduled Surface. Format: YYYY-MM-DD */
   scheduledDate?: InputMaybe<Scalars['Date']>;
   /** Optionally, specify the source of the Scheduled Item. Could be one of: MANUAL or ML */
-  scheduledSource?: InputMaybe<ScheduledItemSource>;
+  scheduledSource?: InputMaybe<ActivitySource>;
   /** Optionally, specify the GUID of the Scheduled Surface this item should be scheduled for. */
   scheduledSurfaceGuid?: InputMaybe<Scalars['ID']>;
   /** The source of the corpus item. */
@@ -679,7 +679,7 @@ export type CreateScheduledCorpusItemInput = {
   /** The GUID of the Scheduled Surface the Approved Item is going to appear on. Example: 'NEW_TAB_EN_US'. */
   scheduledSurfaceGuid: Scalars['ID'];
   /** Source of the Scheduled Item. Could be one of: MANUAL or ML */
-  source: ScheduledItemSource;
+  source: ActivitySource;
 };
 
 /** Input data for adding a SectionItem to a Section */
@@ -851,7 +851,7 @@ export type ImportApprovedCorpusItemInput = {
    *
    * This field was added after this import mutation was created. We may need to expand the enum value list if this mutation is used in the future.
    */
-  scheduledSource: ScheduledItemSource;
+  scheduledSource: ActivitySource;
   /** The GUID of the Scheduled Surface this item should be scheduled for. */
   scheduledSurfaceGuid: Scalars['ID'];
   /** The source of the corpus item. */
@@ -1243,6 +1243,8 @@ export type Mutation = {
    * Called when removing a prospect from the list - specifically not approving or rejecting into the corpus.
    */
   removeProspect?: Maybe<Prospect>;
+  /** Removes an active SectionItem from a Section. */
+  removeSectionItem: SectionItem;
   /** Updates the scheduled date of a Scheduled Surface Scheduled Item. */
   rescheduleScheduledCorpusItem: ScheduledCorpusItem;
   /** Updates an Approved Item. */
@@ -1384,6 +1386,10 @@ export type MutationRejectApprovedCorpusItemArgs = {
 
 export type MutationRemoveProspectArgs = {
   data: RemoveProspectInput;
+};
+
+export type MutationRemoveSectionItemArgs = {
+  externalId: Scalars['String'];
 };
 
 export type MutationRescheduleScheduledCorpusItemArgs = {
@@ -1968,7 +1974,7 @@ export type RescheduleScheduledCorpusItemInput = {
   /** The new scheduled date for the scheduled item to appear on a Scheduled Surface. Format: YYYY-MM-DD. */
   scheduledDate: Scalars['Date'];
   /** Source of the Scheduled Item. Could be one of: MANUAL or ML */
-  source: ScheduledItemSource;
+  source: ActivitySource;
 };
 
 /** Contains information about the human curator who reviewed the schedule for a given date and scheduled surface. */
@@ -2006,7 +2012,7 @@ export type ScheduledCorpusItem = {
   /** The GUID of this scheduledSurface to which this item is scheduled. Example: 'NEW_TAB_EN_US'. */
   scheduledSurfaceGuid: Scalars['ID'];
   /** Source of the Scheduled Item. Could be one of: MANUAL or ML */
-  source: ScheduledItemSource;
+  source: ActivitySource;
   /** A Unix timestamp of when the entity was last updated. */
   updatedAt: Scalars['Int'];
   /** A single sign-on user identifier of the user who last updated this entity. Null on creation. */
@@ -2040,14 +2046,6 @@ export type ScheduledCorpusItemsResult = {
   totalCount: Scalars['Int'];
 };
 
-/** The source of the Scheduled item */
-export enum ScheduledItemSource {
-  /** Manually entered through the curation admin tool */
-  Manual = 'MANUAL',
-  /** Created by ML */
-  Ml = 'ML',
-}
-
 /** A Scheduled Surface, including its associated Prospect Types. */
 export type ScheduledSurface = {
   __typename?: 'ScheduledSurface';
@@ -2069,6 +2067,7 @@ export type SearchCollectionsFilters = {
   title?: InputMaybe<Scalars['String']>;
 };
 
+/** An entity containing Corpus Items. */
 export type Section = {
   __typename?: 'Section';
   /** Indicates whether or not a Section is available for display. */
@@ -2094,10 +2093,16 @@ export type Section = {
   updatedAt: Scalars['Int'];
 };
 
-/** An ApprovedItem belonging to a Section */
+/** Available fields for filtering Sections. */
+export type SectionFilters = {
+  /** Required filter to retrieve Sections & SectionItems for a Scheduled Surface */
+  scheduledSurfaceGuid: Scalars['ID'];
+};
+
+/** A CorpusItem belonging to a Section */
 export type SectionItem = {
   __typename?: 'SectionItem';
-  /** The associated Approved Item. */
+  /** The associated Approved Corpus Item. */
   approvedItem: ApprovedCorpusItem;
   /** A Unix timestamp of when the entity was created. */
   createdAt: Scalars['Int'];
@@ -2823,7 +2828,7 @@ export type ScheduledItemDataFragment = {
   scheduledDate: any;
   updatedAt: number;
   updatedBy?: string | null;
-  source: ScheduledItemSource;
+  source: ActivitySource;
   approvedItem: {
     __typename?: 'ApprovedCorpusItem';
     externalId: string;
@@ -3095,7 +3100,7 @@ export type CreateScheduledCorpusItemMutationVariables = Exact<{
   approvedItemExternalId: Scalars['ID'];
   scheduledSurfaceGuid: Scalars['ID'];
   scheduledDate: Scalars['Date'];
-  source: ScheduledItemSource;
+  source: ActivitySource;
   reasons?: InputMaybe<Scalars['String']>;
   reasonComment?: InputMaybe<Scalars['String']>;
   actionScreen?: InputMaybe<ActionScreen>;
@@ -3397,7 +3402,7 @@ export type RemoveProspectMutation = {
 export type RescheduleScheduledCorpusItemMutationVariables = Exact<{
   externalId: Scalars['ID'];
   scheduledDate: Scalars['Date'];
-  source: ScheduledItemSource;
+  source: ActivitySource;
   actionScreen?: InputMaybe<ActionScreen>;
 }>;
 
@@ -3412,7 +3417,7 @@ export type RescheduleScheduledCorpusItemMutation = {
     scheduledDate: any;
     updatedAt: number;
     updatedBy?: string | null;
-    source: ScheduledItemSource;
+    source: ActivitySource;
     approvedItem: {
       __typename?: 'ApprovedCorpusItem';
       externalId: string;
@@ -4559,7 +4564,7 @@ export type GetScheduledItemsQuery = {
       scheduledDate: any;
       updatedAt: number;
       updatedBy?: string | null;
-      source: ScheduledItemSource;
+      source: ActivitySource;
       approvedItem: {
         __typename?: 'ApprovedCorpusItem';
         externalId: string;
@@ -5537,7 +5542,7 @@ export const CreateScheduledCorpusItemDocument = gql`
     $approvedItemExternalId: ID!
     $scheduledSurfaceGuid: ID!
     $scheduledDate: Date!
-    $source: ScheduledItemSource!
+    $source: ActivitySource!
     $reasons: String
     $reasonComment: String
     $actionScreen: ActionScreen
@@ -6052,7 +6057,7 @@ export const RescheduleScheduledCorpusItemDocument = gql`
   mutation rescheduleScheduledCorpusItem(
     $externalId: ID!
     $scheduledDate: Date!
-    $source: ScheduledItemSource!
+    $source: ActivitySource!
     $actionScreen: ActionScreen
   ) {
     rescheduleScheduledCorpusItem(

--- a/src/api/mutations/createScheduledCorpusItem.ts
+++ b/src/api/mutations/createScheduledCorpusItem.ts
@@ -6,7 +6,7 @@ export const createScheduledCorpusItem = gql`
     $approvedItemExternalId: ID!
     $scheduledSurfaceGuid: ID!
     $scheduledDate: Date!
-    $source: ScheduledItemSource!
+    $source: ActivitySource!
     $reasons: String
     $reasonComment: String
     $actionScreen: ActionScreen

--- a/src/api/mutations/rescheduledScheduledItem.ts
+++ b/src/api/mutations/rescheduledScheduledItem.ts
@@ -5,7 +5,7 @@ export const rescheduleScheduledItem = gql`
   mutation rescheduleScheduledCorpusItem(
     $externalId: ID!
     $scheduledDate: Date!
-    $source: ScheduledItemSource!
+    $source: ActivitySource!
     $actionScreen: ActionScreen
   ) {
     rescheduleScheduledCorpusItem(

--- a/src/curated-corpus/components/RemoveItemFromScheduledSurfaceModal/RemoveItemFromScheduledSurfaceModal.test.tsx
+++ b/src/curated-corpus/components/RemoveItemFromScheduledSurfaceModal/RemoveItemFromScheduledSurfaceModal.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import {
   ScheduledCorpusItem,
-  ScheduledItemSource,
+  ActivitySource,
 } from '../../../api/generatedTypes';
 import { RemoveItemFromScheduledSurfaceModal } from './RemoveItemFromScheduledSurfaceModal';
 import { getTestApprovedItem } from '../../helpers/approvedItem';
@@ -19,7 +19,7 @@ describe('The RemoveItemFromScheduledSurfaceModal component', () => {
     scheduledSurfaceGuid: 'POCKET_HITS_DE_DE',
     updatedAt: 1635114926,
     updatedBy: 'jdoe',
-    source: ScheduledItemSource.Manual,
+    source: ActivitySource.Manual,
   };
   const usItem: ScheduledCorpusItem = {
     approvedItem,
@@ -30,7 +30,7 @@ describe('The RemoveItemFromScheduledSurfaceModal component', () => {
     scheduledSurfaceGuid: 'NEW_TAB_EN_US',
     updatedAt: 1935114924,
     updatedBy: 'klm',
-    source: ScheduledItemSource.Manual,
+    source: ActivitySource.Manual,
   };
   const isOpen = true;
   const onSave = jest.fn();

--- a/src/curated-corpus/components/ScheduleDayData/ScheduleDayData.tsx
+++ b/src/curated-corpus/components/ScheduleDayData/ScheduleDayData.tsx
@@ -3,7 +3,7 @@ import { Box, Grid } from '@mui/material';
 import {
   ScheduledCorpusItem,
   ScheduledCorpusItemsResult,
-  ScheduledItemSource,
+  ActivitySource,
   useRescheduleScheduledCorpusItemMutation,
 } from '../../../api/generatedTypes';
 import {
@@ -162,10 +162,10 @@ export const ScheduleDayData: React.FC<ScheduleDayDataProps> = (
                 filters.topics === getDisplayTopic(item.approvedItem.topic) ||
                 filters.publishers === item.approvedItem.publisher ||
                 (filters.types === 'Ml' &&
-                  item.source === ScheduledItemSource.Ml &&
+                  item.source === ActivitySource.Ml &&
                   !item.approvedItem.isSyndicated) ||
                 (filters.types == 'ML-Syndicated' &&
-                  item.source === ScheduledItemSource.Ml &&
+                  item.source === ActivitySource.Ml &&
                   item.approvedItem.isSyndicated) ||
                 (filters.types === 'Collections' &&
                   item.approvedItem.isCollection) ||

--- a/src/curated-corpus/components/ScheduleDayFilterRow/ScheduleDayFilterRow.tsx
+++ b/src/curated-corpus/components/ScheduleDayFilterRow/ScheduleDayFilterRow.tsx
@@ -6,7 +6,7 @@ import { DropDownFilter } from '../../components';
 import {
   Maybe,
   ScheduledCorpusItem,
-  ScheduledItemSource,
+  ActivitySource,
 } from '../../../api/generatedTypes';
 import { getDisplayTopic, getGroupedTopicData } from '../../helpers/topics';
 import { getGroupedPublisherData } from '../../helpers/publishers';
@@ -66,16 +66,14 @@ export const ScheduleDayFilterRow: React.FC<ScheduleDayFilterRowProps> = (
       name: 'Ml',
       count: scheduledItems.filter(
         (item) =>
-          item.source === ScheduledItemSource.Ml &&
-          !item.approvedItem.isSyndicated,
+          item.source === ActivitySource.Ml && !item.approvedItem.isSyndicated,
       ).length,
     },
     {
       name: 'ML-Syndicated',
       count: scheduledItems.filter(
         (item) =>
-          item.source === ScheduledItemSource.Ml &&
-          item.approvedItem.isSyndicated,
+          item.source === ActivitySource.Ml && item.approvedItem.isSyndicated,
       ).length,
     },
     {

--- a/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.tsx
+++ b/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react';
 import { Grid } from '@mui/material';
 import {
   ScheduledCorpusItem,
-  ScheduledItemSource,
+  ActivitySource,
 } from '../../../api/generatedTypes';
 
 import { StyledScheduledItemCard } from '../../../_shared/styled';
@@ -69,7 +69,7 @@ export const ScheduledItemCardWrapper: React.FC<
       <StyledScheduledItemCard variant="outlined">
         <SuggestedScheduleItemListCard
           item={item.approvedItem}
-          isMlScheduled={item.source === ScheduledItemSource.Ml}
+          isMlScheduled={item.source === ActivitySource.Ml}
           currentScheduledDate={currentScheduledDate}
           scheduledSurfaceGuid={scheduledSurfaceGuid}
           onEdit={onEdit}

--- a/src/curated-corpus/components/actions/ScheduleCorpusItemAction/ScheduleCorpusItemAction.tsx
+++ b/src/curated-corpus/components/actions/ScheduleCorpusItemAction/ScheduleCorpusItemAction.tsx
@@ -5,7 +5,7 @@ import {
   ActionScreen,
   ApprovedCorpusItem,
   CreateScheduledCorpusItemInput,
-  ScheduledItemSource,
+  ActivitySource,
   useCreateScheduledCorpusItemMutation,
 } from '../../../../api/generatedTypes';
 import { useNotifications, useRunMutation } from '../../../../_shared/hooks';
@@ -83,7 +83,7 @@ export const ScheduleCorpusItemAction: React.FC<
       approvedItemExternalId: item.externalId,
       scheduledSurfaceGuid: values.scheduledSurfaceGuid,
       scheduledDate: values.scheduledDate.toISODate(),
-      source: ScheduledItemSource.Manual,
+      source: ActivitySource.Manual,
       actionScreen,
     };
     // Run the mutation

--- a/src/curated-corpus/helpers/scheduledItem.ts
+++ b/src/curated-corpus/helpers/scheduledItem.ts
@@ -1,7 +1,4 @@
-import {
-  ScheduledCorpusItem,
-  ScheduledItemSource,
-} from '../../api/generatedTypes';
+import { ScheduledCorpusItem, ActivitySource } from '../../api/generatedTypes';
 import { getTestApprovedItem } from './approvedItem';
 import { ScheduledSurfaces } from './definitions';
 
@@ -9,7 +6,7 @@ export const scheduledItem: ScheduledCorpusItem = {
   externalId: '456-qwerty',
   scheduledDate: '2024-01-01',
   scheduledSurfaceGuid: ScheduledSurfaces[0].guid, // New Tab EN-US
-  source: ScheduledItemSource.Manual,
+  source: ActivitySource.Manual,
   createdAt: 1635014927,
   createdBy: 'Amy',
   updatedAt: 1635014927,

--- a/src/curated-corpus/integration-test-mocks/createScheduledCorpusItem.ts
+++ b/src/curated-corpus/integration-test-mocks/createScheduledCorpusItem.ts
@@ -1,4 +1,4 @@
-import { ActionScreen, ScheduledItemSource } from '../../api/generatedTypes';
+import { ActionScreen, ActivitySource } from '../../api/generatedTypes';
 
 import { createScheduledCorpusItem } from '../../api/mutations/createScheduledCorpusItem';
 import { getTestApprovedItem } from '../helpers/approvedItem';
@@ -22,7 +22,7 @@ export const successMock = (
         approvedItemExternalId: '123-abc',
         scheduledSurfaceGuid,
         scheduledDate,
-        source: ScheduledItemSource.Manual,
+        source: ActivitySource.Manual,
         actionScreen: ActionScreen.Schedule,
       },
     },

--- a/src/curated-corpus/integration-test-mocks/getScheduledItems.ts
+++ b/src/curated-corpus/integration-test-mocks/getScheduledItems.ts
@@ -5,7 +5,7 @@ import {
   CuratedStatus,
   GetScheduledItemsQuery,
   ScheduledCorpusItem,
-  ScheduledItemSource,
+  ActivitySource,
   Topics,
 } from '../../api/generatedTypes';
 import { getScheduledItems } from '../../api/queries/getScheduledItems';
@@ -50,7 +50,7 @@ export const scheduledItems: ScheduledCorpusItem[] = [
     updatedAt: 1635014926,
     updatedBy: 'Amy',
     scheduledSurfaceGuid: 'NEW_TAB_EN_US',
-    source: ScheduledItemSource.Manual,
+    source: ActivitySource.Manual,
     approvedItem,
   },
   {
@@ -61,7 +61,7 @@ export const scheduledItems: ScheduledCorpusItem[] = [
     updatedAt: 1635014926,
     updatedBy: 'Amy',
     scheduledSurfaceGuid: 'NEW_TAB_EN_US',
-    source: ScheduledItemSource.Manual,
+    source: ActivitySource.Manual,
     // Tweak topic & publisher to test ScheduleSummaryConnector
     approvedItem: {
       ...approvedItem,
@@ -78,7 +78,7 @@ export const scheduledItems: ScheduledCorpusItem[] = [
     updatedAt: 1635014926,
     updatedBy: 'Amy',
     scheduledSurfaceGuid: 'NEW_TAB_EN_US',
-    source: ScheduledItemSource.Ml,
+    source: ActivitySource.Ml,
     approvedItem: {
       ...approvedItem,
       topic: Topics.HealthFitness,

--- a/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
+++ b/src/curated-corpus/pages/ProspectingPage/ProspectingPage.tsx
@@ -27,7 +27,7 @@ import {
   CuratedStatus,
   Prospect,
   RejectProspectMutationVariables,
-  ScheduledItemSource,
+  ActivitySource,
   useCreateApprovedCorpusItemMutation,
   useCreateScheduledCorpusItemMutation,
   useGetProspectsLazyQuery,
@@ -535,7 +535,7 @@ export const ProspectingPage: React.FC = (): JSX.Element => {
       approvedItemExternalId: approvedItem?.externalId,
       scheduledSurfaceGuid: values.scheduledSurfaceGuid,
       scheduledDate: values.scheduledDate.toISODate(),
-      source: ScheduledItemSource.Manual,
+      source: ActivitySource.Manual,
       // Refrain from sending empty strings (form defaults) to the mutation
       // if no data has been supplied for these fields: for example, when they're
       // not needed for the Pocket Hits surface or any other surface where

--- a/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
+++ b/src/curated-corpus/pages/SchedulePage/SchedulePage.tsx
@@ -28,7 +28,7 @@ import {
   Prospect,
   ScheduledCorpusItem,
   ScheduledCorpusItemsResult,
-  ScheduledItemSource,
+  ActivitySource,
   useCreateApprovedCorpusItemMutation,
   useCreateScheduledCorpusItemMutation,
   useDeleteScheduledItemMutation,
@@ -499,7 +499,7 @@ export const SchedulePage: React.FC = (): ReactElement => {
       approvedItemExternalId: approvedItem?.externalId,
       scheduledSurfaceGuid: values.scheduledSurfaceGuid,
       scheduledDate: values.scheduledDate.toISODate(),
-      source: ScheduledItemSource.Manual,
+      source: ActivitySource.Manual,
       // Refrain from sending empty strings (form defaults) to the mutation
       // if no data has been supplied for these fields: for example, when they're
       // not needed for the Pocket Hits surface or any other surface where


### PR DESCRIPTION
## Goal
Updating generated types, replacing `ScheduledItemSource` enum with `ActivitySource` enum.

## Todos

- [x] Deployed to dev

## Reference

Tickets:

- https://mozilla-hub.atlassian.net/browse/MC-1646
