### PR TITLE
HNT-970: Optionally display Section description

### DIFF
--- a/src/curated-corpus/components/SectionDetails/SectionDetails.test.tsx
+++ b/src/curated-corpus/components/SectionDetails/SectionDetails.test.tsx
@@ -28,6 +28,7 @@ describe('The SectionDetails component', () => {
     {
       externalId: '1',
       title: 'Section 1',
+      description: 'Section 1 description',
       iab: iabMetadata1,
       active: true,
       disabled: false,
@@ -91,6 +92,7 @@ describe('The SectionDetails component', () => {
     );
 
     expect(screen.getByText('Section 1')).toBeInTheDocument();
+    expect(screen.getByText('Section 1 description')).toBeInTheDocument();
     expect(screen.getByText('Section 2')).toBeInTheDocument();
   });
 

--- a/src/curated-corpus/components/SectionDetails/SectionDetails.tsx
+++ b/src/curated-corpus/components/SectionDetails/SectionDetails.tsx
@@ -16,6 +16,7 @@ import AdUnitsIcon from '@mui/icons-material/AdUnits';
 import { SectionItemCardWrapper } from '../SectionItemCardWrapper/SectionItemCardWrapper';
 import { useRunMutation } from '../../../_shared/hooks';
 import { getIABCategoryTreeLabel } from '../../helpers/helperFunctions';
+import { curationPalette } from '../../../theme';
 
 interface SectionDetailsProps {
   /**
@@ -114,10 +115,24 @@ export const SectionDetails: React.FC<SectionDetailsProps> = (
                   alignItems="center"
                   p={2}
                 >
-                  {/* Section Title */}
-                  <h2 style={{ marginRight: '2rem' }}>{section.title}</h2>
+                  {/* Wrap title + description */}
+                  <Box display="flex" flexDirection="column" mr={4}>
+                    <h2>{section.title}</h2>
+                    {section.description && (
+                      <p
+                        style={{
+                          margin: 0,
+                          color: curationPalette.regularGrey,
+                        }}
+                      >
+                        {section.description}
+                      </p>
+                    )}
+                  </Box>
+
                   <p>{section.active}</p>
-                  {/* Enable/Disable Switch */}
+
+                  {/* Disable + enable toggle switch */}
                   <FormGroup>
                     <FormControlLabel
                       control={
@@ -132,6 +147,7 @@ export const SectionDetails: React.FC<SectionDetailsProps> = (
                       labelPlacement="end" // Places label next to switch
                     />
                   </FormGroup>
+
                   {/* IAB Label */}
                   {section.iab && (
                     <Chip


### PR DESCRIPTION
## Goal

Display section description when provided

## Demo

<img width="1410" height="821" alt="Screenshot 2025-09-03 at 13 50 18" src="https://github.com/user-attachments/assets/fa891e30-b357-4ab6-8104-6745ac79fdc3" />

https://github.com/user-attachments/assets/63624fa9-91ac-44f5-8334-7c9ddd3a1ed0




## Todos

- [x] Deployed to dev

## Reference

Tickets:

- https://mozilla-hub.atlassian.net/browse/HNT-970