### PR TITLE
feat: add new Section fields to GraphQL fragment

### DIFF
--- a/src/api/fragments/SectionData.ts
+++ b/src/api/fragments/SectionData.ts
@@ -14,6 +14,9 @@ export const BaseSectionData = gql`
     createSource
     disabled
     active
+    description
+    heroTitle
+    heroDescription
   }
 `;
 export const SectionData = gql`


### PR DESCRIPTION

  ## Goal

  Update the GraphQL fragments to support new Section fields (description,
  heroTitle, heroDescription) as part of Phase 3 Custom Editorial Sections
  implementation. These fields will enable richer content display for curated
  sections in the Admin tools.

  ## Todos

  - [x] Add new shared Section fields to BaseSectionData fragment
  - [ ] Server-side GraphQL schema update required (to be done separately)
  - [ ] Add SectionStatus enum and admin-specific fields (status, startDate,
  endDate) after server update
  - [ ] Run GraphQL codegen after server schema is updated


  ## Reference

  Documentation here:

  - Phase 3: Custom (Editorial) Sections - API Technical Specification (MVP) |
  Corpus GraphQL API Updates

  Tickets:

  - HNT-875

  ## Implementation Decisions

  - Added fields to the shared `BaseSectionData` fragment rather than creating
  a new fragment, as these fields will be available across both Shared and
  Admin graphs
