### PR TITLE
HNT-582: render full IAB label for a Section

### DIFF
--- a/src/api/fragments/SectionData.ts
+++ b/src/api/fragments/SectionData.ts
@@ -7,9 +7,9 @@ export const BaseSectionData = gql`
     title
     scheduledSurfaceGuid
     iab {
-        taxonomy
-        categories
-      }
+      taxonomy
+      categories
+    }
     sort
     createSource
     disabled

--- a/src/api/fragments/SectionData.ts
+++ b/src/api/fragments/SectionData.ts
@@ -6,6 +6,10 @@ export const BaseSectionData = gql`
     externalId
     title
     scheduledSurfaceGuid
+    iab {
+        taxonomy
+        categories
+      }
     sort
     createSource
     disabled

--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -607,6 +607,8 @@ export type CreateOrUpdateSectionInput = {
   createSource: ActivitySource;
   /** An alternative primary key in UUID format supplied by ML. */
   externalId: Scalars['ID'];
+  /** Optional IAB metadata input */
+  iab?: InputMaybe<IabMetadataInput>;
   /** The GUID of the Scheduled Surface. Example: 'NEW_TAB_EN_US'. */
   scheduledSurfaceGuid: Scalars['ID'];
   /** Controls the display order of Sections. */
@@ -766,6 +768,22 @@ export type IabCategory = {
   externalId: Scalars['String'];
   name: Scalars['String'];
   slug: Scalars['String'];
+};
+
+/**
+ * Represents IAB metadata for a Section.
+ * Used by both admin input/output and public output.
+ */
+export type IabMetadata = {
+  __typename?: 'IABMetadata';
+  categories: Array<Scalars['String']>;
+  taxonomy: Scalars['String'];
+};
+
+/** Input data for creating IAB metadata for a Section */
+export type IabMetadataInput = {
+  categories: Array<Scalars['String']>;
+  taxonomy: Scalars['String'];
 };
 
 export type IabParentCategory = {
@@ -2096,6 +2114,8 @@ export type Section = {
   disabled: Scalars['Boolean'];
   /** An alternative primary key in UUID format. */
   externalId: Scalars['ID'];
+  /** Optional IAB metadata returned to the client (i.e. Merino->Firefox, Admin Tools) */
+  iab?: Maybe<IabMetadata>;
   /** The GUID of the Scheduled Surface. Example: 'NEW_TAB_EN_US'. */
   scheduledSurfaceGuid: Scalars['ID'];
   /**
@@ -2150,10 +2170,10 @@ export enum SectionItemRemovalReason {
   NoImage = 'NO_IMAGE',
   OffTopic = 'OFF_TOPIC',
   OneSided = 'ONE_SIDED',
+  Other = 'OTHER',
   Paywall = 'PAYWALL',
   PublisherQuality = 'PUBLISHER_QUALITY',
   SetDiversity = 'SET_DIVERSITY',
-  Other = 'OTHER',
 }
 
 export type ShareableListComplete = {
@@ -2659,6 +2679,11 @@ export type BaseSectionDataFragment = {
   createSource: ActivitySource;
   disabled: boolean;
   active: boolean;
+  iab?: {
+    __typename?: 'IABMetadata';
+    taxonomy: string;
+    categories: Array<string>;
+  } | null;
 };
 
 export type SectionDataFragment = {
@@ -2714,6 +2739,11 @@ export type SectionDataFragment = {
       }>;
     };
   }>;
+  iab?: {
+    __typename?: 'IABMetadata';
+    taxonomy: string;
+    categories: Array<string>;
+  } | null;
 };
 
 export type BaseSectionItemDataFragment = {
@@ -3455,6 +3485,11 @@ export type DisableEnableSectionMutation = {
         }>;
       };
     }>;
+    iab?: {
+      __typename?: 'IABMetadata';
+      taxonomy: string;
+      categories: Array<string>;
+    } | null;
   };
 };
 
@@ -5003,6 +5038,11 @@ export type GetSectionsWithSectionItemsQuery = {
         }>;
       };
     }>;
+    iab?: {
+      __typename?: 'IABMetadata';
+      taxonomy: string;
+      categories: Array<string>;
+    } | null;
   }>;
 };
 
@@ -5201,6 +5241,10 @@ export const BaseSectionDataFragmentDoc = gql`
     externalId
     title
     scheduledSurfaceGuid
+    iab {
+      taxonomy
+      categories
+    }
     sort
     createSource
     disabled

--- a/src/curated-corpus/components/SectionDetails/SectionDetails.test.tsx
+++ b/src/curated-corpus/components/SectionDetails/SectionDetails.test.tsx
@@ -7,17 +7,28 @@ import { MockedProvider } from '@apollo/client/testing';
 import {
   ActivitySource,
   ApprovedCorpusItem,
+  IabMetadata,
   Section,
 } from '../../../api/generatedTypes';
 import { getTestApprovedItem } from '../../helpers/approvedItem';
 
 describe('The SectionDetails component', () => {
   const item: ApprovedCorpusItem = getTestApprovedItem();
+  const iabMetadata1: IabMetadata = {
+    taxonomy: 'IAB-3.0',
+    categories: ['339'], // Adult Contemporary Music (Tier 3)
+  };
+  const iabMetadata2: IabMetadata = {
+    taxonomy: 'IAB-3.0',
+    categories: ['335'], // Fantasy (Tier 2)
+  };
+
   const mockSections: Section[] = [
     // enabled section
     {
       externalId: '1',
       title: 'Section 1',
+      iab: iabMetadata1,
       active: true,
       disabled: false,
       sectionItems: [
@@ -37,6 +48,7 @@ describe('The SectionDetails component', () => {
     {
       externalId: '2',
       title: 'Section 2',
+      iab: iabMetadata2,
       active: true,
       disabled: true,
       sectionItems: [
@@ -250,5 +262,35 @@ describe('The SectionDetails component', () => {
     );
     const enableSwitch = screen.getByRole('checkbox', { name: /enable/i });
     expect(enableSwitch).toBeInTheDocument();
+  });
+
+  it('should render IAB labels', async () => {
+    render(
+      <MockedProvider>
+        <SnackbarProvider maxSnack={3}>
+          <SectionDetails
+            sections={mockSections}
+            currentSection="all"
+            setCurrentSectionItem={mockSetCurrentSectionItem}
+            currentScheduledSurfaceGuid="NEW_TAB_EN_US"
+            toggleEditModal={mockToggleEditModal}
+            toggleRejectModal={mockToggleRejectModal}
+            toggleRemoveSectionItemModal={mockToggleRemoveSectionItemModal}
+            refetch={mockRefetch}
+          />
+        </SnackbarProvider>
+      </MockedProvider>,
+    );
+    expect(screen.getByText('Section 1')).toBeInTheDocument();
+    expect(screen.getByText('Section 2')).toBeInTheDocument();
+
+    // check IAB labels
+    // IAB label for Section 1
+    expect(
+      screen.getByText('Entertainment → Music → Adult Contemporary Music'),
+    ).toBeInTheDocument();
+
+    // IAB label for Section 2
+    expect(screen.getByText('Genres → Fantasy')).toBeInTheDocument();
   });
 });

--- a/src/curated-corpus/components/SectionDetails/SectionDetails.tsx
+++ b/src/curated-corpus/components/SectionDetails/SectionDetails.tsx
@@ -4,9 +4,18 @@ import {
   SectionItem,
   useDisableEnableSectionMutation,
 } from '../../../api/generatedTypes';
-import { Box, FormControlLabel, FormGroup, Grid, Switch } from '@mui/material';
+import {
+  Box,
+  Chip,
+  FormControlLabel,
+  FormGroup,
+  Grid,
+  Switch,
+} from '@mui/material';
+import AdUnitsIcon from '@mui/icons-material/AdUnits';
 import { SectionItemCardWrapper } from '../SectionItemCardWrapper/SectionItemCardWrapper';
 import { useRunMutation } from '../../../_shared/hooks';
+import { getIABCategoryTreeLabel } from '../../helpers/helperFunctions';
 
 interface SectionDetailsProps {
   /**
@@ -123,6 +132,18 @@ export const SectionDetails: React.FC<SectionDetailsProps> = (
                       labelPlacement="end" // Places label next to switch
                     />
                   </FormGroup>
+                  {/* IAB Label */}
+                  {section.iab && (
+                    <Chip
+                      variant="outlined"
+                      color="primary"
+                      label={getIABCategoryTreeLabel(
+                        'IAB-3.0',
+                        section.iab.categories[0],
+                      )}
+                      icon={<AdUnitsIcon />}
+                    />
+                  )}
                 </Box>
               </Box>
               <Grid

--- a/src/curated-corpus/helpers/helperFunctions.test.ts
+++ b/src/curated-corpus/helpers/helperFunctions.test.ts
@@ -9,6 +9,7 @@ import {
   formatFormLabel,
   getCuratorNameFromLdap,
   getFormattedImageUrl,
+  getIABCategoryTreeLabel,
   getLastScheduledDayDiff,
   getLocalDateTimeForGuid,
   getScheduledSurfaceName,
@@ -354,6 +355,37 @@ describe('helperFunctions ', () => {
           '«Meeresregionen» – in die »pelagischen« Zonen – verlegt',
         ),
       ).toEqual('„Meeresregionen” – in die „pelagischen” Zonen – verlegt');
+    });
+  });
+
+  describe('getIABCategoryTreeLabel function', () => {
+    it('should return full hierarchy for a Tier 4 IAB category', () => {
+      const iabLabel = getIABCategoryTreeLabel('IAB-3.0', '341'); // Urban AC Music (Tier 4)
+      expect(iabLabel).toEqual(
+        'Entertainment → Music → Adult Contemporary Music → Urban AC Music',
+      );
+    });
+    it('should return full hierarchy for a Tier 3 IAB category', () => {
+      const iabLabel = getIABCategoryTreeLabel('IAB-3.0', '339'); // Adult Contemporary Music (Tier 3)
+      expect(iabLabel).toEqual(
+        'Entertainment → Music → Adult Contemporary Music',
+      );
+    });
+    it('should return full hierarchy for a Tier 2 IAB category', () => {
+      const iabLabel = getIABCategoryTreeLabel('IAB-3.0', '338'); // Music (Tier 2)
+      expect(iabLabel).toEqual('Entertainment → Music');
+    });
+    it('should return only the IAB category name for a Tier 1 IAB category', () => {
+      const iabLabel = getIABCategoryTreeLabel('IAB-3.0', 'JLBCU7'); // Entertainment (Tier 1)
+      expect(iabLabel).toEqual('Entertainment');
+    });
+    it('should return an empty string for an unknown IAB category code', () => {
+      const label = getIABCategoryTreeLabel('IAB-3.0', 'unknown_code');
+      expect(label).toEqual('');
+    });
+    it('should return an empty string for an unknown taxonomy version', () => {
+      const label = getIABCategoryTreeLabel('unknown_taxonomy_version', '341');
+      expect(label).toEqual('');
     });
   });
 });

--- a/src/curated-corpus/helpers/helperFunctions.ts
+++ b/src/curated-corpus/helpers/helperFunctions.ts
@@ -237,7 +237,7 @@ export const getIABCategoryTreeLabel = (
   iabCode: string,
 ): string => {
   const iabTaxonomy = CORPUS_IAB_CATEGORIES[taxonomy];
-  // Check if taxonomy version exists
+  // Check if taxonomy version/ IAB code exists
   if (!iabTaxonomy || !iabTaxonomy[iabCode]) return '';
 
   // Array to hold IAB category names from each Tier in the hierarchy, from parent -> child
@@ -246,7 +246,7 @@ export const getIABCategoryTreeLabel = (
 
   // Start from target IAB category (child) & walk up the parent chain
   while (currentIABCategory) {
-    // Add child category to the end of the array
+    // Add child category to the END of the array
     iabLabels.unshift(currentIABCategory.name);
     // Walk up to the parent IAB category (if there is a parent)
     currentIABCategory = currentIABCategory.parentId

--- a/src/curated-corpus/helpers/helperFunctions.ts
+++ b/src/curated-corpus/helpers/helperFunctions.ts
@@ -8,6 +8,10 @@ import { ScheduledSurfaces } from './definitions';
 import { applyCurlyQuotes } from '../../_shared/utils/applyCurlyQuotes';
 import { applyApTitleCase } from '../../_shared/utils/applyApTitleCase';
 import { applyQuotesDashesDE } from '../../_shared/utils/applyQuotesDashesDE';
+import {
+  CORPUS_IAB_CATEGORIES,
+  CorpusIABCategory,
+} from '../../api/corpusIABCategories';
 
 // downloads image from source url
 export const fetchFileFromUrl = async (
@@ -220,4 +224,35 @@ export const applyTitleFormattingByLanguage = (
   else {
     return applyCurlyQuotes(applyApTitleCase(title));
   }
+};
+
+/**
+ * Constructs the full IAB label (parent/child hierarchy) based on the provided IAB code
+ * @param taxonomy the IAB taxonomy version
+ * @param iabCode the iabCode to lookup in taxonomy
+ * @returns string IAB category names joined with an arrow (->) to form a readable path
+ */
+export const getIABCategoryTreeLabel = (
+  taxonomy: string,
+  iabCode: string,
+): string => {
+  const iabTaxonomy = CORPUS_IAB_CATEGORIES[taxonomy];
+  // Check if taxonomy version exists
+  if (!iabTaxonomy || !iabTaxonomy[iabCode]) return '';
+
+  // Array to hold IAB category names from each Tier in the hierarchy, from parent -> child
+  const iabLabels: string[] = [];
+  let currentIABCategory: CorpusIABCategory | null = iabTaxonomy[iabCode];
+
+  // Start from target IAB category (child) & walk up the parent chain
+  while (currentIABCategory) {
+    // Add child category to the end of the array
+    iabLabels.unshift(currentIABCategory.name);
+    // Walk up to the parent IAB category (if there is a parent)
+    currentIABCategory = currentIABCategory.parentId
+      ? iabTaxonomy[currentIABCategory.parentId]
+      : null;
+  }
+
+  return iabLabels.join(' → ');
 };


### PR DESCRIPTION
## Goal

Display the full IAB label for an ML Section. 

## Demo
Curators approved the IAB label placement ([slack thread](https://mozilla.slack.com/archives/C05EVRU1U1X/p1746553916031829)).
![Screenshot 2025-05-06 at 10 49 38](https://github.com/user-attachments/assets/89769ed0-9f49-4202-b0c5-244a26bf8a50)

![Screenshot 2025-05-06 at 10 49 49](https://github.com/user-attachments/assets/e3e655b2-4875-48aa-b62d-adcc3e9fd18f)

## Todos

- [x] Deploy to dev

## Reference

Tickets:

- https://mozilla-hub.atlassian.net/browse/HNT-582
