### PR TITLE
HNT-1105: hide ML removal reason & show set_diversity reason for removing section items

### DIFF
--- a/src/curated-corpus/components/RemoveSectionItemForm/RemoveSectionItemForm.test.tsx
+++ b/src/curated-corpus/components/RemoveSectionItemForm/RemoveSectionItemForm.test.tsx
@@ -26,6 +26,35 @@ describe('The RemoveSectionItemForm component', () => {
     expect(buttons).toHaveLength(2);
   });
 
+  it('renders all expected removal reasons except ML', () => {
+    render(<RemoveSectionItemForm onSubmit={handleSubmit} />);
+
+    // "ML" reason should NOT be present
+    const mlCheckbox = screen.queryByLabelText(/ml/i);
+    expect(mlCheckbox).not.toBeInTheDocument();
+
+    // These are the expected labels (adjust capitalization if needed)
+    const expectedLabels = [
+      /article quality/i,
+      /controversial/i,
+      /dated/i,
+      /hed dek quality/i,
+      /image quality/i,
+      /no image/i,
+      /off topic/i,
+      /one sided/i,
+      /paywall/i,
+      /publisher quality/i,
+      /set diversity/i,
+      /other/i,
+    ];
+
+    expectedLabels.forEach((labelRegex) => {
+      const checkbox = screen.getByLabelText(labelRegex);
+      expect(checkbox).toBeInTheDocument();
+    });
+  });
+
   it('displays an error message if no checkboxes have been selected', async () => {
     render(<RemoveSectionItemForm onSubmit={handleSubmit} />);
 

--- a/src/curated-corpus/components/RemoveSectionItemForm/RemoveSectionItemForm.tsx
+++ b/src/curated-corpus/components/RemoveSectionItemForm/RemoveSectionItemForm.tsx
@@ -57,12 +57,16 @@ export const RemoveSectionItemForm: React.FC<
       onSubmit(values, formikHelpers);
     },
   });
+  // remove "ML" from list of reasons, its only used by ML process
+  const filteredReasons = Object.values(SectionItemRemovalReason).filter(
+    (reason) => reason !== SectionItemRemovalReason.Ml,
+  );
   return (
     <form name="remove-section-item-form" onSubmit={formik.handleSubmit}>
       <Grid container spacing={3}>
         <Grid item xs={12} sm={6}>
           <FormGroup>
-            {Object.values(SectionItemRemovalReason)
+            {filteredReasons
               .slice(0, 6) // first 6 reasons in first column (12 reasons total)
               .map((value) => {
                 return (
@@ -84,7 +88,7 @@ export const RemoveSectionItemForm: React.FC<
         </Grid>
         <Grid item xs={12} sm={6}>
           <FormGroup>
-            {Object.values(SectionItemRemovalReason)
+            {filteredReasons
               .slice(6, 12) // remaining 6 reasons in second column
               .map((value) => {
                 return (


### PR DESCRIPTION
## Goal

Hide "ML" reason when removing section items as this reason is only used by ML processes. Show "SET_DIVERSITY" removal reason as it was hidden due to css.

## Todos

- [ ] deploy to dev

## Reference

Tickets:

- https://mozilla-hub.atlassian.net/browse/HNT-1105