### PR TITLE
fix(curated-corpus): add Polish to the language picker

### DIFF
--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -1348,6 +1348,8 @@ export type Mutation = {
    * Called when approving or rejecting a prospect into the corpus.
    */
   updateProspectAsCurated?: Maybe<Prospect>;
+  /** Updates a SectionItem's mutable fields (e.g. rank). */
+  updateSectionItem: SectionItem;
   /** Uploads an image to S3 for an Approved Item */
   uploadApprovedCorpusItemImage: ApprovedCorpusImageUrl;
 };
@@ -1514,6 +1516,10 @@ export type MutationUpdateLabelArgs = {
 
 export type MutationUpdateProspectAsCuratedArgs = {
   id: Scalars['ID'];
+};
+
+export type MutationUpdateSectionItemArgs = {
+  data: UpdateSectionItemInput;
 };
 
 export type MutationUploadApprovedCorpusItemImageArgs = {
@@ -2578,6 +2584,14 @@ export type UpdateCustomSectionInput = {
 export type UpdateLabelInput = {
   externalId?: InputMaybe<Scalars['String']>;
   name: Scalars['String'];
+};
+
+/** Input data for updating a SectionItem's mutable fields */
+export type UpdateSectionItemInput = {
+  /** ID of the SectionItem. A string in UUID format. */
+  externalId: Scalars['ID'];
+  /** The updated rank of the SectionItem in relation to its siblings. */
+  rank: Scalars['Int'];
 };
 
 export type UrlMetadata = {

--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -493,6 +493,8 @@ export enum CorpusLanguage {
   Fr = 'FR',
   /** Italian */
   It = 'IT',
+  /** Polish */
+  Pl = 'PL',
 }
 
 /** A node in a CorpusSearchConnection result */

--- a/src/curated-corpus/helpers/definitions.ts
+++ b/src/curated-corpus/helpers/definitions.ts
@@ -46,13 +46,14 @@ Object.keys(ProspectType).forEach((key, index) => {
 
 export const prospectFilterOptions: DropdownOption[] = prospectFilters;
 
-// Language codes. Currently only English and German are needed.
+// Language codes for the curation tool's language picker.
 export const languages: DropdownOption[] = [
   { code: CorpusLanguage.En, name: 'English' },
   { code: CorpusLanguage.De, name: 'German' },
   { code: CorpusLanguage.Es, name: 'Spanish' },
   { code: CorpusLanguage.Fr, name: 'French' },
   { code: CorpusLanguage.It, name: 'Italian' },
+  { code: CorpusLanguage.Pl, name: 'Polish' },
 ];
 
 // This maps to the status (CuratedStatus type) field in DB for an ApprovedItem


### PR DESCRIPTION
## Problem
#1274 added Poland (`NEW_TAB_PL_PL`) as a scheduled surface, but Polish is missing from the language picker, so curators cannot set or see `PL` on corpus items and sections.

## Change
- Add Polish to the `languages` dropdown options (`definitions.ts`).
- Add `Pl = 'PL'` to the generated `CorpusLanguage` enum (`generatedTypes.ts`).

The enum value comes from the backing schema change in Pocket/content-monorepo#391, which is now deployed. `generatedTypes.ts` was updated by running `api:generate-types`.
