### PR TITLE
MC-1656: adding edit & remove section item actions

### DIFF
--- a/src/_shared/components/CardActionButtonRow/CardActionButtonRow.test.tsx
+++ b/src/_shared/components/CardActionButtonRow/CardActionButtonRow.test.tsx
@@ -10,9 +10,10 @@ describe('The CardActionButtonRow component', () => {
   const onReschedule = jest.fn();
   const onUnschedule = jest.fn();
   const onReject = jest.fn();
+  const onRemove = jest.fn();
 
   //TODO update when reject button flow ready
-  it('should render all four card action buttons and call their callbacks', () => {
+  it('should render all five card action buttons and call their callbacks', () => {
     render(
       <CardActionButtonRow
         onEdit={onEdit}
@@ -20,6 +21,7 @@ describe('The CardActionButtonRow component', () => {
         onReschedule={onReschedule}
         onMoveToBottom={onMoveToBottom}
         onReject={onReject}
+        onRemove={onRemove}
       />,
     );
 
@@ -58,6 +60,14 @@ describe('The CardActionButtonRow component', () => {
     expect(rejectButton).toBeInTheDocument();
     userEvent.click(rejectButton);
     expect(onReject).toHaveBeenCalled();
+
+    //assert for remove button and onRemove callback
+    const removeButton = screen.getByRole('button', {
+      name: 'remove',
+    });
+    expect(removeButton).toBeInTheDocument();
+    userEvent.click(rejectButton);
+    expect(onReject).toHaveBeenCalled();
   });
   it('should only render card actions that are passed', () => {
     render(<CardActionButtonRow onEdit={onEdit} onReject={onReject} />);
@@ -87,5 +97,9 @@ describe('The CardActionButtonRow component', () => {
     expect(rejectButton).toBeInTheDocument();
     userEvent.click(rejectButton);
     expect(onReject).toHaveBeenCalled();
+
+    // assert removeButton button is NOT present
+    const removeButton = screen.queryByLabelText('remove');
+    expect(removeButton).not.toBeInTheDocument();
   });
 });

--- a/src/_shared/components/CardActionButtonRow/CardActionButtonRow.tsx
+++ b/src/_shared/components/CardActionButtonRow/CardActionButtonRow.tsx
@@ -75,7 +75,7 @@ export const CardActionButtonRow: React.FC<CardActionButtonRowProps> = (
         )}
 
         {onRemove && (
-          <Tooltip title="Reject" placement="bottom">
+          <Tooltip title="Remove" placement="bottom">
             <IconButton
               aria-label="remove"
               onClick={onRemove}

--- a/src/_shared/components/CardActionButtonRow/CardActionButtonRow.tsx
+++ b/src/_shared/components/CardActionButtonRow/CardActionButtonRow.tsx
@@ -6,6 +6,7 @@ import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import EventBusyOutlinedIcon from '@mui/icons-material/EventBusyOutlined';
 import KeyboardDoubleArrowDownOutlinedIcon from '@mui/icons-material/KeyboardDoubleArrowDownOutlined';
 import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
+import ClearIcon from '@mui/icons-material/Clear';
 import { curationPalette } from '../../../theme';
 
 interface CardActionButtonRowProps {
@@ -32,14 +33,25 @@ interface CardActionButtonRowProps {
   /**
    * Callback for the "Reject" (trash) button
    */
-  onReject: VoidFunction;
+  onReject?: VoidFunction;
+
+  /**
+   * Callback for the "Remove" (X) button
+   */
+  onRemove?: VoidFunction;
 }
 
 export const CardActionButtonRow: React.FC<CardActionButtonRowProps> = (
   props,
 ): JSX.Element => {
-  const { onEdit, onUnschedule, onReschedule, onMoveToBottom, onReject } =
-    props;
+  const {
+    onEdit,
+    onUnschedule,
+    onReschedule,
+    onMoveToBottom,
+    onReject,
+    onRemove,
+  } = props;
 
   return (
     <Stack
@@ -50,15 +62,29 @@ export const CardActionButtonRow: React.FC<CardActionButtonRowProps> = (
       ml="0.5rem"
     >
       <Stack direction="row" justifyContent="flex-start">
-        <Tooltip title="Reject" placement="bottom">
-          <IconButton
-            aria-label="reject"
-            onClick={onReject}
-            sx={{ color: curationPalette.jetBlack }}
-          >
-            <DeleteOutlinedIcon />
-          </IconButton>
-        </Tooltip>
+        {onReject && (
+          <Tooltip title="Reject" placement="bottom">
+            <IconButton
+              aria-label="reject"
+              onClick={onReject}
+              sx={{ color: curationPalette.jetBlack }}
+            >
+              <DeleteOutlinedIcon />
+            </IconButton>
+          </Tooltip>
+        )}
+
+        {onRemove && (
+          <Tooltip title="Reject" placement="bottom">
+            <IconButton
+              aria-label="remove"
+              onClick={onRemove}
+              sx={{ color: curationPalette.jetBlack }}
+            >
+              <ClearIcon />
+            </IconButton>
+          </Tooltip>
+        )}
 
         {onMoveToBottom && (
           <Tooltip title="Move to bottom" placement="bottom">

--- a/src/_shared/components/CardActionButtonRow/CardActionButtonRow.tsx
+++ b/src/_shared/components/CardActionButtonRow/CardActionButtonRow.tsx
@@ -74,18 +74,6 @@ export const CardActionButtonRow: React.FC<CardActionButtonRowProps> = (
           </Tooltip>
         )}
 
-        {onRemove && (
-          <Tooltip title="Remove" placement="bottom">
-            <IconButton
-              aria-label="remove"
-              onClick={onRemove}
-              sx={{ color: curationPalette.jetBlack }}
-            >
-              <ClearIcon />
-            </IconButton>
-          </Tooltip>
-        )}
-
         {onMoveToBottom && (
           <Tooltip title="Move to bottom" placement="bottom">
             <IconButton
@@ -130,6 +118,17 @@ export const CardActionButtonRow: React.FC<CardActionButtonRowProps> = (
               sx={{ color: curationPalette.jetBlack }}
             >
               <EventBusyOutlinedIcon />
+            </IconButton>
+          </Tooltip>
+        )}
+        {onRemove && (
+          <Tooltip title="Remove" placement="bottom">
+            <IconButton
+              aria-label="remove"
+              onClick={onRemove}
+              sx={{ color: curationPalette.jetBlack }}
+            >
+              <ClearIcon />
             </IconButton>
           </Tooltip>
         )}

--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -53,6 +53,8 @@ export enum ActionScreen {
   Prospecting = 'PROSPECTING',
   /** This action took place from the schedule screen in the admin tool */
   Schedule = 'SCHEDULE',
+  /** This action took place from the sections screen in the admin tool */
+  Sections = 'SECTIONS',
 }
 
 /** The source of en entity */
@@ -1234,7 +1236,10 @@ export type Mutation = {
   moderateShareableList?: Maybe<ShareableListComplete>;
   /** Refresh an Item's article content. */
   refreshItemArticle: Item;
-  /** Rejects an Approved Item: deletes it from the corpus and creates a Rejected Item instead. */
+  /**
+   * Rejects an Approved Item: deletes it from the corpus and creates a Rejected Item instead.
+   * Also deletes all associated SectionItems.
+   */
   rejectApprovedCorpusItem: ApprovedCorpusItem;
   /**
    * Marks a prospect as 'curated' in the database, preventing it from being displayed for prospecting.
@@ -3510,6 +3515,56 @@ export type RemoveProspectMutation = {
     isSyndicated?: boolean | null;
     isCollection?: boolean | null;
   } | null;
+};
+
+export type RemoveSectionItemMutationVariables = Exact<{
+  externalId: Scalars['String'];
+}>;
+
+export type RemoveSectionItemMutation = {
+  __typename?: 'Mutation';
+  removeSectionItem: {
+    __typename?: 'SectionItem';
+    createdAt: number;
+    updatedAt: number;
+    externalId: string;
+    rank?: number | null;
+    approvedItem: {
+      __typename?: 'ApprovedCorpusItem';
+      externalId: string;
+      prospectId?: string | null;
+      title: string;
+      language: CorpusLanguage;
+      publisher: string;
+      datePublished?: any | null;
+      url: any;
+      hasTrustedDomain: boolean;
+      imageUrl: any;
+      excerpt: string;
+      status: CuratedStatus;
+      source: CorpusItemSource;
+      topic: string;
+      isCollection: boolean;
+      isTimeSensitive: boolean;
+      isSyndicated: boolean;
+      createdBy: string;
+      createdAt: number;
+      updatedBy?: string | null;
+      updatedAt: number;
+      authors: Array<{
+        __typename?: 'CorpusItemAuthor';
+        name: string;
+        sortOrder: number;
+      }>;
+      scheduledSurfaceHistory: Array<{
+        __typename?: 'ApprovedCorpusItemScheduledSurfaceHistory';
+        externalId: string;
+        createdBy: string;
+        scheduledDate: any;
+        scheduledSurfaceGuid: string;
+      }>;
+    };
+  };
 };
 
 export type RescheduleScheduledCorpusItemMutationVariables = Exact<{
@@ -6266,6 +6321,57 @@ export type RemoveProspectMutationResult =
 export type RemoveProspectMutationOptions = Apollo.BaseMutationOptions<
   RemoveProspectMutation,
   RemoveProspectMutationVariables
+>;
+export const RemoveSectionItemDocument = gql`
+  mutation RemoveSectionItem($externalId: String!) {
+    removeSectionItem(externalId: $externalId) {
+      ...SectionItemData
+    }
+  }
+  ${SectionItemDataFragmentDoc}
+`;
+export type RemoveSectionItemMutationFn = Apollo.MutationFunction<
+  RemoveSectionItemMutation,
+  RemoveSectionItemMutationVariables
+>;
+
+/**
+ * __useRemoveSectionItemMutation__
+ *
+ * To run a mutation, you first call `useRemoveSectionItemMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useRemoveSectionItemMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [removeSectionItemMutation, { data, loading, error }] = useRemoveSectionItemMutation({
+ *   variables: {
+ *      externalId: // value for 'externalId'
+ *   },
+ * });
+ */
+export function useRemoveSectionItemMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    RemoveSectionItemMutation,
+    RemoveSectionItemMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    RemoveSectionItemMutation,
+    RemoveSectionItemMutationVariables
+  >(RemoveSectionItemDocument, options);
+}
+export type RemoveSectionItemMutationHookResult = ReturnType<
+  typeof useRemoveSectionItemMutation
+>;
+export type RemoveSectionItemMutationResult =
+  Apollo.MutationResult<RemoveSectionItemMutation>;
+export type RemoveSectionItemMutationOptions = Apollo.BaseMutationOptions<
+  RemoveSectionItemMutation,
+  RemoveSectionItemMutationVariables
 >;
 export const RescheduleScheduledCorpusItemDocument = gql`
   mutation rescheduleScheduledCorpusItem(

--- a/src/api/mutations/removeSectionItem.ts
+++ b/src/api/mutations/removeSectionItem.ts
@@ -1,0 +1,11 @@
+import { gql } from '@apollo/client';
+import { SectionItemData } from '../fragments/SectionItemData';
+
+export const removeSectionItem = gql`
+  mutation RemoveSectionItem($externalId: String!) {
+    removeSectionItem(externalId: $externalId) {
+      ...SectionItemData
+    }
+  }
+  ${SectionItemData}
+`;

--- a/src/curated-corpus/components/SectionDetails/SectionDetails.test.tsx
+++ b/src/curated-corpus/components/SectionDetails/SectionDetails.test.tsx
@@ -140,7 +140,7 @@ describe('The SectionDetails component', () => {
     expect(mockToggleEditModal).toHaveBeenCalled();
   });
 
-  it('should render reject button', async () => {
+  it('should render & click reject button', async () => {
     render(
       <MockedProvider>
         <SnackbarProvider maxSnack={3}>

--- a/src/curated-corpus/components/SectionDetails/SectionDetails.test.tsx
+++ b/src/curated-corpus/components/SectionDetails/SectionDetails.test.tsx
@@ -140,7 +140,7 @@ describe('The SectionDetails component', () => {
     expect(mockToggleEditModal).toHaveBeenCalled();
   });
 
-  it('should render & click reject button', async () => {
+  it('should render & click remove button', async () => {
     render(
       <MockedProvider>
         <SnackbarProvider maxSnack={3}>

--- a/src/curated-corpus/components/SectionItemCardWrapper/SectionItemCardWrapper.tsx
+++ b/src/curated-corpus/components/SectionItemCardWrapper/SectionItemCardWrapper.tsx
@@ -21,9 +21,9 @@ interface SectionItemCardWrapperProps {
   onEdit: VoidFunction;
 
   /**
-   * Callback for the "Reject" (trash) button
+   * Callback for the "Remove" (X) button
    */
-  onReject: VoidFunction;
+  onRemove: VoidFunction;
 
   /**
    * The surface the card is displayed on, e.g. EN_US
@@ -34,7 +34,7 @@ interface SectionItemCardWrapperProps {
 export const SectionItemCardWrapper: React.FC<SectionItemCardWrapperProps> = (
   props,
 ): ReactElement => {
-  const { item, onEdit, onReject, scheduledSurfaceGuid } = props;
+  const { item, onEdit, onRemove, scheduledSurfaceGuid } = props;
 
   return (
     <Grid item xs={12} sm={6} md={3}>
@@ -42,7 +42,7 @@ export const SectionItemCardWrapper: React.FC<SectionItemCardWrapperProps> = (
         <StoryItemListCard
           item={item}
           cardActionButtonRow={
-            <CardActionButtonRow onEdit={onEdit} onReject={onReject} />
+            <CardActionButtonRow onEdit={onEdit} onRemove={onRemove} />
           }
           isMlScheduled={item.source === CorpusItemSource.Ml}
           scheduledSurfaceGuid={scheduledSurfaceGuid}

--- a/src/curated-corpus/pages/SectionsPage/SectionsPage.tsx
+++ b/src/curated-corpus/pages/SectionsPage/SectionsPage.tsx
@@ -1,14 +1,21 @@
 import React, { useEffect, useState } from 'react';
 import {
+  ActionScreen,
   Section,
+  SectionItem,
   useGetScheduledSurfacesForUserQuery,
   useGetSectionsWithSectionItemsLazyQuery,
 } from '../../../api/generatedTypes';
 import { DropdownOption } from '../../helpers/definitions';
 import { Box, Grid } from '@mui/material';
 import { HandleApiResponse } from '../../../_shared/components';
-import { SectionDetails, SplitButton } from '../../components';
+import {
+  EditCorpusItemAction,
+  SectionDetails,
+  SplitButton,
+} from '../../components';
 import FilterListIcon from '@mui/icons-material/FilterList';
+import { useToggle } from '../../../_shared/hooks';
 
 export const SectionsPage: React.FC = (): JSX.Element => {
   // set up the initial scheduled surface guid value (nothing at this point)
@@ -21,6 +28,19 @@ export const SectionsPage: React.FC = (): JSX.Element => {
   >([]);
 
   const [currentSection, setCurrentSection] = useState('');
+
+  /**
+   * Set the current SectionItem to be worked on.
+   */
+  const [currentSectionItem, setCurrentSectionItem] = useState<
+    Omit<SectionItem, '__typename'> | undefined
+  >(undefined);
+
+  /**
+   * Keep track of whether the "Edit item modal" is open or not
+   */
+  const [editItemModalOpen, toggleEditModal] = useToggle(false);
+
   // Get a list of sections on the page
   const [
     callGetSectionsWithSectionItemsQuery,
@@ -113,6 +133,15 @@ export const SectionsPage: React.FC = (): JSX.Element => {
   return (
     <>
       <h1>Sections</h1>
+      {currentSectionItem?.approvedItem && (
+        <EditCorpusItemAction
+          item={currentSectionItem.approvedItem}
+          actionScreen={ActionScreen.Sections}
+          modalOpen={editItemModalOpen}
+          toggleModal={toggleEditModal}
+          refetch={refetch}
+        />
+      )}
       <Grid container spacing={3}>
         <Grid item xs={12} sm={8}>
           <Grid container spacing={3}>
@@ -152,7 +181,10 @@ export const SectionsPage: React.FC = (): JSX.Element => {
       <SectionDetails
         sections={sections}
         currentSection={currentSection}
+        setCurrentSectionItem={setCurrentSectionItem}
         currentScheduledSurfaceGuid={currentScheduledSurfaceGuid}
+        toggleEditModal={toggleEditModal}
+        refetch={refetch}
       />
     </>
   );


### PR DESCRIPTION
## Goal

Wiring up actions for editing corpus metadata on a `SectionItem` & removing a `SectionItem`.

* Added new `onRemove` callback to `CardActionButtonRow` to differentiate between the `onReject` callback. Using the `ClearIcon` (X) for the remove button.
* Updated `SectionDetails` component tests.

## Todos

- [x] deploy to dev

## Reference

### Demo


https://github.com/user-attachments/assets/3f86cdb9-9c81-4b19-97a3-541f783ba124


Tickets:

- https://mozilla-hub.atlassian.net/browse/MC-1656
