### PR TITLE
(chore)MC-1676: CardActionButtonRow component refactor

### DIFF
--- a/src/_shared/components/CardActionButtonRow/CardActionButtonRow.test.tsx
+++ b/src/_shared/components/CardActionButtonRow/CardActionButtonRow.test.tsx
@@ -2,26 +2,63 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { CardActionButtonRow } from './CardActionButtonRow';
+import { CardAction, CardActionButtonRow } from './CardActionButtonRow';
+import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
+import KeyboardDoubleArrowDownOutlinedIcon from '@mui/icons-material/KeyboardDoubleArrowDownOutlined';
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
+import ScheduleIcon from '@mui/icons-material/Schedule';
+import EventBusyOutlinedIcon from '@mui/icons-material/EventBusyOutlined';
+import ClearIcon from '@mui/icons-material/Clear';
 
 describe('The CardActionButtonRow component', () => {
+  const onReject = jest.fn();
   const onMoveToBottom = jest.fn();
   const onEdit = jest.fn();
   const onReschedule = jest.fn();
   const onUnschedule = jest.fn();
-  const onReject = jest.fn();
   const onRemove = jest.fn();
 
   //TODO update when reject button flow ready
-  it('should render all five card action buttons and call their callbacks', () => {
+  it('should render all bottom left & bottom right buttons and call their callbacks', () => {
+    const cardActionButtonsLeft: CardAction[] = [
+      {
+        actionName: 'Reject',
+        icon: <DeleteOutlinedIcon />,
+        onClick: () => onReject(),
+      },
+      {
+        actionName: 'Move to bottom',
+        icon: <KeyboardDoubleArrowDownOutlinedIcon />,
+        onClick: () => onMoveToBottom(),
+      },
+      {
+        actionName: 'Edit',
+        icon: <EditOutlinedIcon />,
+        onClick: () => onEdit(),
+      },
+      {
+        actionName: 'Re-schedule',
+        icon: <ScheduleIcon />,
+        onClick: () => onReschedule(),
+      },
+    ];
+    const cardActionButtonsRight: CardAction[] = [
+      {
+        actionName: 'Unschedule',
+        icon: <EventBusyOutlinedIcon />,
+        onClick: () => onUnschedule(),
+      },
+      {
+        actionName: 'Remove',
+        icon: <ClearIcon />,
+        onClick: () => onRemove(),
+      },
+    ];
+
     render(
       <CardActionButtonRow
-        onEdit={onEdit}
-        onUnschedule={onUnschedule}
-        onReschedule={onReschedule}
-        onMoveToBottom={onMoveToBottom}
-        onReject={onReject}
-        onRemove={onRemove}
+        cardActionButtonsLeft={cardActionButtonsLeft}
+        cardActionButtonsRight={cardActionButtonsRight}
       />,
     );
 
@@ -47,7 +84,7 @@ describe('The CardActionButtonRow component', () => {
 
     // assert move to bottom button is present and calls its callback
     const moveToBottomButton = screen.getByRole('button', {
-      name: 'move to bottom',
+      name: 'move-to-bottom',
     });
     expect(moveToBottomButton).toBeInTheDocument();
     userEvent.click(moveToBottomButton);
@@ -69,8 +106,23 @@ describe('The CardActionButtonRow component', () => {
     userEvent.click(rejectButton);
     expect(onReject).toHaveBeenCalled();
   });
-  it('should only render card actions that are passed', () => {
-    render(<CardActionButtonRow onEdit={onEdit} onReject={onReject} />);
+  it('should only render card button actions that are passed', () => {
+    // only provide 2 buttons on bottom left
+    const cardActionButtonsLeft: CardAction[] = [
+      {
+        actionName: 'Reject',
+        icon: <DeleteOutlinedIcon />,
+        onClick: () => onReject(),
+      },
+      {
+        actionName: 'Edit',
+        icon: <EditOutlinedIcon />,
+        onClick: () => onEdit(),
+      },
+    ];
+    render(
+      <CardActionButtonRow cardActionButtonsLeft={cardActionButtonsLeft} />,
+    );
 
     // assert edit button is present and calls its callback
     const editButton = screen.getByRole('button', { name: 'edit' });

--- a/src/_shared/components/CardActionButtonRow/CardActionButtonRow.tsx
+++ b/src/_shared/components/CardActionButtonRow/CardActionButtonRow.tsx
@@ -10,7 +10,7 @@ export interface CardAction {
   /**
    * The material UI icon
    */
-  icon: React.ReactNode;
+  icon: ReactNode;
   /**
    * Callback for the button
    */

--- a/src/_shared/components/CardActionButtonRow/CardActionButtonRow.tsx
+++ b/src/_shared/components/CardActionButtonRow/CardActionButtonRow.tsx
@@ -36,6 +36,8 @@ export const CardActionButtonRow: React.FC<CardActionButtonRowProps> = (
     return actions.map(({ actionName, icon, onClick }) => (
       <Tooltip key={actionName} title={actionName} placement="bottom">
         <IconButton
+          // convert to lowercase & replace space with hyphens
+          // /\s/g replace all spaces with hyphens
           aria-label={actionName.toLowerCase().replace(/\s/g, '-')}
           onClick={onClick}
           sx={{ color: curationPalette.jetBlack }}

--- a/src/_shared/components/CardActionButtonRow/CardActionButtonRow.tsx
+++ b/src/_shared/components/CardActionButtonRow/CardActionButtonRow.tsx
@@ -1,57 +1,50 @@
-import React from 'react';
-import { IconButton, Tooltip } from '@mui/material';
-import { Stack } from '@mui/system';
-import ScheduleIcon from '@mui/icons-material/Schedule';
-import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
-import EventBusyOutlinedIcon from '@mui/icons-material/EventBusyOutlined';
-import KeyboardDoubleArrowDownOutlinedIcon from '@mui/icons-material/KeyboardDoubleArrowDownOutlined';
-import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
-import ClearIcon from '@mui/icons-material/Clear';
+import React, { ReactNode } from 'react';
+import { IconButton, Tooltip, Stack } from '@mui/material';
 import { curationPalette } from '../../../theme';
+
+export interface CardAction {
+  /**
+   * The name of the button action (i.e. "Edit")
+   */
+  actionName: string;
+  /**
+   * The material UI icon
+   */
+  icon: React.ReactNode;
+  /**
+   * Callback for the button
+   */
+  onClick: VoidFunction;
+}
 
 interface CardActionButtonRowProps {
   /**
-   * Callback for the "Unschedule" button
+   * Card action buttons aligned to bottom left
    */
-  onUnschedule?: VoidFunction;
-
+  cardActionButtonsLeft?: CardAction[];
   /**
-   * Callback for the "Reschedule" button
+   * Card action buttons aligned to bottom right
    */
-  onReschedule?: VoidFunction;
-
-  /**
-   * Callback for the "Edit" button
-   */
-  onEdit: VoidFunction;
-
-  /**
-   * Callback for the "Move to bottom" button
-   */
-  onMoveToBottom?: VoidFunction;
-
-  /**
-   * Callback for the "Reject" (trash) button
-   */
-  onReject?: VoidFunction;
-
-  /**
-   * Callback for the "Remove" (X) button
-   */
-  onRemove?: VoidFunction;
+  cardActionButtonsRight?: CardAction[];
 }
 
 export const CardActionButtonRow: React.FC<CardActionButtonRowProps> = (
   props,
 ): JSX.Element => {
-  const {
-    onEdit,
-    onUnschedule,
-    onReschedule,
-    onMoveToBottom,
-    onReject,
-    onRemove,
-  } = props;
+  const { cardActionButtonsLeft = [], cardActionButtonsRight = [] } = props;
+  const renderCardActionButtons = (actions: CardAction[]): ReactNode => {
+    return actions.map(({ actionName, icon, onClick }) => (
+      <Tooltip key={actionName} title={actionName} placement="bottom">
+        <IconButton
+          aria-label={actionName.toLowerCase().replace(/\s/g, '-')}
+          onClick={onClick}
+          sx={{ color: curationPalette.jetBlack }}
+        >
+          {icon}
+        </IconButton>
+      </Tooltip>
+    ));
+  };
 
   return (
     <Stack
@@ -61,77 +54,13 @@ export const CardActionButtonRow: React.FC<CardActionButtonRowProps> = (
       mr="0.5rem"
       ml="0.5rem"
     >
-      <Stack direction="row" justifyContent="flex-start">
-        {onReject && (
-          <Tooltip title="Reject" placement="bottom">
-            <IconButton
-              aria-label="reject"
-              onClick={onReject}
-              sx={{ color: curationPalette.jetBlack }}
-            >
-              <DeleteOutlinedIcon />
-            </IconButton>
-          </Tooltip>
-        )}
-
-        {onMoveToBottom && (
-          <Tooltip title="Move to bottom" placement="bottom">
-            <IconButton
-              aria-label="move to bottom"
-              onClick={onMoveToBottom}
-              sx={{ color: curationPalette.jetBlack }}
-            >
-              <KeyboardDoubleArrowDownOutlinedIcon />
-            </IconButton>
-          </Tooltip>
-        )}
-
-        <Tooltip title="Edit" placement="bottom">
-          <IconButton
-            aria-label="edit"
-            onClick={onEdit}
-            sx={{ color: curationPalette.jetBlack }}
-          >
-            <EditOutlinedIcon />
-          </IconButton>
-        </Tooltip>
-
-        {onReschedule && (
-          <Tooltip title="Re-schedule" placement="bottom">
-            <IconButton
-              aria-label="re-schedule"
-              onClick={onReschedule}
-              sx={{ color: curationPalette.jetBlack }}
-            >
-              <ScheduleIcon />
-            </IconButton>
-          </Tooltip>
-        )}
+      <Stack direction="row">
+        {/*buttons aligned on bottom left of card*/}
+        {renderCardActionButtons(cardActionButtonsLeft)}
       </Stack>
-
-      <Stack direction="row" justifyContent="flex-start">
-        {onUnschedule && (
-          <Tooltip title="Unschedule" placement="bottom">
-            <IconButton
-              aria-label="unschedule"
-              onClick={onUnschedule}
-              sx={{ color: curationPalette.jetBlack }}
-            >
-              <EventBusyOutlinedIcon />
-            </IconButton>
-          </Tooltip>
-        )}
-        {onRemove && (
-          <Tooltip title="Remove" placement="bottom">
-            <IconButton
-              aria-label="remove"
-              onClick={onRemove}
-              sx={{ color: curationPalette.jetBlack }}
-            >
-              <ClearIcon />
-            </IconButton>
-          </Tooltip>
-        )}
+      <Stack direction="row">
+        {/*buttons aligned on bottom right of card*/}
+        {renderCardActionButtons(cardActionButtonsRight)}
       </Stack>
     </Stack>
   );

--- a/src/_shared/components/index.ts
+++ b/src/_shared/components/index.ts
@@ -23,4 +23,5 @@ export { ImageUpload } from '../../curated-corpus/components/ImageUpload/ImageUp
 export { PageNotFound } from '../components/PageNotFound/PageNotFound';
 export { FloatingActionButton } from '../components/FloatingActionButton/FloatingActionButton';
 export { CardActionButtonRow } from '../components/CardActionButtonRow/CardActionButtonRow';
+export type { CardAction } from '../components/CardActionButtonRow/CardActionButtonRow';
 export { CorpusItemCardImage } from '../components/CorpusItemCardImage/CorpusItemCardImage';

--- a/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.tsx
+++ b/src/curated-corpus/components/ScheduledItemCardWrapper/ScheduledItemCardWrapper.tsx
@@ -1,5 +1,10 @@
 import React, { ReactElement } from 'react';
 import { Grid } from '@mui/material';
+import ScheduleIcon from '@mui/icons-material/Schedule';
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
+import EventBusyOutlinedIcon from '@mui/icons-material/EventBusyOutlined';
+import KeyboardDoubleArrowDownOutlinedIcon from '@mui/icons-material/KeyboardDoubleArrowDownOutlined';
+import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
 import {
   ScheduledCorpusItem,
   ActivitySource,
@@ -7,7 +12,7 @@ import {
 
 import { StyledScheduledItemCard } from '../../../_shared/styled';
 import { StoryItemListCard } from '../StoryItemListCard/StoryItemListCard';
-import { CardActionButtonRow } from '../../../_shared/components';
+import { CardAction, CardActionButtonRow } from '../../../_shared/components';
 
 interface ScheduledItemCardWrapperProps {
   /**
@@ -65,6 +70,35 @@ export const ScheduledItemCardWrapper: React.FC<
     scheduledSurfaceGuid,
   } = props;
 
+  // card action buttons to be rendered & aligned on bottom left
+  const cardActionButtonsLeft: CardAction[] = [
+    {
+      actionName: 'Reject',
+      icon: <DeleteOutlinedIcon />,
+      onClick: () => onReject(),
+    },
+    {
+      actionName: 'Move to bottom',
+      icon: <KeyboardDoubleArrowDownOutlinedIcon />,
+      onClick: () => onMoveToBottom(),
+    },
+    { actionName: 'Edit', icon: <EditOutlinedIcon />, onClick: () => onEdit() },
+    {
+      actionName: 'Re-schedule',
+      icon: <ScheduleIcon />,
+      onClick: () => onReschedule(),
+    },
+  ];
+
+  // card action buttons to be rendered & aligned on bottom right
+  const cardActionButtonsRight: CardAction[] = [
+    {
+      actionName: 'Unschedule',
+      icon: <EventBusyOutlinedIcon />,
+      onClick: () => onUnschedule(),
+    },
+  ];
+
   return (
     <Grid item xs={12} sm={6} md={3}>
       <StyledScheduledItemCard variant="outlined">
@@ -72,11 +106,8 @@ export const ScheduledItemCardWrapper: React.FC<
           item={item.approvedItem}
           cardActionButtonRow={
             <CardActionButtonRow
-              onEdit={onEdit}
-              onUnschedule={onUnschedule}
-              onReschedule={onReschedule}
-              onMoveToBottom={onMoveToBottom}
-              onReject={onReject}
+              cardActionButtonsLeft={cardActionButtonsLeft}
+              cardActionButtonsRight={cardActionButtonsRight}
             />
           }
           isMlScheduled={item.source === ActivitySource.Ml}

--- a/src/curated-corpus/components/SectionItemCardWrapper/SectionItemCardWrapper.tsx
+++ b/src/curated-corpus/components/SectionItemCardWrapper/SectionItemCardWrapper.tsx
@@ -1,5 +1,7 @@
 import React, { ReactElement } from 'react';
 import { Grid } from '@mui/material';
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
+import ClearIcon from '@mui/icons-material/Clear';
 import {
   ApprovedCorpusItem,
   CorpusItemSource,
@@ -7,7 +9,7 @@ import {
 
 import { StyledScheduledItemCard } from '../../../_shared/styled';
 import { StoryItemListCard } from '../StoryItemListCard/StoryItemListCard';
-import { CardActionButtonRow } from '../../../_shared/components';
+import { CardAction, CardActionButtonRow } from '../../../_shared/components';
 
 interface SectionItemCardWrapperProps {
   /**
@@ -36,13 +38,25 @@ export const SectionItemCardWrapper: React.FC<SectionItemCardWrapperProps> = (
 ): ReactElement => {
   const { item, onEdit, onRemove, scheduledSurfaceGuid } = props;
 
+  // card action buttons to be rendered & aligned on bottom left
+  const cardActionButtonsLeft: CardAction[] = [
+    { actionName: 'Edit', icon: <EditOutlinedIcon />, onClick: () => onEdit() },
+  ];
+  // card action buttons to be rendered & aligned on bottom right
+  const cardActionButtonsRight: CardAction[] = [
+    { actionName: 'Remove', icon: <ClearIcon />, onClick: () => onRemove() },
+  ];
+
   return (
     <Grid item xs={12} sm={6} md={3}>
       <StyledScheduledItemCard variant="outlined">
         <StoryItemListCard
           item={item}
           cardActionButtonRow={
-            <CardActionButtonRow onEdit={onEdit} onRemove={onRemove} />
+            <CardActionButtonRow
+              cardActionButtonsLeft={cardActionButtonsLeft}
+              cardActionButtonsRight={cardActionButtonsRight}
+            />
           }
           isMlScheduled={item.source === CorpusItemSource.Ml}
           scheduledSurfaceGuid={scheduledSurfaceGuid}

--- a/src/curated-corpus/components/StoryItemListCard/StoryItemListCard.test.tsx
+++ b/src/curated-corpus/components/StoryItemListCard/StoryItemListCard.test.tsx
@@ -5,17 +5,46 @@ import { ApprovedCorpusItem } from '../../../api/generatedTypes';
 import { StoryItemListCard } from './StoryItemListCard';
 import { flattenAuthors } from '../../../_shared/utils/flattenAuthors';
 import { getTestApprovedItem } from '../../helpers/approvedItem';
-import { CardActionButtonRow } from '../../../_shared/components';
+import { CardAction, CardActionButtonRow } from '../../../_shared/components';
+import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
+import KeyboardDoubleArrowDownOutlinedIcon from '@mui/icons-material/KeyboardDoubleArrowDownOutlined';
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
+import ScheduleIcon from '@mui/icons-material/Schedule';
+import EventBusyOutlinedIcon from '@mui/icons-material/EventBusyOutlined';
 
 describe('The StoryItemListCard component', () => {
   let item: ApprovedCorpusItem = getTestApprovedItem();
   const currentScheduledDate = '2024-01-20';
 
-  const onMoveToBottom = jest.fn();
-  const onEdit = jest.fn();
-  const onReschedule = jest.fn();
-  const onUnschedule = jest.fn();
-  const onReject = jest.fn();
+  const cardActionButtonsLeft: CardAction[] = [
+    {
+      actionName: 'Reject',
+      icon: <DeleteOutlinedIcon />,
+      onClick: () => jest.fn(),
+    },
+    {
+      actionName: 'Move to bottom',
+      icon: <KeyboardDoubleArrowDownOutlinedIcon />,
+      onClick: () => jest.fn(),
+    },
+    {
+      actionName: 'Edit',
+      icon: <EditOutlinedIcon />,
+      onClick: () => jest.fn(),
+    },
+    {
+      actionName: 'Re-schedule',
+      icon: <ScheduleIcon />,
+      onClick: () => jest.fn(),
+    },
+  ];
+  const cardActionButtonsRight: CardAction[] = [
+    {
+      actionName: 'Unschedule',
+      icon: <EventBusyOutlinedIcon />,
+      onClick: () => jest.fn(),
+    },
+  ];
 
   it('shows basic story item information with all optional card actions', () => {
     render(
@@ -24,11 +53,8 @@ describe('The StoryItemListCard component', () => {
         item={item}
         cardActionButtonRow={
           <CardActionButtonRow
-            onEdit={onEdit}
-            onUnschedule={onUnschedule}
-            onReschedule={onReschedule}
-            onMoveToBottom={onMoveToBottom}
-            onReject={onReject}
+            cardActionButtonsLeft={cardActionButtonsLeft}
+            cardActionButtonsRight={cardActionButtonsRight}
           />
         }
         currentScheduledDate={currentScheduledDate}
@@ -59,11 +85,8 @@ describe('The StoryItemListCard component', () => {
         item={item}
         cardActionButtonRow={
           <CardActionButtonRow
-            onEdit={onEdit}
-            onUnschedule={onUnschedule}
-            onReschedule={onReschedule}
-            onMoveToBottom={onMoveToBottom}
-            onReject={onReject}
+            cardActionButtonsLeft={cardActionButtonsLeft}
+            cardActionButtonsRight={cardActionButtonsRight}
           />
         }
         currentScheduledDate={currentScheduledDate}
@@ -82,11 +105,8 @@ describe('The StoryItemListCard component', () => {
         currentScheduledDate={currentScheduledDate}
         cardActionButtonRow={
           <CardActionButtonRow
-            onEdit={onEdit}
-            onUnschedule={onUnschedule}
-            onReschedule={onReschedule}
-            onMoveToBottom={onMoveToBottom}
-            onReject={onReject}
+            cardActionButtonsLeft={cardActionButtonsLeft}
+            cardActionButtonsRight={cardActionButtonsRight}
           />
         }
         scheduledSurfaceGuid="NEW_TAB_EN_US"
@@ -109,11 +129,8 @@ describe('The StoryItemListCard component', () => {
         currentScheduledDate={currentScheduledDate}
         cardActionButtonRow={
           <CardActionButtonRow
-            onEdit={onEdit}
-            onUnschedule={onUnschedule}
-            onReschedule={onReschedule}
-            onMoveToBottom={onMoveToBottom}
-            onReject={onReject}
+            cardActionButtonsLeft={cardActionButtonsLeft}
+            cardActionButtonsRight={cardActionButtonsRight}
           />
         }
         scheduledSurfaceGuid="NEW_TAB_EN_US"


### PR DESCRIPTION
## Goal

Abstract the `CardActionButtonRow` component to be more generic & not need to know about all card button actions across different component.

* Added new `CardAction` type to take in the action name, MUI icon & `onClick` callback.
* Adjusted `CardActionButtonRowProps` to take an array of (optional) right-aligned `CardAction` & (optional) left-aligned `CardAction`.

Components can now specify right and/or left card action buttons like this:
```
  // card action buttons to be rendered & aligned on bottom left
  const cardActionButtonsLeft: CardAction[] = [
    { actionName: 'Edit', icon: <EditOutlinedIcon />, onClick: () => onEdit() },
  ];
  // card action buttons to be rendered & aligned on bottom right
  const cardActionButtonsRight: CardAction[] = [
    { actionName: 'Remove', icon: <ClearIcon />, onClick: () => onRemove() },
  ];

<CardActionButtonRow
    cardActionButtonsLeft={cardActionButtonsLeft}
    cardActionButtonsRight={cardActionButtonsRight}
/>
```

## Todos

- [x] deploy to dev

## Reference

Tickets:

- https://mozilla-hub.atlassian.net/browse/MC-1676
