### PR TITLE
HNT-504: adding rejection reasons modal for section items

### DIFF
--- a/src/curated-corpus/components/SectionDetails/SectionDetails.test.tsx
+++ b/src/curated-corpus/components/SectionDetails/SectionDetails.test.tsx
@@ -56,6 +56,7 @@ describe('The SectionDetails component', () => {
 
   const mockSetCurrentSectionItem = jest.fn();
   const mockToggleEditModal = jest.fn();
+  const mockToggleRejectModal = jest.fn();
   const mockRefetch = jest.fn();
 
   it('should render all sections when currentSection is "all"', () => {
@@ -68,6 +69,7 @@ describe('The SectionDetails component', () => {
             setCurrentSectionItem={mockSetCurrentSectionItem}
             currentScheduledSurfaceGuid="NEW_TAB_EN_US"
             toggleEditModal={mockToggleEditModal}
+            toggleRejectModal={mockToggleRejectModal}
             refetch={mockRefetch}
           />
         </SnackbarProvider>
@@ -88,6 +90,7 @@ describe('The SectionDetails component', () => {
             setCurrentSectionItem={mockSetCurrentSectionItem}
             currentScheduledSurfaceGuid="NEW_TAB_EN_US"
             toggleEditModal={mockToggleEditModal}
+            toggleRejectModal={mockToggleRejectModal}
             refetch={mockRefetch}
           />
         </SnackbarProvider>
@@ -108,6 +111,7 @@ describe('The SectionDetails component', () => {
             setCurrentSectionItem={mockSetCurrentSectionItem}
             currentScheduledSurfaceGuid="NEW_TAB_EN_US"
             toggleEditModal={mockToggleEditModal}
+            toggleRejectModal={mockToggleRejectModal}
             refetch={mockRefetch}
           />
         </SnackbarProvider>
@@ -128,6 +132,7 @@ describe('The SectionDetails component', () => {
             setCurrentSectionItem={mockSetCurrentSectionItem}
             currentScheduledSurfaceGuid="NEW_TAB_EN_US"
             toggleEditModal={mockToggleEditModal}
+            toggleRejectModal={mockToggleRejectModal}
             refetch={mockRefetch}
           />
         </SnackbarProvider>
@@ -144,6 +149,33 @@ describe('The SectionDetails component', () => {
     expect(mockToggleEditModal).toHaveBeenCalled();
   });
 
+  it('should call setCurrentSectionItem and toggleRejectModal on rejectButton click', async () => {
+    render(
+      <MockedProvider>
+        <SnackbarProvider maxSnack={3}>
+          <SectionDetails
+            sections={mockSections}
+            currentSection="Section 1"
+            setCurrentSectionItem={mockSetCurrentSectionItem}
+            currentScheduledSurfaceGuid="NEW_TAB_EN_US"
+            toggleEditModal={mockToggleEditModal}
+            toggleRejectModal={mockToggleRejectModal}
+            refetch={mockRefetch}
+          />
+        </SnackbarProvider>
+      </MockedProvider>,
+    );
+
+    const rejectButton = screen.getByRole('button', { name: /reject/i });
+    expect(rejectButton).toBeInTheDocument();
+    userEvent.click(rejectButton);
+
+    expect(mockSetCurrentSectionItem).toHaveBeenCalledWith(
+      mockSections[0].sectionItems[0],
+    );
+    expect(mockToggleRejectModal).toHaveBeenCalled();
+  });
+
   it('should render & click remove button', async () => {
     render(
       <MockedProvider>
@@ -154,6 +186,7 @@ describe('The SectionDetails component', () => {
             setCurrentSectionItem={mockSetCurrentSectionItem}
             currentScheduledSurfaceGuid="NEW_TAB_EN_US"
             toggleEditModal={mockToggleEditModal}
+            toggleRejectModal={mockToggleRejectModal}
             refetch={mockRefetch}
           />
         </SnackbarProvider>
@@ -177,6 +210,7 @@ describe('The SectionDetails component', () => {
             setCurrentSectionItem={mockSetCurrentSectionItem}
             currentScheduledSurfaceGuid="NEW_TAB_EN_US"
             toggleEditModal={mockToggleEditModal}
+            toggleRejectModal={mockToggleRejectModal}
             refetch={mockRefetch}
           />
         </SnackbarProvider>
@@ -196,6 +230,7 @@ describe('The SectionDetails component', () => {
             setCurrentSectionItem={mockSetCurrentSectionItem}
             currentScheduledSurfaceGuid="NEW_TAB_EN_US"
             toggleEditModal={mockToggleEditModal}
+            toggleRejectModal={mockToggleRejectModal}
             refetch={mockRefetch}
           />
         </SnackbarProvider>

--- a/src/curated-corpus/components/SectionDetails/SectionDetails.tsx
+++ b/src/curated-corpus/components/SectionDetails/SectionDetails.tsx
@@ -34,6 +34,10 @@ interface SectionDetailsProps {
    */
   toggleEditModal: VoidFunction;
   /**
+   * A toggle function for the "Reject this item" modal.
+   */
+  toggleRejectModal: VoidFunction;
+  /**
    * A function that triggers a new API call to refetch the data for a given
    * query. Needed on the Schedule page to refresh data after every action.
    */
@@ -48,6 +52,7 @@ export const SectionDetails: React.FC<SectionDetailsProps> = (
     setCurrentSectionItem,
     currentScheduledSurfaceGuid,
     toggleEditModal,
+    toggleRejectModal,
     refetch,
   } = props;
 
@@ -154,6 +159,10 @@ export const SectionDetails: React.FC<SectionDetailsProps> = (
                               // back to the parent component
                               setCurrentSectionItem(item);
                               toggleEditModal();
+                            }}
+                            onReject={() => {
+                              setCurrentSectionItem(item);
+                              toggleRejectModal();
                             }}
                             onRemove={() => {
                               setCurrentSectionItem(item);

--- a/src/curated-corpus/components/SectionItemCardWrapper/SectionItemCardWrapper.tsx
+++ b/src/curated-corpus/components/SectionItemCardWrapper/SectionItemCardWrapper.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from 'react';
 import { Grid } from '@mui/material';
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import ClearIcon from '@mui/icons-material/Clear';
+import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
 import {
   ApprovedCorpusItem,
   CorpusItemSource,
@@ -28,6 +29,11 @@ interface SectionItemCardWrapperProps {
   onRemove: VoidFunction;
 
   /**
+   * Callback for the "Reject" (trash) button
+   */
+  onReject: VoidFunction;
+
+  /**
    * The surface the card is displayed on, e.g. EN_US
    */
   scheduledSurfaceGuid: string;
@@ -36,10 +42,15 @@ interface SectionItemCardWrapperProps {
 export const SectionItemCardWrapper: React.FC<SectionItemCardWrapperProps> = (
   props,
 ): ReactElement => {
-  const { item, onEdit, onRemove, scheduledSurfaceGuid } = props;
+  const { item, onEdit, onRemove, onReject, scheduledSurfaceGuid } = props;
 
   // card action buttons to be rendered & aligned on bottom left
   const cardActionButtonsLeft: CardAction[] = [
+    {
+      actionName: 'Reject',
+      icon: <DeleteOutlinedIcon />,
+      onClick: () => onReject(),
+    },
     { actionName: 'Edit', icon: <EditOutlinedIcon />, onClick: () => onEdit() },
   ];
   // card action buttons to be rendered & aligned on bottom right

--- a/src/curated-corpus/pages/SectionsPage/SectionsPage.tsx
+++ b/src/curated-corpus/pages/SectionsPage/SectionsPage.tsx
@@ -11,6 +11,7 @@ import { Box, Grid } from '@mui/material';
 import { HandleApiResponse } from '../../../_shared/components';
 import {
   EditCorpusItemAction,
+  RejectCorpusItemAction,
   SectionDetails,
   SplitButton,
 } from '../../components';
@@ -40,6 +41,11 @@ export const SectionsPage: React.FC = (): JSX.Element => {
    * Keep track of whether the "Edit item modal" is open or not
    */
   const [editItemModalOpen, toggleEditModal] = useToggle(false);
+
+  /**
+   * Keep track of whether the "Reject item modal" is open or not
+   */
+  const [rejectItemModalOpen, toggleRejectModal] = useToggle(false);
 
   // Get a list of sections on the page
   const [
@@ -134,13 +140,22 @@ export const SectionsPage: React.FC = (): JSX.Element => {
     <>
       <h1>Sections</h1>
       {currentSectionItem?.approvedItem && (
-        <EditCorpusItemAction
-          item={currentSectionItem.approvedItem}
-          actionScreen={ActionScreen.Sections}
-          modalOpen={editItemModalOpen}
-          toggleModal={toggleEditModal}
-          refetch={refetch}
-        />
+        <>
+          <EditCorpusItemAction
+            item={currentSectionItem.approvedItem}
+            actionScreen={ActionScreen.Sections}
+            modalOpen={editItemModalOpen}
+            toggleModal={toggleEditModal}
+            refetch={refetch}
+          />
+          <RejectCorpusItemAction
+            item={currentSectionItem.approvedItem}
+            actionScreen={ActionScreen.Sections}
+            modalOpen={rejectItemModalOpen}
+            toggleModal={toggleRejectModal}
+            refetch={refetch}
+          />
+        </>
       )}
       <Grid container spacing={3}>
         <Grid item xs={12} sm={8}>
@@ -184,6 +199,7 @@ export const SectionsPage: React.FC = (): JSX.Element => {
         setCurrentSectionItem={setCurrentSectionItem}
         currentScheduledSurfaceGuid={currentScheduledSurfaceGuid}
         toggleEditModal={toggleEditModal}
+        toggleRejectModal={toggleRejectModal}
         refetch={refetch}
       />
     </>


### PR DESCRIPTION
## Goal

Adding rejection action for section items.

- Adding reject button (trash icon) to section items
- Displaying rejection reasons modal (same reasons for rejecting an approved corpus item)
- Calling `rejectApprovedCorpusItem` mutation

## Todos

- [x] deployed to dev

## Demo

https://github.com/user-attachments/assets/8d8d7b30-06f8-419e-b977-16801b9a345b


## Reference

Tickets:

- https://mozilla-hub.atlassian.net/browse/HNT-504