### PR TITLE
chore: regenerate admin-api types for nullable createSectionItem (HNT-2681)

### DIFF
--- a/src/api/generatedTypes.ts
+++ b/src/api/generatedTypes.ts
@@ -1256,8 +1256,12 @@ export type Mutation = {
   createScheduleReview: ScheduleReview;
   /** Creates a Scheduled Surface Scheduled Item. */
   createScheduledCorpusItem: ScheduledCorpusItem;
-  /** Creates a SectionItem within a Section. */
-  createSectionItem: SectionItem;
+  /**
+   * Creates a SectionItem within a Section.
+   * Returns null (a no-op) when an ML-automated process attempts to re-add an
+   * item that an editor previously removed manually.
+   */
+  createSectionItem?: Maybe<SectionItem>;
   /** Deletes a CollectionPartnerAssociation. */
   deleteCollectionPartnerAssociation: CollectionPartnerAssociation;
   /** Deletes a CollectionStory. Also deletes all the related CollectionStoryAuthor records. */
@@ -3246,11 +3250,11 @@ export type CreateSectionItemMutationVariables = Exact<{
 
 export type CreateSectionItemMutation = {
   __typename?: 'Mutation';
-  createSectionItem: {
+  createSectionItem?: {
     __typename?: 'SectionItem';
     externalId: string;
     rank?: number | null;
-  };
+  } | null;
 };
 
 export type DeleteCustomSectionMutationVariables = Exact<{


### PR DESCRIPTION
## Summary

Regenerates `src/api/generatedTypes.ts` to track the admin-api schema change in [Pocket/content-monorepo#395](https://github.com/Pocket/content-monorepo/pull/395) (HNT-2681), where `Mutation.createSectionItem` became nullable.

## No application changes
This change just keeps the schema up-to-date; there's no impact to the admin tools from this.

The only consumer, `CustomSectionDetails.tsx`, calls `runMutation(createSectionItem, …)` and never reads `data.createSectionItem`, so the nullable type introduces no TS errors. Also note the null path is ML-only (gated on the ML service user); human curators using this UI never receive null.