### PR TITLE
MC-1655: Adding the initial read-only page to manage Sections

### DIFF
--- a/src/_shared/components/Header/Header.tsx
+++ b/src/_shared/components/Header/Header.tsx
@@ -227,25 +227,33 @@ export const Header: React.FC<HeaderProps> = (props): JSX.Element => {
                 alignItems="center"
               >
                 <Hidden smDown implementation="css">
-                  <Grid item sm={8}>
+                  <Grid
+                    item
+                    sm={12}
+                    sx={{ display: 'flex', justifyContent: 'flex-end' }}
+                  >
                     <List
                       sx={{
                         display: 'flex',
                         flexDirection: 'row',
                         padding: 0,
+                        flexWrap: 'nowrap', // Prevents wrapping
+                        justifyContent: 'flex-end', // Keeps alignment the same
                       }}
                     >
-                      {menuLinks.map((link: MenuLink) => {
-                        return (
-                          <ListItem
-                            component={StyledAppBarLink}
-                            to={link.url}
-                            key={link.url}
-                          >
-                            <ListItemText primary={link.text} />
-                          </ListItem>
-                        );
-                      })}
+                      {menuLinks.map((link: MenuLink) => (
+                        <ListItem
+                          component={StyledAppBarLink}
+                          to={link.url}
+                          key={link.url}
+                          sx={{
+                            padding: '0 0.75rem',
+                            minWidth: 'auto',
+                          }}
+                        >
+                          <ListItemText primary={link.text} />
+                        </ListItem>
+                      ))}
                     </List>
                   </Grid>
                 </Hidden>

--- a/src/api/fragments/SectionData.ts
+++ b/src/api/fragments/SectionData.ts
@@ -1,0 +1,25 @@
+import { gql } from '@apollo/client';
+import { SectionItemData } from './SectionItemData';
+
+export const BaseSectionData = gql`
+  fragment BaseSectionData on Section {
+    externalId
+    title
+    scheduledSurfaceGuid
+    sort
+    createSource
+    active
+  }
+`;
+export const SectionData = gql`
+  fragment SectionData on Section {
+    ...BaseSectionData
+    sectionItems {
+      ...SectionItemData
+    }
+    createdAt
+    updatedAt
+  }
+  ${BaseSectionData}
+  ${SectionItemData}
+`;

--- a/src/api/fragments/SectionItemData.ts
+++ b/src/api/fragments/SectionItemData.ts
@@ -1,0 +1,22 @@
+import { gql } from '@apollo/client';
+import { CuratedItemData } from './curatedItemData';
+
+export const BaseSectionItemData = gql`
+  fragment BaseSectionItemData on SectionItem {
+    externalId
+    rank
+  }
+`;
+
+export const SectionItemData = gql`
+  fragment SectionItemData on SectionItem {
+    ...BaseSectionItemData
+    approvedItem {
+      ...CuratedItemData
+    }
+    createdAt
+    updatedAt
+  }
+  ${BaseSectionItemData}
+  ${CuratedItemData}
+`;

--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -2624,6 +2624,119 @@ export type CuratedItemDataWithHistoryFragment = {
   }>;
 };
 
+export type BaseSectionDataFragment = {
+  __typename?: 'Section';
+  externalId: string;
+  title: string;
+  scheduledSurfaceGuid: string;
+  sort?: number | null;
+  createSource: ActivitySource;
+  active: boolean;
+};
+
+export type SectionDataFragment = {
+  __typename?: 'Section';
+  createdAt: number;
+  updatedAt: number;
+  externalId: string;
+  title: string;
+  scheduledSurfaceGuid: string;
+  sort?: number | null;
+  createSource: ActivitySource;
+  active: boolean;
+  sectionItems: Array<{
+    __typename?: 'SectionItem';
+    createdAt: number;
+    updatedAt: number;
+    externalId: string;
+    rank?: number | null;
+    approvedItem: {
+      __typename?: 'ApprovedCorpusItem';
+      externalId: string;
+      prospectId?: string | null;
+      title: string;
+      language: CorpusLanguage;
+      publisher: string;
+      datePublished?: any | null;
+      url: any;
+      hasTrustedDomain: boolean;
+      imageUrl: any;
+      excerpt: string;
+      status: CuratedStatus;
+      source: CorpusItemSource;
+      topic: string;
+      isCollection: boolean;
+      isTimeSensitive: boolean;
+      isSyndicated: boolean;
+      createdBy: string;
+      createdAt: number;
+      updatedBy?: string | null;
+      updatedAt: number;
+      authors: Array<{
+        __typename?: 'CorpusItemAuthor';
+        name: string;
+        sortOrder: number;
+      }>;
+      scheduledSurfaceHistory: Array<{
+        __typename?: 'ApprovedCorpusItemScheduledSurfaceHistory';
+        externalId: string;
+        createdBy: string;
+        scheduledDate: any;
+        scheduledSurfaceGuid: string;
+      }>;
+    };
+  }>;
+};
+
+export type BaseSectionItemDataFragment = {
+  __typename?: 'SectionItem';
+  externalId: string;
+  rank?: number | null;
+};
+
+export type SectionItemDataFragment = {
+  __typename?: 'SectionItem';
+  createdAt: number;
+  updatedAt: number;
+  externalId: string;
+  rank?: number | null;
+  approvedItem: {
+    __typename?: 'ApprovedCorpusItem';
+    externalId: string;
+    prospectId?: string | null;
+    title: string;
+    language: CorpusLanguage;
+    publisher: string;
+    datePublished?: any | null;
+    url: any;
+    hasTrustedDomain: boolean;
+    imageUrl: any;
+    excerpt: string;
+    status: CuratedStatus;
+    source: CorpusItemSource;
+    topic: string;
+    isCollection: boolean;
+    isTimeSensitive: boolean;
+    isSyndicated: boolean;
+    createdBy: string;
+    createdAt: number;
+    updatedBy?: string | null;
+    updatedAt: number;
+    authors: Array<{
+      __typename?: 'CorpusItemAuthor';
+      name: string;
+      sortOrder: number;
+    }>;
+    scheduledSurfaceHistory: Array<{
+      __typename?: 'ApprovedCorpusItemScheduledSurfaceHistory';
+      externalId: string;
+      createdBy: string;
+      scheduledDate: any;
+      scheduledSurfaceGuid: string;
+    }>;
+  };
+};
+
 export type ShareableListCompletePropsFragment = {
   __typename?: 'ShareableListComplete';
   externalId: string;
@@ -4691,6 +4804,67 @@ export type SearchCollectionsQuery = {
   };
 };
 
+export type GetSectionsWithSectionItemsQueryVariables = Exact<{
+  scheduledSurfaceGuid: Scalars['ID'];
+}>;
+
+export type GetSectionsWithSectionItemsQuery = {
+  __typename?: 'Query';
+  getSectionsWithSectionItems: Array<{
+    __typename?: 'Section';
+    createdAt: number;
+    updatedAt: number;
+    externalId: string;
+    title: string;
+    scheduledSurfaceGuid: string;
+    sort?: number | null;
+    createSource: ActivitySource;
+    active: boolean;
+    sectionItems: Array<{
+      __typename?: 'SectionItem';
+      createdAt: number;
+      updatedAt: number;
+      externalId: string;
+      rank?: number | null;
+      approvedItem: {
+        __typename?: 'ApprovedCorpusItem';
+        externalId: string;
+        prospectId?: string | null;
+        title: string;
+        language: CorpusLanguage;
+        publisher: string;
+        datePublished?: any | null;
+        url: any;
+        hasTrustedDomain: boolean;
+        imageUrl: any;
+        excerpt: string;
+        status: CuratedStatus;
+        source: CorpusItemSource;
+        topic: string;
+        isCollection: boolean;
+        isTimeSensitive: boolean;
+        isSyndicated: boolean;
+        createdBy: string;
+        createdAt: number;
+        updatedBy?: string | null;
+        updatedAt: number;
+        authors: Array<{
+          __typename?: 'CorpusItemAuthor';
+          name: string;
+          sortOrder: number;
+        }>;
+        scheduledSurfaceHistory: Array<{
+          __typename?: 'ApprovedCorpusItemScheduledSurfaceHistory';
+          externalId: string;
+          createdBy: string;
+          scheduledDate: any;
+          scheduledSurfaceGuid: string;
+        }>;
+      };
+    }>;
+  }>;
+};
+
 export type GetStoryFromParserQueryVariables = Exact<{
   url: Scalars['String'];
 }>;
@@ -4881,6 +5055,80 @@ export const CollectionStoryDataFragmentDoc = gql`
     sortOrder
   }
 `;
+export const BaseSectionDataFragmentDoc = gql`
+  fragment BaseSectionData on Section {
+    externalId
+    title
+    scheduledSurfaceGuid
+    sort
+    createSource
+    active
+  }
+`;
+export const BaseSectionItemDataFragmentDoc = gql`
+  fragment BaseSectionItemData on SectionItem {
+    externalId
+    rank
+  }
+`;
+export const CuratedItemDataFragmentDoc = gql`
+  fragment CuratedItemData on ApprovedCorpusItem {
+    externalId
+    prospectId
+    title
+    language
+    publisher
+    datePublished
+    authors {
+      name
+      sortOrder
+    }
+    url
+    hasTrustedDomain
+    imageUrl
+    excerpt
+    status
+    source
+    topic
+    isCollection
+    isTimeSensitive
+    isSyndicated
+    createdBy
+    createdAt
+    updatedBy
+    updatedAt
+    scheduledSurfaceHistory {
+      externalId
+      createdBy
+      scheduledDate
+      scheduledSurfaceGuid
+    }
+  }
+`;
+export const SectionItemDataFragmentDoc = gql`
+  fragment SectionItemData on SectionItem {
+    ...BaseSectionItemData
+    approvedItem {
+      ...CuratedItemData
+    }
+    createdAt
+    updatedAt
+  }
+  ${BaseSectionItemDataFragmentDoc}
+  ${CuratedItemDataFragmentDoc}
+`;
+export const SectionDataFragmentDoc = gql`
+  fragment SectionData on Section {
+    ...BaseSectionData
+    sectionItems {
+      ...SectionItemData
+    }
+    createdAt
+    updatedAt
+  }
+  ${BaseSectionDataFragmentDoc}
+  ${SectionItemDataFragmentDoc}
+`;
 export const ShareableListItemPropsFragmentDoc = gql`
   fragment ShareableListItemProps on ShareableListItem {
     externalId
@@ -5029,40 +5277,6 @@ export const ProspectDataWithCorpusItemsFragmentDoc = gql`
   ${CuratedItemDataWithHistoryFragmentDoc}
   ${RejectedItemDataFragmentDoc}
   ${BasicParserItemDataFragmentDoc}
-`;
-export const CuratedItemDataFragmentDoc = gql`
-  fragment CuratedItemData on ApprovedCorpusItem {
-    externalId
-    prospectId
-    title
-    language
-    publisher
-    datePublished
-    authors {
-      name
-      sortOrder
-    }
-    url
-    hasTrustedDomain
-    imageUrl
-    excerpt
-    status
-    source
-    topic
-    isCollection
-    isTimeSensitive
-    isSyndicated
-    createdBy
-    createdAt
-    updatedBy
-    updatedAt
-    scheduledSurfaceHistory {
-      externalId
-      createdBy
-      scheduledDate
-      scheduledSurfaceGuid
-    }
-  }
 `;
 export const ScheduledItemDataFragmentDoc = gql`
   fragment ScheduledItemData on ScheduledCorpusItem {
@@ -8269,6 +8483,65 @@ export type SearchCollectionsLazyQueryHookResult = ReturnType<
 export type SearchCollectionsQueryResult = Apollo.QueryResult<
   SearchCollectionsQuery,
   SearchCollectionsQueryVariables
+>;
+export const GetSectionsWithSectionItemsDocument = gql`
+  query getSectionsWithSectionItems($scheduledSurfaceGuid: ID!) {
+    getSectionsWithSectionItems(scheduledSurfaceGuid: $scheduledSurfaceGuid) {
+      ...SectionData
+    }
+  }
+  ${SectionDataFragmentDoc}
+`;
+
+/**
+ * __useGetSectionsWithSectionItemsQuery__
+ *
+ * To run a query within a React component, call `useGetSectionsWithSectionItemsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetSectionsWithSectionItemsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetSectionsWithSectionItemsQuery({
+ *   variables: {
+ *      scheduledSurfaceGuid: // value for 'scheduledSurfaceGuid'
+ *   },
+ * });
+ */
+export function useGetSectionsWithSectionItemsQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetSectionsWithSectionItemsQuery,
+    GetSectionsWithSectionItemsQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetSectionsWithSectionItemsQuery,
+    GetSectionsWithSectionItemsQueryVariables
+  >(GetSectionsWithSectionItemsDocument, options);
+}
+export function useGetSectionsWithSectionItemsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetSectionsWithSectionItemsQuery,
+    GetSectionsWithSectionItemsQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetSectionsWithSectionItemsQuery,
+    GetSectionsWithSectionItemsQueryVariables
+  >(GetSectionsWithSectionItemsDocument, options);
+}
+export type GetSectionsWithSectionItemsQueryHookResult = ReturnType<
+  typeof useGetSectionsWithSectionItemsQuery
+>;
+export type GetSectionsWithSectionItemsLazyQueryHookResult = ReturnType<
+  typeof useGetSectionsWithSectionItemsLazyQuery
+>;
+export type GetSectionsWithSectionItemsQueryResult = Apollo.QueryResult<
+  GetSectionsWithSectionItemsQuery,
+  GetSectionsWithSectionItemsQueryVariables
 >;
 export const GetStoryFromParserDocument = gql`
   query getStoryFromParser($url: String!) {

--- a/src/api/queries/getSectionsWithSectionItems.ts
+++ b/src/api/queries/getSectionsWithSectionItems.ts
@@ -1,0 +1,15 @@
+import { gql } from '@apollo/client';
+import { SectionData } from '../fragments/SectionData';
+
+/**
+ * Retrieve all active Sections with their active SectionItems for a given ScheduledSurface.
+ * Returns an empty array if no Sections found.
+ */
+export const getSectionsWithSectionItems = gql`
+  query getSectionsWithSectionItems($scheduledSurfaceGuid: ID!) {
+    getSectionsWithSectionItems(scheduledSurfaceGuid: $scheduledSurfaceGuid) {
+      ...SectionData
+    }
+  }
+  ${SectionData}
+`;

--- a/src/curated-corpus/pages/CuratedCorpusLandingPage/CuratedCorpusLandingPage.tsx
+++ b/src/curated-corpus/pages/CuratedCorpusLandingPage/CuratedCorpusLandingPage.tsx
@@ -14,6 +14,7 @@ import {
   ProspectingPage,
   RejectedPage,
   SchedulePage,
+  SectionsPage,
 } from '../';
 import { client } from '../../../api/client';
 
@@ -40,6 +41,10 @@ export const CuratedCorpusLandingPage = (): JSX.Element => {
     {
       text: 'Rejected',
       url: `${path}/rejected/`,
+    },
+    {
+      text: 'Sections',
+      url: `${path}/sections/`,
     },
   ];
 
@@ -83,6 +88,12 @@ export const CuratedCorpusLandingPage = (): JSX.Element => {
                   all prospects that have been rejected.
                 </ListItemText>
               </ListItem>
+              <ListItem>
+                <ListItemText>
+                  <Link to={`${path}/sections/`}>Sections</Link> will show you
+                  all ML-generated sections with their related stories.
+                </ListItemText>
+              </ListItem>
             </List>
           </Route>
           <Route exact path={`${path}/prospecting/`}>
@@ -99,6 +110,9 @@ export const CuratedCorpusLandingPage = (): JSX.Element => {
           </Route>
           <Route exact path={`${path}/rejected/`}>
             <RejectedPage />
+          </Route>
+          <Route exact path={`${path}/sections/`}>
+            <SectionsPage />
           </Route>
           <Route component={PageNotFound} />
         </Switch>

--- a/src/curated-corpus/pages/SectionsPage/SectionsPage.tsx
+++ b/src/curated-corpus/pages/SectionsPage/SectionsPage.tsx
@@ -20,27 +20,25 @@ export const SectionsPage: React.FC = (): JSX.Element => {
     DropdownOption[]
   >([]);
 
-  // state variable to toggle on or off the empty state component
-  // if the callGetSectionsWithSectionItemsQuery query returns no data and no errors, this will be set to true
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [showEmptyState, setShowEmptyState] = useState<boolean>(false);
   const [currentSection, setCurrentSection] = useState('');
   // Get a list of sections on the page
-  const [callGetSectionsWithSectionItemsQuery, { error, data, refetch }] =
-    useGetSectionsWithSectionItemsLazyQuery({
-      // Do not cache sections. On update, remove the relevant section item
-      // cards from the screen manually once the sections have been checked by curators.
-      fetchPolicy: 'no-cache',
-      notifyOnNetworkStatusChange: true,
-      variables: {
-        scheduledSurfaceGuid: currentScheduledSurfaceGuid,
-      },
-      onCompleted: (data) => {
-        if (!data && !error) {
-          setShowEmptyState(true);
-        }
-      },
-    });
+  const [
+    callGetSectionsWithSectionItemsQuery,
+    {
+      // error commented out for now, enabled when enabling notifications
+      // error,
+      data,
+      refetch,
+    },
+  ] = useGetSectionsWithSectionItemsLazyQuery({
+    // Do not cache sections. On update, remove the relevant section item
+    // cards from the screen manually once the sections have been checked by curators.
+    fetchPolicy: 'no-cache',
+    notifyOnNetworkStatusChange: true,
+    variables: {
+      scheduledSurfaceGuid: currentScheduledSurfaceGuid,
+    },
+  });
 
   // Get the list of Scheduled Surfaces the currently logged-in user has access to.
   const {
@@ -58,7 +56,7 @@ export const SectionsPage: React.FC = (): JSX.Element => {
         setCurrentScheduledSurfaceGuid(options[0].code);
         setScheduledSurfaceOptions(options);
       }
-      // call the dependent queries now
+      // Call the dependent queries now
       callGetSectionsWithSectionItemsQuery();
     },
   });
@@ -68,7 +66,7 @@ export const SectionsPage: React.FC = (): JSX.Element => {
    * dropdown, refetch all the data on the page for that surface.
    */
   const updateScheduledSurface = (option: DropdownOption) => {
-    // fetch sections for the selected Scheduled Surface
+    // Fetch sections for the selected Scheduled Surface
     refetch && refetch({ scheduledSurfaceGuid: option.code });
 
     // Update the split button to reflect which ScheduledSurface the user is now on.
@@ -84,8 +82,7 @@ export const SectionsPage: React.FC = (): JSX.Element => {
 
   // Storing the sections here which will be shown in the UI.
   const [sections, setSections] = useState<Section[]>([]);
-  // Section titles to be displayed in the Dropdown
-  const [sectionTitles, setSectionTitles] = useState<string[]>([]);
+
   // Section options stored as a Dropdown object
   const [sectionOptions, setSectionOptions] = useState<DropdownOption[]>([]);
 
@@ -99,7 +96,6 @@ export const SectionsPage: React.FC = (): JSX.Element => {
       const sectionTitlesArr: string[] = fetchedSections.map(
         (section) => section.title,
       );
-      setSectionTitles(sectionTitlesArr);
 
       // Add "All Sections" option as default
       const options = [
@@ -138,7 +134,7 @@ export const SectionsPage: React.FC = (): JSX.Element => {
             </Grid>
             <Grid item xs={12} sm={6}>
               <Box display="flex" justifyContent="flex-end" mb={2}>
-                {sectionTitles.length > 0 && (
+                {sectionOptions.length > 0 && (
                   <SplitButton
                     icon={<FilterListIcon fontSize="large" />}
                     onMenuOptionClick={updateSection}

--- a/src/curated-corpus/pages/SectionsPage/SectionsPage.tsx
+++ b/src/curated-corpus/pages/SectionsPage/SectionsPage.tsx
@@ -1,0 +1,174 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Section,
+  useGetScheduledSurfacesForUserQuery,
+  useGetSectionsWithSectionItemsLazyQuery,
+} from '../../../api/generatedTypes';
+import { DropdownOption } from '../../helpers/definitions';
+import { Box, Grid } from '@mui/material';
+import { HandleApiResponse } from '../../../_shared/components';
+import { SplitButton } from '../../components';
+import FilterListIcon from '@mui/icons-material/FilterList';
+
+export const SectionsPage: React.FC = (): JSX.Element => {
+  // set up the initial scheduled surface guid value (nothing at this point)
+  const [currentScheduledSurfaceGuid, setCurrentScheduledSurfaceGuid] =
+    useState('');
+
+  // Set up the options we'll feed to the Scheduled Surface dropdown
+  const [scheduledSurfaceOptions, setScheduledSurfaceOptions] = useState<
+    DropdownOption[]
+  >([]);
+
+  // state variable to toggle on or off the empty state component
+  // if the callGetSectionsWithSectionItemsQuery query returns no data and no errors, this will be set to true
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [showEmptyState, setShowEmptyState] = useState<boolean>(false);
+  const [currentSection, setCurrentSection] = useState('');
+  // Get a list of sections on the page
+  const [callGetSectionsWithSectionItemsQuery, { error, data, refetch }] =
+    useGetSectionsWithSectionItemsLazyQuery({
+      // Do not cache sections. On update, remove the relevant section item
+      // cards from the screen manually once the sections have been checked by curators.
+      fetchPolicy: 'no-cache',
+      notifyOnNetworkStatusChange: true,
+      variables: {
+        scheduledSurfaceGuid: currentScheduledSurfaceGuid,
+      },
+      onCompleted: (data) => {
+        if (!data && !error) {
+          setShowEmptyState(true);
+        }
+      },
+    });
+
+  // Get the list of Scheduled Surfaces the currently logged-in user has access to.
+  const {
+    data: scheduledSurfaceData,
+    loading: scheduledSurfaceLoading,
+    error: scheduledSurfaceError,
+  } = useGetScheduledSurfacesForUserQuery({
+    onCompleted: (data) => {
+      const options = data.getScheduledSurfacesForUser.map(
+        (scheduledSurface) => {
+          return { code: scheduledSurface.guid, name: scheduledSurface.name };
+        },
+      );
+      if (options.length > 0) {
+        setCurrentScheduledSurfaceGuid(options[0].code);
+        setScheduledSurfaceOptions(options);
+      }
+      // call the dependent queries now
+      callGetSectionsWithSectionItemsQuery();
+    },
+  });
+
+  /**
+   * When the user selects another Scheduled Surface from the
+   * dropdown, refetch all the data on the page for that surface.
+   */
+  const updateScheduledSurface = (option: DropdownOption) => {
+    // fetch sections for the selected Scheduled Surface
+    refetch && refetch({ scheduledSurfaceGuid: option.code });
+
+    // Update the split button to reflect which ScheduledSurface the user is now on.
+    setCurrentScheduledSurfaceGuid(option.code);
+  };
+
+  /**
+   * When the user selects a section from the section Dropdown, set that current section.
+   */
+  const updateSection = (option: DropdownOption) => {
+    setCurrentSection(option.code);
+  };
+
+  // Storing the sections here which will be shown in the UI.
+  const [sections, setSections] = useState<Section[]>([]);
+  // Section titles to be displayed in the Dropdown
+  const [sectionTitles, setSectionTitles] = useState<string[]>([]);
+  // Section options stored as a Dropdown object
+  const [sectionOptions, setSectionOptions] = useState<DropdownOption[]>([]);
+
+  // UseEffect hook that gets the sections for the selected scheduled surface
+  // has the section data & currentScheduledSurfaceGuid as the dependency and initial execution is also on page load
+  useEffect(() => {
+    if (currentScheduledSurfaceGuid && data) {
+      const fetchedSections = data.getSectionsWithSectionItems;
+      setSections(fetchedSections);
+
+      const sectionTitlesArr: string[] = fetchedSections.map(
+        (section) => section.title,
+      );
+      setSectionTitles(sectionTitlesArr);
+
+      // Add "All Sections" option as default
+      const options = [
+        { code: 'all', name: 'All Sections' },
+        ...sectionTitlesArr.map((title) => ({ code: title, name: title })),
+      ];
+
+      setSectionOptions(options);
+      setCurrentSection('all'); // Set default to "All Sections"
+    }
+  }, [data, currentScheduledSurfaceGuid]);
+
+  return (
+    <>
+      <h1>Sections</h1>
+      <Grid container spacing={3}>
+        <Grid item xs={12} sm={8}>
+          <Grid container spacing={3}>
+            <Grid item xs={12} sm={6}>
+              {!scheduledSurfaceData && (
+                <HandleApiResponse
+                  loading={scheduledSurfaceLoading}
+                  error={scheduledSurfaceError}
+                />
+              )}
+              {scheduledSurfaceOptions.length > 0 && (
+                <>
+                  Sections for
+                  <SplitButton
+                    onMenuOptionClick={updateScheduledSurface}
+                    options={scheduledSurfaceOptions}
+                    size="small"
+                  />
+                </>
+              )}
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <Box display="flex" justifyContent="flex-end" mb={2}>
+                {sectionTitles.length > 0 && (
+                  <SplitButton
+                    icon={<FilterListIcon fontSize="large" />}
+                    onMenuOptionClick={updateSection}
+                    options={sectionOptions}
+                    size="medium"
+                  />
+                )}
+              </Box>
+            </Grid>
+          </Grid>
+          {sections &&
+            sections
+              .filter(
+                (section) =>
+                  currentSection === 'all' || section.title === currentSection,
+              )
+              .map((section) => (
+                <Box
+                  key={section.externalId}
+                  mt={2}
+                  p={2}
+                  border={1}
+                  borderColor="grey.300"
+                >
+                  <h2>{section.title}</h2>
+                  <p>{section.active}</p>
+                </Box>
+              ))}
+        </Grid>
+      </Grid>
+    </>
+  );
+};

--- a/src/curated-corpus/pages/index.ts
+++ b/src/curated-corpus/pages/index.ts
@@ -4,3 +4,4 @@ export { CuratedCorpusLandingPage } from './CuratedCorpusLandingPage/CuratedCorp
 export { RejectedPage } from './RejectedPage/RejectedPage';
 export { ProspectingPage } from './ProspectingPage/ProspectingPage';
 export { SchedulePage } from './SchedulePage/SchedulePage';
+export { SectionsPage } from './SectionsPage/SectionsPage';


### PR DESCRIPTION
## Goal

Adding the initial basic read-only page to manage Sections.
Added the menu / header link to the new Sections page.

- Calling the admin `getSectionsWithSectionItems` query & displaying Section titles (per scheduled surface).

## Todos

- [x] deploy to dev

## Reference

Demo:


https://github.com/user-attachments/assets/26367586-5ae4-4d20-8820-0c4f798f19b5



Tickets:

- https://mozilla-hub.atlassian.net/browse/MC-1655
